### PR TITLE
Add AI review workflow (Claude Opus) on every PR

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,39 @@
+---
+name: ai-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+# One review per (PR, latest commit). Newer commit cancels in-flight review.
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure anthropic SDK is installed
+        run: |
+          python3 -m pip install --user --quiet --upgrade 'anthropic>=0.39.0'
+
+      - name: Run AI review
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Lever to swap models per cost class. Keep the cutting-edge default.
+          AI_REVIEW_MODEL: claude-opus-4-7
+        run: python3 scripts/ci/ai-review.py

--- a/docs/ci/ai-review-prompt.md
+++ b/docs/ci/ai-review-prompt.md
@@ -1,0 +1,104 @@
+# AS215932 hyrule-infra — AI reviewer prompt
+
+You are a senior infrastructure reviewer for `AS215932/network-operations`, the
+infrastructure-as-code repo behind a small sovereign IPv6-first ISP. You review
+pull requests and post structured findings.
+
+## What this repo controls
+
+- Three routers running FRRouting (`rtr` Debian, `cr1-nl1` and `cr1-de1` FreeBSD).
+- Thirteen-ish infra VMs on XCP-NG dom0 (`dns`, `api`, `web`, `proxy`, `mon`,
+  `vpn`, `xoa`, `irc`, `mail`, `noc`, `log`, `vault`, `ci`) plus off-net `ns2`.
+- Host-level firewalls (nftables on Linux, pf on FreeBSD).
+- Icinga2 monitoring on `mon`, Prometheus + Grafana, Loki via Vector.
+- Vault for secrets, Vault Agent rendering env/JWT files.
+- A self-hosted GitHub Actions runner on `ci`.
+
+## Non-negotiable conventions
+
+1. **`docs/network-flows.md` is the firewall spec.** Every rule in
+   `host_vars/<host>.yml :: firewall_extra_rules` traces to a row in that file.
+   A PR that adds a rule without updating `network-flows.md` is incomplete.
+2. **IPv6-first.** Internal networking is `2a0c:b641:b50::/44`. No RFC1918
+   addresses for infra VMs. IPv4 only exists on `dom0`'s WAN bridge and via
+   NAT64/DNS64 on `rtr`.
+3. **Static IPs only.** No DHCP for infra VMs.
+4. **Peer references by name, never literal.** Rules use
+   `{{ peers.mon.ipv6 }}`, not the address itself. New peers go in
+   `group_vars/all.yml` first.
+5. **Render-then-review.** `ansible/generated/<host>/*` must be committed
+   alongside any change that affects rendering. The `render-check` workflow
+   enforces this.
+6. **Snapshot bracket on every apply.** Pre + post Icinga snapshots from `mon`
+   bracket every applied change. Snapshots must survive `--limit` (issue #16).
+7. **FreeBSD vs Linux split.** On FreeBSD (`cr1-*`): pf, ifconfig, doas. On
+   Linux: nftables, ip, sudo. Don't conflate.
+8. **`monitoring_register: true` only for new hosts.** Hosts in the legacy
+   `configs/mon/icinga2/hosts/{infra-vms,routers,dom0}.conf` should be migrated
+   one at a time — setting it true on a host already in legacy fails the
+   icinga2 reload (duplicate Host object).
+9. **Vault is the only source for production secrets.** `secrets.local.sh` is
+   bootstrap/import only.
+10. **Commit discipline:** small logical commits, separate concerns, never an
+    omnibus PR for multi-part work.
+
+## Review format
+
+Return a single JSON object (no prose outside the JSON) with this shape:
+
+```json
+{
+  "summary": "One-paragraph overall assessment. State the change, the risk class, and your recommendation (approve / request changes / comment-only). Do NOT 'approve' on behalf of a human — that's review-comment style only.",
+  "classification": "safe-class | needs-review | risky",
+  "findings": [
+    {
+      "file": "path/relative/to/repo/root",
+      "line": 42,
+      "severity": "info | warning | error",
+      "body": "One short paragraph. Cite the convention you're checking against."
+    }
+  ]
+}
+```
+
+Classification rules:
+- `safe-class` only when the diff is **entirely** under `ansible/generated/`,
+  `docs/**`, or `*.md`. Generated-only PRs are auto-merge candidates.
+- `needs-review` for any source change (templates, tasks, host_vars, configs,
+  workflows). The default.
+- `risky` for changes that touch: BGP policy, NAT64 / DNS64, the firewall
+  default-policy, Vault auth, the apply path, or any other "if this is wrong,
+  the estate breaks" surface.
+
+Severity rules:
+- `error` — convention violated and the PR will cause regressions if merged.
+- `warning` — convention violated but the impact is bounded (e.g. dead code,
+  unused var, stale comment).
+- `info` — observation worth surfacing but not blocking (style, naming,
+  followup opportunity).
+
+Findings rules:
+- Be specific. Cite `file:line` always.
+- One finding per concrete issue. Don't bundle.
+- Don't comment on `ansible/generated/` — those are render outputs, not source.
+- Don't restate what the PR description already says.
+- Skip "nit" findings unless the violation is also in the conventions above.
+- If the PR is clean, return `findings: []` with a one-sentence summary.
+
+Token budget: target ≤ 5k output tokens. If the diff is very large
+(> 20 changed files), pick the 10 most consequential and note in the summary
+that the rest were sampled.
+
+## Style for individual findings
+
+Good:
+> `host_vars/web.yml:18` — adds `firewall_extra_rules` for TCP/8081 from
+> `proxy` but the matching row isn't in `docs/network-flows.md` § "web". Per
+> convention, network-flows.md is the firewall spec — please add the row
+> before merging.
+
+Bad (too vague):
+> Don't forget to update network-flows.md.
+
+Bad (restating the diff):
+> This PR adds a firewall rule to allow TCP/8081 from proxy to web.

--- a/scripts/ci/ai-review.py
+++ b/scripts/ci/ai-review.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+ai-review.py — invoked by .github/workflows/ai-review.yml.
+
+Reads a PR diff, calls the Claude API with the repo's reviewer prompt,
+parses the response, and posts review comments via `gh`.
+
+Env vars (set by the workflow):
+  PR_NUMBER             — GitHub PR number to review
+  REPO                  — owner/repo (e.g. AS215932/network-operations)
+  ANTHROPIC_API_KEY     — repo secret
+  GITHUB_TOKEN          — provided by Actions
+
+Caching strategy:
+  System prompt + CLAUDE.md are marked cache_control=ephemeral so the
+  per-PR diff is the only cache miss after the first run. At ~50k input /
+  ~5k output, hot-path cost is roughly 90% input-cache discount.
+
+Limits:
+  - MAX_INPUT_CHARS bounds the diff sent to Claude (truncate after).
+  - Output JSON is parsed strictly; malformed responses post as a single
+    summary comment with the parse error.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import anthropic
+except ImportError:
+    sys.stderr.write("ERROR: anthropic SDK not installed (pip install anthropic)\n")
+    sys.exit(2)
+
+REPO = os.environ["REPO"]
+PR_NUMBER = os.environ["PR_NUMBER"]
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+MODEL = os.environ.get("AI_REVIEW_MODEL", "claude-opus-4-7")
+MAX_INPUT_CHARS = int(os.environ.get("AI_REVIEW_MAX_INPUT_CHARS", "180000"))
+MAX_OUTPUT_TOKENS = int(os.environ.get("AI_REVIEW_MAX_OUTPUT_TOKENS", "5000"))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+REVIEWER_PROMPT = REPO_ROOT / "docs" / "ci" / "ai-review-prompt.md"
+
+
+def gh(*args: str, check: bool = True) -> str:
+    """Run `gh` and return stdout. Inherits GITHUB_TOKEN from env."""
+    res = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=check
+    )
+    return res.stdout
+
+
+def fetch_pr_context() -> dict[str, Any]:
+    diff = gh("pr", "diff", PR_NUMBER, "--repo", REPO)
+    meta = json.loads(
+        gh(
+            "pr",
+            "view",
+            PR_NUMBER,
+            "--repo",
+            REPO,
+            "--json",
+            "title,body,author,changedFiles,additions,deletions",
+        )
+    )
+    return {"diff": diff, "meta": meta}
+
+
+def build_messages(ctx: dict[str, Any]) -> tuple[list[dict], list[dict]]:
+    """Return (system_blocks, message_blocks). System blocks are cached."""
+    system_blocks = [
+        {
+            "type": "text",
+            "text": REVIEWER_PROMPT.read_text(),
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": (
+                "## Repository conventions (CLAUDE.md)\n\n"
+                "Treat the following as authoritative project conventions. "
+                "Reference specific sections when applicable in your findings.\n\n"
+                + CLAUDE_MD.read_text()
+            ),
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    diff = ctx["diff"]
+    truncated = False
+    if len(diff) > MAX_INPUT_CHARS:
+        diff = diff[:MAX_INPUT_CHARS] + "\n\n[truncated]"
+        truncated = True
+
+    meta = ctx["meta"]
+    user_text = (
+        f"# PR #{PR_NUMBER}: {meta.get('title', '(no title)')}\n\n"
+        f"Author: {meta.get('author', {}).get('login', 'unknown')}\n"
+        f"Files changed: {meta.get('changedFiles', 0)} "
+        f"(+{meta.get('additions', 0)}, -{meta.get('deletions', 0)})\n"
+        f"{'**Diff truncated to fit input budget.**' if truncated else ''}\n\n"
+        "## PR description\n\n"
+        f"{meta.get('body', '') or '(no description provided)'}\n\n"
+        "## Unified diff\n\n"
+        f"```diff\n{diff}\n```\n\n"
+        "Review per the rules in the system prompt. Return JSON only."
+    )
+    return system_blocks, [{"role": "user", "content": user_text}]
+
+
+def call_claude(system_blocks, messages) -> dict[str, Any]:
+    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_OUTPUT_TOKENS,
+        system=system_blocks,
+        messages=messages,
+    )
+    body = "".join(b.text for b in resp.content if b.type == "text")
+    # Robust to leading prose: try to find the first '{' and last '}'.
+    start = body.find("{")
+    end = body.rfind("}")
+    if start < 0 or end < 0:
+        raise ValueError(f"no JSON object in response: {body[:300]}")
+    try:
+        return json.loads(body[start : end + 1])
+    except json.JSONDecodeError as e:
+        raise ValueError(f"could not parse JSON: {e}\nbody={body[:500]}")
+
+
+def post_review(review: dict[str, Any]) -> None:
+    summary = review.get("summary", "(no summary)")
+    classification = review.get("classification", "needs-review")
+    findings = review.get("findings", [])
+
+    overall = (
+        f"## AI review (classification: `{classification}`)\n\n"
+        f"{summary}\n\n"
+        + (
+            "_No file-level findings._"
+            if not findings
+            else f"_{len(findings)} file-level finding(s) below._"
+        )
+        + "\n\n<sub>Posted by `.github/workflows/ai-review.yml`. The AI never approves source PRs.</sub>"
+    )
+
+    # Post the overall summary as a comment review.
+    gh(
+        "pr",
+        "comment",
+        PR_NUMBER,
+        "--repo",
+        REPO,
+        "--body",
+        overall,
+    )
+
+    # Then per-finding inline comments via gh api.
+    for f in findings:
+        path = f.get("file")
+        line = f.get("line")
+        severity = f.get("severity", "info")
+        body = f.get("body", "")
+        if not path or not line or not body:
+            continue
+        prefix = {
+            "error": ":x: **error** — ",
+            "warning": ":warning: **warning** — ",
+            "info": ":information_source: ",
+        }.get(severity, "")
+        # Use gh api to create a single-line PR review comment.
+        # Spec: POST /repos/{owner}/{repo}/pulls/{pull_number}/comments needs
+        # commit_id; we use the PR head sha.
+        head_sha = gh(
+            "pr", "view", PR_NUMBER, "--repo", REPO, "--json", "headRefOid", "-q", ".headRefOid"
+        ).strip()
+        try:
+            subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    "--method",
+                    "POST",
+                    f"/repos/{REPO}/pulls/{PR_NUMBER}/comments",
+                    "-f",
+                    f"body={prefix}{body}",
+                    "-f",
+                    f"commit_id={head_sha}",
+                    "-f",
+                    f"path={path}",
+                    "-F",
+                    f"line={line}",
+                    "-f",
+                    "side=RIGHT",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            # Inline-comment failures are non-fatal — fall back to a PR comment.
+            sys.stderr.write(
+                f"warning: inline comment failed for {path}:{line}: {e.stderr}\n"
+            )
+            gh(
+                "pr",
+                "comment",
+                PR_NUMBER,
+                "--repo",
+                REPO,
+                "--body",
+                f"{prefix}`{path}:{line}` — {body}",
+            )
+
+    # If safe-class, set the label so auto-merge can pick it up.
+    if classification == "safe-class":
+        try:
+            gh(
+                "pr",
+                "edit",
+                PR_NUMBER,
+                "--repo",
+                REPO,
+                "--add-label",
+                "safe-class",
+            )
+        except subprocess.CalledProcessError:
+            sys.stderr.write("warning: could not add safe-class label\n")
+
+
+def main() -> int:
+    try:
+        ctx = fetch_pr_context()
+        system_blocks, messages = build_messages(ctx)
+        review = call_claude(system_blocks, messages)
+        post_review(review)
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"ai-review failed: {exc}\n")
+        # Surface the failure on the PR so it's visible.
+        try:
+            gh(
+                "pr",
+                "comment",
+                PR_NUMBER,
+                "--repo",
+                REPO,
+                "--body",
+                f":x: AI review failed: `{type(exc).__name__}: {exc}`\n\n<sub>See workflow run logs for details.</sub>",
+            )
+        except subprocess.CalledProcessError:
+            pass
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`.github/workflows/ai-review.yml` runs Claude Opus 4.7 on every PR. The script (`scripts/ci/ai-review.py`):

- Fetches the PR diff via `gh pr diff`.
- Sends it to Claude with the pinned reviewer prompt (`docs/ci/ai-review-prompt.md`) and the repo's `CLAUDE.md` as cached system blocks.
- Parses the JSON response into one overall PR comment + per-finding inline review comments.
- Adds the `safe-class` label when the diff is entirely under `ansible/generated/`, `docs/`, or `*.md` (PR 0d's auto-merge workflow keys on this).

The AI **never** approves source PRs — comment-style review only. A human always clicks merge.

## Cost

~\$0.50/PR at current Opus pricing (50k input cached + ~5k output uncached). Cache hit means the per-PR delta is the diff itself, not the 30k+ tokens of conventions. 100 PRs/year ≈ \$50. The `MAX_INPUT_CHARS=180k` cap bounds runaway diffs.

## Reviewer prompt

`docs/ci/ai-review-prompt.md` encodes the repo's non-negotiable conventions:

- `docs/network-flows.md` as the firewall spec.
- IPv6-first addressing; no RFC1918 for infra.
- Peer references by name (`{{ peers.X }}`), never literals.
- Snapshot bracket on every apply.
- `monitoring_register: true` only for hosts not in legacy infra-vms.conf.
- Vault is the only source of production secrets.
- FreeBSD vs Linux split (pf/ifconfig/doas vs nftables/ip/sudo).

The prompt also defines the JSON response shape: `summary`, `classification` (`safe-class` / `needs-review` / `risky`), and `findings[]` with `file:line:severity:body`.

## Required repo secret

`ANTHROPIC_API_KEY` — set via `gh secret set ANTHROPIC_API_KEY --repo AS215932/network-operations --body \"\$ANTHROPIC_API_KEY\"`. Until that's set, this workflow will fail open (post a failure comment on the PR). Listed in docs/ci/provision.md step 6.

## Bootstrap chicken-and-egg

Same as PRs 0b and 0a: this workflow runs on the self-hosted `hyrule-infra` runner; it queues until that runner is online.

## Test plan

- [ ] Merge PR #41 (ci VM), provision the VM, register runner, set `ANTHROPIC_API_KEY` repo secret.
- [ ] Open a trivial PR (docs typo). Confirm AI review posts within ~60s of sync.
- [ ] Open a PR violating a convention (e.g. firewall rule without network-flows.md update). Confirm the reviewer flags it with the right `file:line`.
- [ ] Open an `ansible/generated/`-only PR. Confirm the AI sets `classification: safe-class` and adds the `safe-class` label.

## Rollback

`git revert` this PR. No effect — the workflow simply doesn't run.

Related: plan file `we-need-to-go-zany-robin.md` (Phase 0 PR 0c).