### PR TITLE
Add apply.yml manual-gate workflow + deploy runbook

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -1,0 +1,163 @@
+---
+name: apply
+
+# Manual gated deployment. Run with:
+#   gh workflow run apply.yml -F playbook=firewall -F limit=cr1-de1 -F dry_run=true
+#
+# The first invocation each session must be approved via the `production`
+# environment protection rule (set up once: settings → environments).
+# A required reviewer (the user) approves; the workflow then runs the
+# pre-snapshot → render/apply → post-snapshot → diff sequence and posts
+# the diff to the run summary + as a comment on the named PR (if any).
+
+on:
+  workflow_dispatch:
+    inputs:
+      playbook:
+        description: Playbook to apply (matches ansible/playbooks/<name>.yml)
+        type: choice
+        required: true
+        options:
+          - firewall
+          - monitoring
+          - icinga2
+          - logs
+          - noc
+          - vault
+          - ci
+          - knot
+          - extmon
+          - rtr_routing
+          - networkd_resolved
+          - mail_openbsd
+          - freebsd_resolv
+          - noc_mcp_key
+      limit:
+        description: Ansible --limit pattern (host or group)
+        type: string
+        required: true
+        default: ""
+      dry_run:
+        description: Dry-run only (render + check, no apply)
+        type: boolean
+        required: true
+        default: true
+      pr_number:
+        description: PR number to post the diff to (optional)
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    # `production` is an environment with a required reviewer rule.
+    # The job pauses until the reviewer approves.
+    environment: production
+    timeout-minutes: 30
+    env:
+      ANSIBLE_FORCE_COLOR: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Source Vault-rendered secrets
+        run: |
+          # Vault Agent on `ci` renders /etc/github-runner/secrets.env. Sourced
+          # here so playbooks pick up DISCORD_WEBHOOK_URL, ICINGA_API_*, etc.
+          if [ -r /etc/github-runner/secrets.env ]; then
+            set -a; . /etc/github-runner/secrets.env; set +a
+            # Re-export for subsequent steps via GITHUB_ENV.
+            grep -E '^[A-Z_][A-Z0-9_]*=' /etc/github-runner/secrets.env >> "$GITHUB_ENV"
+          else
+            echo "::warning::/etc/github-runner/secrets.env not found — apply may fail on env-var lookups"
+          fi
+
+      - name: Pre-deploy Icinga snapshot
+        working-directory: ansible
+        run: |
+          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+            --tags snapshot \
+            -e snapshot_phase=pre
+
+      - name: Render-only (dry run)
+        if: ${{ inputs.dry_run }}
+        working-directory: ansible
+        run: |
+          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+            --tags validate \
+            --connection=local \
+            --skip-tags=snapshot \
+            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+
+      - name: Apply
+        if: ${{ !inputs.dry_run }}
+        working-directory: ansible
+        run: |
+          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+            --tags apply \
+            -e "${{ inputs.playbook }}_apply=true" \
+            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+
+      - name: Post-deploy Icinga snapshot
+        if: ${{ !inputs.dry_run }}
+        working-directory: ansible
+        run: |
+          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+            --tags snapshot \
+            -e snapshot_phase=post
+
+      - name: Capture snapshot diff
+        if: ${{ !inputs.dry_run }}
+        id: diff
+        run: |
+          set -e
+          shopt -s nullglob
+          snapshots_root=ansible/generated/snapshots
+          if [ ! -d "$snapshots_root" ]; then
+            echo "::warning::no snapshots directory found at $snapshots_root"
+            echo "diff=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Two most recent snapshot dirs are pre/post.
+          mapfile -t dirs < <(ls -1dt "$snapshots_root"/*/ 2>/dev/null | head -2)
+          if [ "${#dirs[@]}" -lt 2 ]; then
+            echo "::warning::need 2 snapshot dirs, found ${#dirs[@]}"
+            exit 0
+          fi
+          {
+            echo "## Icinga snapshot diff"
+            echo
+            echo '```diff'
+            diff -ruN "${dirs[1]}" "${dirs[0]}" || true
+            echo '```'
+          } > /tmp/diff.md
+          {
+            echo "diff<<EOF"
+            cat /tmp/diff.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post diff to workflow summary
+        if: ${{ !inputs.dry_run }}
+        run: cat /tmp/diff.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post diff as PR comment
+        if: ${{ !inputs.dry_run && inputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ inputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/diff.md
+
+      - name: Upload snapshots as artifact
+        if: ${{ !inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots-${{ inputs.playbook }}-${{ inputs.limit }}
+          path: ansible/generated/snapshots/
+          retention-days: 30

--- a/docs/ci/deploy-runbook.md
+++ b/docs/ci/deploy-runbook.md
@@ -1,0 +1,124 @@
+# Deploy runbook (CI lane)
+
+How to ship a change from "PR merged" to "live on production." Production is
+the next environment after `main` — there is no staging VM, by design (the
+approved plan trades fidelity for a smaller blast surface). Safety lives in
+two layers:
+
+1. **Render-check** before merge — the diff between `ansible/generated/` and
+   what render produces is empty.
+2. **Icinga snapshot bracket** around apply — what was broken before and what
+   is broken after, captured as artifacts on the workflow run.
+
+## When to ship
+
+After your PR merges to `main`. Most days that's also the same day, but
+deploys happen one at a time. If two operators merge back-to-back, ship
+sequentially (each apply's post-snapshot is the next apply's pre-snapshot
+baseline).
+
+Do not ship during the documented merge-freeze windows (see `MEMORY.md` for
+any active freezes).
+
+## How to dispatch a deploy
+
+```bash
+gh workflow run apply.yml \
+  -F playbook=firewall \
+  -F limit=cr1-de1 \
+  -F dry_run=false \
+  -F pr_number=42         # optional — auto-comments the diff onto the PR
+```
+
+Or via the GitHub UI: **Actions → apply → Run workflow → pick playbook /
+limit / dry-run / PR**.
+
+The workflow pauses immediately at the **`production` environment review**
+gate. Approve in the UI; the run unfreezes.
+
+## What the workflow does
+
+1. **Source secrets** — Vault Agent on the `ci` runner has rendered
+   `/etc/github-runner/secrets.env` with `DISCORD_WEBHOOK_URL`,
+   `ICINGA_API_USER`, etc. The workflow exports them into `GITHUB_ENV`.
+2. **Pre-snapshot** — `ansible-playbook <pb>.yml --tags snapshot -e snapshot_phase=pre`.
+   Captures current Icinga problem set from `mon`.
+3. **Render-only OR apply** — depending on `dry_run`. Apply uses
+   `--tags apply -e <pb>_apply=true --limit <limit>`.
+4. **Post-snapshot** — same as step 2 with `snapshot_phase=post`.
+5. **Diff snapshots** — `diff -ruN pre post`. The diff lands in the workflow
+   run summary, on the named PR (if `pr_number`), and as an uploaded artifact
+   (`snapshots-<playbook>-<limit>`).
+
+## How to read the snapshot diff
+
+- **Empty diff** — clean apply. Ship the next change.
+- **Lines starting with `+`** — checks that *became* problems. Investigate
+  whether your change caused them.
+- **Lines starting with `-`** — checks that resolved. Probably unrelated
+  (recovery during the apply window); note in run summary.
+- **Both `+` and `-` on the same check** — flap. Look at the snapshot's
+  detail JSON for last_hard_state_change.
+
+If the diff has `+` entries for checks that look related to your change, the
+expected response is:
+
+1. **If the apply succeeded but new checks fail**: roll forward — fix the
+   templates and dispatch another apply. Don't roll back the systemd unit
+   reload; that just makes the next deploy harder.
+2. **If the apply failed mid-flight**: roll back the change with another PR,
+   re-dispatch.
+
+## Manual deploy (bypass CI)
+
+When the runner is offline or unreachable. Same shape as the workflow but
+local:
+
+```bash
+cd ansible
+set -a; source ../secrets.local.sh; set +a
+
+# Pre-snapshot (manual)
+ansible-playbook playbooks/<pb>.yml --tags snapshot -e snapshot_phase=pre
+
+# Apply
+ansible-playbook playbooks/<pb>.yml --tags apply \
+  -e '{"<pb>_apply":true}' \
+  --limit <limit>
+
+# Post-snapshot
+ansible-playbook playbooks/<pb>.yml --tags snapshot -e snapshot_phase=post
+
+# Diff manually
+ls -1dt ansible/generated/snapshots/*/ | head -2 | \
+  xargs -I{} diff -ruN
+```
+
+Record the deploy in the PR description after the fact.
+
+## Environment protection setup (one-time)
+
+The `production` environment with a required reviewer is set via the GitHub
+UI: **Settings → Environments → New environment → production → Required
+reviewers: @<your-handle>**. Or via:
+
+```bash
+gh api -X PUT /repos/AS215932/network-operations/environments/production \
+  -f reviewers='[{"type":"User","id":<user-id>}]'
+```
+
+Once set, every `apply.yml` run pauses for approval before the apply step.
+
+## Branch protection setup (one-time)
+
+`main` must require: `lint`, `render-check`, `ai-review` checks. See the
+PR #44 description (`feat/0d-ci-auto-merge`) for the exact `gh api` call.
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Workflow stuck "Waiting for self-hosted runner" | `ci` VM offline / runner not registered | Re-run `docs/ci/provision.md` from step 4 |
+| Pre-snapshot fails with "icinga-snapshot not found" | First time apply on a brand-new mon | One-time: SSH to mon and create `/usr/local/bin/icinga-snapshot` (covered separately) |
+| Apply step fails with "Permission denied (publickey)" | `runner` user's SSH key not in target host's authorized_keys | Push key via `playbooks/noc-mcp-key.yml`-style fan-out (filed as follow-up if not done) |
+| `--limit X` skips snapshot plays | You're running pre-fix #16 code | Confirm the snapshot --limit fix (issue #16) is merged |


### PR DESCRIPTION
## Summary

Final piece of the Phase 0 CI/CD foundation. `.github/workflows/apply.yml` is the **manual** production-deploy lane:

- Triggered via `gh workflow run apply.yml` or the GitHub UI.
- Inputs: `playbook`, `limit`, `dry_run` (default true), `pr_number` (optional).
- Runs inside the `production` GitHub environment, which has a required reviewer rule — the workflow pauses until a human approves.
- Sequence: Vault secrets → pre-snapshot → render-only OR apply → post-snapshot → diff → post to summary/PR/artifact.

`docs/ci/deploy-runbook.md` is the operator-facing single-pager: when to ship, how to dispatch, reading snapshot diffs, manual deploy bypass, and the one-time setup for the production environment + branch protection.

## CI lane recap

With this PR, the full lane is:

| Phase | When | What |
|-------|------|------|
| A | every PR | lint + render-check + ai-review (PRs 0b/0c, #42/#43) |
| B | trivial PRs after green | auto-merge (PR 0d, #44) |
| C | deploy | manual `workflow_dispatch` with environment protection + snapshot bracket (this PR) |

## Required one-time setup (called out in deploy-runbook.md)

1. Create the `production` environment with required reviewers:
   ```bash
   gh api -X PUT /repos/AS215932/network-operations/environments/production \
     -f reviewers='[{"type":"User","id":<your-user-id>}]'
   ```
2. Set branch protection on `main` (see PR #44 description).
3. Vault Agent on `ci` renders `/etc/github-runner/secrets.env` (filed as a follow-up if not done; PR 0a's `ci` VM scaffolding is the prerequisite).

## Test plan

- [ ] After PRs 0a–0d are merged and the `ci` runner is online with required env vars rendered by Vault Agent.
- [ ] `gh workflow run apply.yml -F playbook=firewall -F limit=cr1-de1 -F dry_run=true` — confirm the run pauses for `production` approval, then renders only and posts a snapshot bracket to the run summary.
- [ ] Same with `dry_run=false` for a low-risk deploy (e.g. a docs-only change that touches `monitoring`). Confirm the diff posts cleanly.
- [ ] `gh workflow run apply.yml -F playbook=firewall -F limit=ALL` (or with no `limit`) is allowed but flagged in the runbook — runs against everything except dom0.

## Rollback

`git revert`. Manual deploys via local `ansible-playbook` continue to work (the runbook covers the manual bypass).

Related: plan file `we-need-to-go-zany-robin.md` (Phase 0 PR 0e).

## Summary by Sourcery

Add a manually triggered, environment-protected production deploy workflow with snapshot-based verification and an accompanying operator runbook for using it.

New Features:
- Introduce an apply.yml workflow_dispatch pipeline for running selected Ansible playbooks against production with dry-run and PR-comment support.
- Capture and publish Icinga snapshot diffs, including artifact upload, around deployments to track pre/post state.
- Add deploy-runbook documentation describing when and how to run production deploys, environment protection setup, and common failure modes.