### PR TITLE
snapshot plays survive --limit (#16)

### DIFF
--- a/ansible/playbooks/firewall.yml
+++ b/ansible/playbooks/firewall.yml
@@ -1,16 +1,4 @@
 ---
-- name: Firewall — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Pre-deploy Icinga snapshot
-      include_role:
-        name: firewall
-        tasks_from: snapshot
-      vars:
-        snapshot_phase: pre
-  tags: [snapshot, always]
-
 - name: Firewall — apply
   hosts: all:!dom0
   serial: 1
@@ -18,18 +6,24 @@
   # don't require connectivity to the hosts.
   gather_facts: false
   become: true
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - firewall
-  tags: [firewall]
-
-- name: Firewall — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [firewall]

--- a/ansible/playbooks/icinga2.yml
+++ b/ansible/playbooks/icinga2.yml
@@ -15,34 +15,28 @@
 #   ansible-playbook playbooks/icinga2.yml --tags apply \
 #       -e '{"icinga2_apply":true}' --limit mon
 
-- name: icinga2 — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+- name: icinga2 — render + apply
+  hosts: mon
+  gather_facts: true
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: icinga2 — render + apply
-  hosts: mon
-  gather_facts: true
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - icinga2
-  tags: [icinga2]
-
-- name: icinga2 — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [icinga2]

--- a/ansible/playbooks/knot.yml
+++ b/ansible/playbooks/knot.yml
@@ -1,16 +1,4 @@
 ---
-- name: Knot DNS — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Pre-deploy Icinga snapshot
-      include_role:
-        name: firewall
-        tasks_from: snapshot
-      vars:
-        snapshot_phase: pre
-  tags: [snapshot, always]
-
 - name: Knot DNS — apply
   hosts: nameservers
   # Primary first, then secondary — so when ns2 starts, ns1 already serves
@@ -18,18 +6,24 @@
   serial: 1
   gather_facts: false
   become: true
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - knot
-  tags: [knot]
-
-- name: Knot DNS — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [knot]

--- a/ansible/playbooks/logs.yml
+++ b/ansible/playbooks/logs.yml
@@ -17,24 +17,30 @@
 #   ansible-playbook playbooks/logs.yml --tags validate \
 #     --connection=local --skip-tags=snapshot
 
-- name: Logs — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+- name: Logs — bring up aggregator first (log VM)
+  hosts: log
+  gather_facts: true
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: Logs — bring up aggregator first (log VM)
-  hosts: log
-  gather_facts: true
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - logs
+  post_tasks:
+    - name: Post-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
   tags: [logs, aggregator]
 
 - name: Logs — agents on every opted-in host
@@ -42,18 +48,26 @@
   serial: 1
   gather_facts: true
   become: true
+  pre_tasks:
+    # Also bracket the agents play so `--limit <agent>` runs still get a
+    # snapshot bracket even when the aggregator play didn't match the limit.
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - logs
-  tags: [logs, agents]
-
-- name: Logs — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [logs, agents]

--- a/ansible/playbooks/mail_openbsd.yml
+++ b/ansible/playbooks/mail_openbsd.yml
@@ -8,34 +8,28 @@
 #   set -a; source ../secrets.local.sh; set +a
 #   ansible-playbook playbooks/mail_openbsd.yml --tags apply -e '{"mail_apply":true}'
 
-- name: OpenBSD mail server — pre-deploy snapshot
-  hosts: localhost
+- name: OpenBSD mail server
+  hosts: mail
   gather_facts: false
-  tasks:
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: OpenBSD mail server
-  hosts: mail
-  gather_facts: false
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - mail_openbsd
-  tags: [mail]
-
-- name: OpenBSD mail server — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [mail]

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -8,35 +8,29 @@
 # Apply: source ../secrets.local.sh first.
 #   ansible-playbook playbooks/monitoring.yml --tags apply -e '{"monitoring_apply":true}'
 
-- name: Monitoring — pre-deploy snapshot
-  hosts: localhost
+- name: Monitoring — apply
+  hosts: linux:openbsd
+  serial: 1
   gather_facts: false
-  tasks:
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: Monitoring — apply
-  hosts: linux:openbsd
-  serial: 1
-  gather_facts: false
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - monitoring
-  tags: [monitoring]
-
-- name: Monitoring — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [monitoring]

--- a/ansible/playbooks/networkd_resolved.yml
+++ b/ansible/playbooks/networkd_resolved.yml
@@ -1,33 +1,27 @@
 ---
-- name: networkd_resolved — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+- name: networkd_resolved — apply search domain + DNS drop-in
+  hosts: linux
+  serial: 1
+  gather_facts: true
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: networkd_resolved — apply search domain + DNS drop-in
-  hosts: linux
-  serial: 1
-  gather_facts: true
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - networkd_resolved
-  tags: [networkd_resolved]
-
-- name: networkd_resolved — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [networkd_resolved]

--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -21,23 +21,29 @@
 #   set -a; source ../secrets.local.sh; set +a
 #   ansible-playbook playbooks/noc.yml --tags apply -e '{"noc_apply":true}' --limit noc
 
-- name: noc — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+- name: noc — apply hyrule-mcp + noc-agent
+  hosts: noc
+  serial: 1
+  gather_facts: true
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: noc — apply hyrule-mcp + noc-agent
-  hosts: noc
-  serial: 1
-  gather_facts: true
-  become: true
+      run_once: true
+      tags: [snapshot, always]
+  post_tasks:
+    - name: Post-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
   vars:
     gemini_api_key: "{{ lookup('env', 'GEMINI_API_KEY') }}"
     noc_discord_webhook: "{{ lookup('env', 'NOC_DISCORD_WEBHOOK') }}"
@@ -72,15 +78,3 @@
           /bin/systemctl restart noc-agent-bot.service
       when: noc_agent_secret_backend == 'vault'
   tags: [noc]
-
-- name: noc — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Post-deploy Icinga snapshot
-      include_role:
-        name: firewall
-        tasks_from: snapshot
-      vars:
-        snapshot_phase: post
-  tags: [snapshot, always]

--- a/ansible/playbooks/vault.yml
+++ b/ansible/playbooks/vault.yml
@@ -7,38 +7,32 @@
 # One-time init/unseal and policy/WIF bootstrap are intentionally explicit;
 # see docs/vault-wif.md and scripts/bootstrap-vault-noc-wif.sh.
 
-- name: Vault — pre-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+- name: Vault — apply
+  hosts: vault
+  serial: 1
+  gather_facts: true
+  become: true
+  pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: pre
-  tags: [snapshot, always]
-
-- name: Vault — apply
-  hosts: vault
-  serial: 1
-  gather_facts: true
-  become: true
+      run_once: true
+      tags: [snapshot, always]
   roles:
     - vault
     - monitoring
     - logs
     - firewall
-  tags: [vault]
-
-- name: Vault — post-deploy snapshot
-  hosts: localhost
-  gather_facts: false
-  tasks:
+  post_tasks:
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall
         tasks_from: snapshot
       vars:
         snapshot_phase: post
-  tags: [snapshot, always]
+      run_once: true
+      tags: [snapshot, always]
+  tags: [vault]

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -47,6 +47,12 @@ pre-deploy snapshot captures known problems before we touch hosts; the
 post-deploy snapshot lets us spot new alerts caused by the rollout. Only use
 `--skip-tags snapshot` for render-only validation or an explicit emergency.
 
+Snapshot plays now live as `pre_tasks` / `post_tasks` on each playbook's
+main play with `run_once: true`, so they fire correctly even when
+`--limit <subset>` is passed (issue #16). No more "remember to run the
+mon-side snapshot manually if you used `--limit`" caveat — the playbook
+enforces the bracket.
+
 This:
 1. SSHes to the host (no `--connection=local`).
 2. Renders the config to `<conf_path>.new` on the host.

--- a/scripts/ci/test-snapshot-bracket.sh
+++ b/scripts/ci/test-snapshot-bracket.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/ci/test-snapshot-bracket.sh — regression test for issue #16.
+#
+# Runs every playbook in `--tags snapshot,validate --connection=local
+# --check --limit <something>` and grep-asserts that the Pre-deploy and
+# Post-deploy Icinga snapshot tasks appear in the dry-run output.
+#
+# Catches the failure mode where a future refactor accidentally puts
+# snapshots back into a standalone `hosts: localhost` play (which gets
+# filtered out by --limit).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../ansible"
+
+# Per-playbook test limit. Picks a host that's actually in each playbook's
+# main hosts: selector. The point of the test is "snapshot fires under
+# --limit", so the limit must match at least one host in the play.
+declare -A test_limits=(
+  [firewall]=noc
+  [monitoring]=noc
+  [icinga2]=mon
+  [logs]=noc
+  [noc]=noc
+  [vault]=vault
+  [knot]=dns
+  [networkd_resolved]=noc
+  [mail_openbsd]=mail
+)
+
+fail=0
+for pb in "${!test_limits[@]}"; do
+  limit="${test_limits[$pb]}"
+  echo "::group::test bracket: ${pb}.yml --limit ${limit}"
+  out=$(
+    ansible-playbook "playbooks/${pb}.yml" \
+      --tags snapshot,always \
+      --connection=local \
+      --check \
+      --limit "${limit}" 2>&1 || true
+  )
+  if ! grep -q 'Pre-deploy Icinga snapshot' <<<"${out}"; then
+    echo "::error::${pb}.yml does NOT trigger pre-deploy snapshot under --limit ${limit}"
+    fail=1
+  fi
+  if ! grep -q 'Post-deploy Icinga snapshot' <<<"${out}"; then
+    echo "::error::${pb}.yml does NOT trigger post-deploy snapshot under --limit ${limit}"
+    fail=1
+  fi
+  echo "::endgroup::"
+done
+
+exit "${fail}"


### PR DESCRIPTION
## Summary

Pre/post Icinga snapshot plays were defined as `hosts: localhost` plays — but Ansible's `--limit` filter applies to all plays including localhost. When the operator ran `--limit noc`, the snapshot plays silently never executed, even though CLAUDE.md says the bracket is non-negotiable.

## Fix

Refactored every affected playbook (firewall, monitoring, icinga2, logs, noc, vault, knot, networkd_resolved, mail_openbsd) to put the snapshot as `pre_tasks` / `post_tasks` on the main play with `run_once: true`. The included `snapshot.yml` already has `delegate_to: mon`, so the snapshot work still happens on mon — just bracketed inside the play that ran.

`logs.yml` is a special case (two main plays for aggregator + agents); both plays get pre+post so the bracket fires whether `--limit` selects the log VM or any of the agent hosts.

## Regression test

`scripts/ci/test-snapshot-bracket.sh` runs every affected playbook in `--tags snapshot,always --check --limit <real host>` mode and grep-asserts the snapshot task names appear in dry-run output. To be wired into `.github/workflows/lint.yml` once PR #42 (the lint workflow itself) lands.

Local run:

```
$ bash scripts/ci/test-snapshot-bracket.sh
::group::test bracket: noc.yml --limit noc
::endgroup::
::group::test bracket: firewall.yml --limit noc
::endgroup::
... (9 playbooks, all pass)
exit code: 0
```

## Doc update

`docs/ansible.md` drops the "remember to run the mon-side snapshot manually if you used `--limit`" caveat. The playbook now enforces the bracket.

## Test plan (post-merge)

- [ ] Re-run `bash scripts/ci/test-snapshot-bracket.sh` against `main` after this PR merges. Should pass.
- [ ] Live: `ansible-playbook playbooks/firewall.yml --tags validate --connection=local --limit noc` produces snapshot artifacts in `ansible/generated/snapshots/<ts>/`.
- [ ] Live apply with `--limit noc`: snapshot bracket actually captures Icinga state.

## Rollback

`git revert`. Reverts to the prior shape; snapshot bracket silently skipped under `--limit`.

Closes #16

## Summary by Sourcery

Ensure Icinga snapshot tasks always run alongside main Ansible plays, even when playbooks are executed with host limits.

New Features:
- Add a regression test script that verifies pre/post Icinga snapshots still run under various --limit executions across all relevant playbooks.

Enhancements:
- Refactor multiple Ansible playbooks to move pre/post Icinga snapshot logic into pre_tasks/post_tasks on their main plays with run_once scoping.
- Update Ansible documentation to describe the new snapshot bracketing behavior and remove the manual snapshot caveat when using --limit.

Tests:
- Introduce scripts/ci/test-snapshot-bracket.sh to assert snapshot tasks execute for each affected playbook when run with --limit.