### PR TITLE
icinga2: scoped noc-agent ApiUser (#15)

### DIFF
--- a/ansible/playbooks/icinga2.yml
+++ b/ansible/playbooks/icinga2.yml
@@ -19,6 +19,8 @@
   hosts: mon
   gather_facts: true
   become: true
+  vars:
+    icinga2_noc_agent_api_password: "{{ lookup('env', 'ICINGA_NOC_AGENT_API_PASSWORD') | default('', true) }}"
   pre_tasks:
     - name: Pre-deploy Icinga snapshot
       include_role:

--- a/ansible/roles/icinga2/tasks/install.yml
+++ b/ansible/roles/icinga2/tasks/install.yml
@@ -70,3 +70,18 @@
   notify: validate and reload icinga2
   no_log: true
   tags: [apply]
+
+# Per issue #15: scoped noc-agent ApiUser, additive to the legacy
+# api-users.conf that holds the default root user. Renders only the new
+# noc-agent user definition; never touches the legacy file.
+- name: Install api-users-managed.conf (scoped noc-agent ApiUser)
+  template:
+    src: api-users-managed.conf.j2
+    dest: "{{ icinga2_conf_dir }}/api-users-managed.conf"
+    owner: nagios
+    group: nagios
+    mode: "0640"
+  notify: validate and reload icinga2
+  no_log: true
+  when: icinga2_noc_agent_api_password | default('') | length > 0
+  tags: [apply]

--- a/ansible/roles/icinga2/templates/api-users-managed.conf.j2
+++ b/ansible/roles/icinga2/templates/api-users-managed.conf.j2
@@ -1,0 +1,19 @@
+// /etc/icinga2/conf.d/api-users-managed.conf — managed by ansible (roles/icinga2)
+//
+// Additive ApiUser definitions. The original /etc/icinga2/conf.d/api-users.conf
+// (containing the default `root` ApiUser from `icinga2 api setup`) is left
+// untouched. This file only adds scoped users that hyrule-infra owns end-to-end.
+//
+// Per issue #15: hyrule-mcp on `noc` must NOT authenticate as `root`
+// (permissions = ["*"]) once HYRULE_MCP_ENABLE_ACTIONS=1 flips. The
+// `noc-agent` ApiUser below carries exactly the permissions the MCP tools
+// actually need.
+
+object ApiUser "noc-agent" {
+  password = "{{ icinga2_noc_agent_api_password }}"
+  permissions = [
+    "actions/acknowledge-problem",
+    "objects/query/Host",
+    "objects/query/Service",
+  ]
+}

--- a/docs/runbooks/rotate-icinga-api-user.md
+++ b/docs/runbooks/rotate-icinga-api-user.md
@@ -1,0 +1,64 @@
+# Rotate the `noc-agent` Icinga2 ApiUser password
+
+Used by `hyrule-mcp` on `noc` to authenticate against the Icinga2 REST API
+on `mon`. Per issue #15, this user replaces the legacy `root` ApiUser with
+scoped permissions (`actions/acknowledge-problem`, `objects/query/Host`,
+`objects/query/Service`).
+
+## When to rotate
+
+- **Annually**, on the same cadence as Vault secret rotation.
+- **Immediately** if the credential leaks (logged accidentally, committed to
+  git, etc.).
+- **After a maintainer leaves the project**.
+
+## Rotate
+
+```bash
+# 1. Generate a new password.
+NEW_PW=$(openssl rand -hex 32)
+
+# 2. Push the new password to the ansible apply via the env var.
+export ICINGA_NOC_AGENT_API_PASSWORD="$NEW_PW"
+
+# 3. Re-apply the icinga2 role to mon (renders + reloads).
+cd ansible
+set -a; source ../secrets.local.sh; set +a
+ansible-playbook playbooks/icinga2.yml --tags apply \
+  -e '{"icinga2_apply":true}' --limit mon
+
+# 4. Update the Vault kv/noc-agent entry. hyrule-mcp reads from there via
+#    Vault Agent's render of /opt/noc-agent/.env.
+vault kv patch kv/noc-agent \
+  icinga_api_user=noc-agent \
+  icinga_api_password="$NEW_PW"
+
+# 5. Watch vault-agent on noc render the new value.
+ssh noc 'journalctl -fu vault-agent-noc-agent'
+# After the next /opt/noc-agent/.env render (driven by Vault TTL — see
+# CTMPL config), noc-agent re-reads .env on its next restart. Since PR #40
+# (vault-agent JWT no-restart), the env-template re-render DOES bounce
+# noc-agent, so the new credential is picked up automatically.
+
+# 6. Smoke: hyrule-mcp should still successfully call icinga_get_host_state.
+curl -s -k -u "noc-agent:$NEW_PW" \
+  "https://mon.as215932.net:5665/v1/objects/hosts/noc" | jq .results
+```
+
+## Failure modes
+
+- **`401 Unauthorized` after rotation**: vault-agent on noc hasn't yet
+  re-rendered `/opt/noc-agent/.env`. Wait one render cycle (≤ wait.max in
+  vault-agent.hcl, default 10s) or `systemctl reload vault-agent-noc-agent`.
+- **`403 Forbidden` on acknowledge-problem**: permissions list mismatch.
+  Compare `/etc/icinga2/conf.d/api-users-managed.conf` against the
+  Ansible template `roles/icinga2/templates/api-users-managed.conf.j2`.
+- **`icinga2 daemon -C` fails**: a stray syntax error somewhere; the
+  managed file uses `--strict-permissions` ownership (`nagios:nagios 0640`),
+  so check perms first with `ls -la /etc/icinga2/conf.d/api-users-managed.conf`.
+
+## Tighten further (future work)
+
+If we ever need more than read-and-ack, this is the file where new
+permissions get added. Don't bring back `permissions = ["*"]`. Each new
+permission warrants a follow-up issue documenting why.


### PR DESCRIPTION
## Summary

hyrule-mcp on `noc` authenticates against the Icinga2 REST API on `mon` as `root` (permissions = ["*"]). That's the wrong blast radius for an LLM-driven client — when `HYRULE_MCP_ENABLE_ACTIONS=1` flips, `icinga_acknowledge_alert` becomes an advertised mutative MCP tool, and a buggy / prompt-injected agent could write to any Icinga endpoint (schedule-downtime on critical infra, config object create/delete, etc.).

## Change

New templated `/etc/icinga2/conf.d/api-users-managed.conf` rendered by the icinga2 role with a scoped `noc-agent` ApiUser:

```icinga2
object ApiUser "noc-agent" {
  password = "{{ icinga2_noc_agent_api_password }}"
  permissions = [
    "actions/acknowledge-problem",
    "objects/query/Host",
    "objects/query/Service",
  ]
}
```

**Additive**: the legacy `/etc/icinga2/conf.d/api-users.conf` (containing the default `root` ApiUser) is left untouched. Icinga2 reads all `*.conf` in `conf.d/`, so both files coexist. The root user remains as break-glass only.

Password sourced from `ICINGA_NOC_AGENT_API_PASSWORD` at apply time (env or future Vault); a `when:` check skips template render when no real password is provided, so render-only validation runs don't fail.

## Files

| Path | Purpose |
|------|---------|
| `ansible/roles/icinga2/templates/api-users-managed.conf.j2` | new ApiUser definition |
| `ansible/roles/icinga2/tasks/install.yml` | template task + handler notification |
| `ansible/playbooks/icinga2.yml` | env var passthrough |
| `docs/runbooks/rotate-icinga-api-user.md` | rotate flow (generate → role apply → Vault patch → noc-agent picks it up) |
| `secrets.local.sh` | comment block points at the runbook and clarifies root is break-glass |

## Why I couldn't preview the live api-users.conf

The `mcp-ops` user on mon can't read `/etc/icinga2/conf.d/` without sudo (root:nagios 0640 perms). I'm filing a follow-up issue about widening that for read-only MCP introspection. For this PR, the additive design sidesteps the issue — we don't need to know what's already in the legacy file.

## Test plan

- [ ] On the ops workstation: `export ICINGA_NOC_AGENT_API_PASSWORD=$(openssl rand -hex 32)`.
- [ ] `ansible-playbook playbooks/icinga2.yml --tags apply -e '{"icinga2_apply":true}' --limit mon`.
- [ ] Verify: `ssh mon 'sudo cat /etc/icinga2/conf.d/api-users-managed.conf'` shows the new user.
- [ ] Smoke (from anywhere with overlay reach): `curl -s -k -u "noc-agent:$PW" https://mon.as215932.net:5665/v1/objects/hosts | jq '.results[0].name'` returns a host name (200 OK).
- [ ] Smoke (refused permission): `curl -s -k -u "noc-agent:$PW" -X POST https://mon.as215932.net:5665/v1/actions/restart-process` → 403 (not `actions/restart-process` permission).
- [ ] Smoke (accepted permission, bogus host): `curl -s -k -u "noc-agent:$PW" -X POST 'https://mon.as215932.net:5665/v1/actions/acknowledge-problem?host=bogus.host'` → 404 with a JSON body, **not** 403.
- [ ] Patch Vault: `vault kv patch kv/noc-agent icinga_api_user=noc-agent icinga_api_password=$PW`.
- [ ] On noc: wait one vault-agent render cycle, then `mcp__hyrule__icinga_get_host_state host=noc` from the ops workstation succeeds.
- [ ] **Then and only then**: `HYRULE_MCP_ENABLE_ACTIONS=1` can be flipped (separate operational step, owned by the user).

## Rollback

`git revert`. The legacy root user remains functional; hyrule-mcp falls back to it on next Vault rotation if creds for noc-agent are removed.

Depends on: nothing.
Closes #15.

## Summary by Sourcery

Introduce a scoped noc-agent Icinga2 ApiUser managed by Ansible to reduce privileges for MCP interactions with the Icinga2 REST API.

New Features:
- Add a managed Icinga2 ApiUser noc-agent with limited permissions for acknowledging problems and querying hosts and services.
- Source the noc-agent API password from an environment variable in the icinga2 playbook so it can be injected at apply time.

Enhancements:
- Render a new api-users-managed.conf via the icinga2 role only when a non-empty noc-agent API password is provided, and trigger Icinga validation and reload on change.
- Document the operational runbook for rotating the noc-agent Icinga2 ApiUser password, including integration with Vault and vault-agent workflows.

Documentation:
- Add a runbook describing how to rotate the noc-agent Icinga2 ApiUser password and handle common failure modes.