### PR TITLE
Add auto-merge workflow for safe-class PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,59 @@
+---
+name: auto-merge
+
+# Auto-merge trivial-class PRs. The AI reviewer in ai-review.yml labels a PR
+# `safe-class` iff the diff is entirely under ansible/generated/, docs/, or
+# *.md. This workflow waits for required checks (lint + render-check), then
+# squash-merges.
+#
+# A human always merges any source change. Auto-merge here is for renders,
+# docs, and AI-research-comment PRs — strictly the low-blast-radius lane.
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, synchronize, reopened]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'safe-class')
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - name: Verify diff scope matches safe-class
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          # Defense-in-depth: even if the label is set, verify the actual
+          # diff only touches the safe-class path set. Refuses merge for any
+          # path outside ansible/generated/, docs/, *.md, or .github/CODEOWNERS-style files.
+          files=$(gh pr view "$PR" --repo "$REPO" --json files -q '.files[].path')
+          violation=0
+          while IFS= read -r f; do
+            case "$f" in
+              ansible/generated/*) ;;
+              docs/*)              ;;
+              *.md)                ;;
+              "")                  ;;
+              *)
+                echo "::error::path '$f' is outside the safe-class set"
+                violation=1
+                ;;
+            esac
+          done <<< "$files"
+          exit "$violation"
+
+      - name: Enable auto-merge (waits for required checks)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR" --repo "$REPO" --squash --auto --delete-branch

--- a/scripts/ci/init-labels.sh
+++ b/scripts/ci/init-labels.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# scripts/ci/init-labels.sh
+#
+# Idempotent label creation for the CI lane. Run once after bootstrap to
+# ensure the labels referenced by ai-review.yml and auto-merge.yml exist.
+#
+# Usage:
+#   gh auth status                    # confirm logged in
+#   scripts/ci/init-labels.sh
+#
+# Safe to re-run: `gh label create --force` updates color/description on
+# existing labels rather than failing.
+
+set -euo pipefail
+
+REPO="${REPO:-AS215932/network-operations}"
+
+declare -A labels=(
+  [safe-class]="0e8a16:Auto-merge candidate (generated/, docs, or *.md only)"
+  [ai-reviewed]="cccccc:AI review has been posted on this PR"
+  [needs-human-review]="d4c5f9:AI review classified this as needs-review"
+  [risky]="b60205:AI review classified this as risky (BGP/NAT64/firewall/Vault)"
+  [routine]="0052cc:Recurring operational task or low-risk infra change"
+)
+
+for name in "${!labels[@]}"; do
+  spec="${labels[$name]}"
+  color="${spec%%:*}"
+  desc="${spec#*:}"
+  echo "ensuring label: $name ($color)"
+  gh label create "$name" \
+    --repo "$REPO" \
+    --color "$color" \
+    --description "$desc" \
+    --force
+done
+
+echo "done."


### PR DESCRIPTION
## Summary

`.github/workflows/auto-merge.yml` watches for the `safe-class` label (set by the AI reviewer in PR #43). On label:

1. **Defense-in-depth check**: re-walks the PR's file list and refuses if any path falls outside `ansible/generated/`, `docs/`, or `*.md` — even if the label is set. The label is necessary but not sufficient.
2. `gh pr merge --squash --auto --delete-branch` — relies on branch protection's required-checks gate (lint + render-check + ai-review) before actually merging.

The AI **never** auto-merges source code. The class definition is strict and explicit. A human always clicks merge on anything that touches a template, task, role, host_vars entry, or workflow.

## Required branch protection (one-time UI / `gh api`)

For `--auto` to wait properly, `main` needs branch protection with required checks: `lint`, `render-check`, `ai-review`. Set via the GitHub UI or:

```bash
gh api -X PUT /repos/AS215932/network-operations/branches/main/protection \
  -f required_status_checks.strict=true \
  -F 'required_status_checks.contexts[]=lint' \
  -F 'required_status_checks.contexts[]=render-check' \
  -F 'required_status_checks.contexts[]=ai-review' \
  -f enforce_admins=false \
  -f required_pull_request_reviews=null \
  -f restrictions=null
```

Add to `docs/ci/provision.md` as a follow-up.

## Label setup

`scripts/ci/init-labels.sh` is idempotent — creates/updates these labels:

| Label | Color | Purpose |
|-------|-------|---------|
| `safe-class` | green | auto-merge candidate (generated/, docs, *.md only) |
| `ai-reviewed` | grey | AI review has been posted |
| `needs-human-review` | purple | AI classified as needs-review |
| `risky` | red | AI classified as risky (BGP/NAT64/firewall/Vault) |
| `routine` | blue | already used in the tracker; here for completeness |

Run once after CI bootstrap: `scripts/ci/init-labels.sh`.

## Test plan

- [ ] After branch protection is set, open a docs typo PR. AI labels it `safe-class`. Auto-merge fires.
- [ ] Open a PR that adds `docs/typo.md` AND `ansible/roles/firewall/templates/something.j2`. AI does NOT label `safe-class`. Auto-merge stays silent.
- [ ] Manually add `safe-class` to a source PR (simulate label-poisoning). Auto-merge's defense-in-depth check refuses, posts the violation list to the workflow logs.

## Rollback

`git revert`. Auto-merge stops, manual merge still works.

Related: plan file `we-need-to-go-zany-robin.md` (Phase 0 PR 0d).

## Summary by Sourcery

Introduce an automated merge workflow for low-risk, AI-classified pull requests and bootstrap the required GitHub labels to support it.

New Features:
- Add an auto-merge GitHub Actions workflow that squashes and auto-merges PRs labeled as safe-class after verifying their diff scope and required checks.
- Introduce a CI script to create and update standard labels used by AI review and auto-merge workflows.