### PR TITLE
Migrate rtr from rtr.ovh1 to monitoring_register (#21)

### DIFF
--- a/ansible/generated/rtr/icinga_host.conf
+++ b/ansible/generated/rtr/icinga_host.conf
@@ -1,0 +1,23 @@
+// /etc/icinga2/conf.d/hosts/ansible/rtr.conf
+// Managed by ansible/roles/monitoring — do not edit by hand.
+// Source of truth: ansible/inventory/host_vars/rtr.yml
+
+object Host "rtr" {
+  address6 = "2a0c:b641:b50:2::1"
+  display_name = "rtr (OVH FR)"
+
+  check_command = "ping6"
+
+  vars.os = "Debian"
+  vars.role = "router"
+  vars.ssh_port = 22
+  vars.has_frr = true
+  vars.underlay_address6 = "2001:41d0:303:48a::2"
+  vars.prom_instance_frr = "[2a0c:b641:b50:2::1]:9342"
+  vars.site = "ovh1"
+
+  vars.prom_instance_node = "[2a0c:b641:b50:2::1]:9100"
+
+  vars.disks["disk /"] = { mountpoint = "/" }
+}
+

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -42,6 +42,18 @@ firewall_extra_raw_nft: |
   # iBGP also accepted on wg ifaces with no source restriction (already covered above
   # via loopback src match, but this is a defense-in-depth allow for the wg link).
 
+# --- Monitoring --- (issue #21: migrate from legacy configs/mon/icinga2/hosts/routers.conf
+# rtr.ovh1 entry to the standard monitoring_register flow. The Host object is now
+# named "rtr" — service files keying on host.name updated accordingly.)
+monitoring_register: true
+monitoring_role: router
+monitoring_display_name: "rtr (OVH FR)"
+monitoring_check_vars:
+  has_frr: true
+  underlay_address6: "{{ peers.rtr.underlay }}"
+  prom_instance_frr: "[{{ peers.rtr.ipv6 }}]:9342"
+  site: "ovh1"
+
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true
 logs_role: router

--- a/configs/mon/icinga2/hosts/routers.conf
+++ b/configs/mon/icinga2/hosts/routers.conf
@@ -1,20 +1,11 @@
 // /etc/icinga2/conf.d/hosts/routers.conf — AS215932 core routers
-
-object Host "rtr.ovh1" {
-  address6 = "2a0c:b641:b50::d"
-  display_name = "rtr (OVH FR)"
-
-  check_command = "ping6"
-
-  vars.os = "Debian"
-  vars.site = "ovh1"
-  vars.role = "router"
-  vars.has_frr = true
-  vars.ssh_port = 22
-  vars.underlay_address6 = "2001:41d0:303:48a::2"
-  vars.prom_instance_node = "[2a0c:b641:b50:2::1]:9100"
-  vars.prom_instance_frr = "[2a0c:b641:b50:2::1]:9342"
-}
+//
+// rtr is no longer registered here — see issue #21. It's now managed via
+// the standard monitoring_register: true path in
+// ansible/inventory/host_vars/rtr.yml and rendered into
+// /etc/icinga2/conf.d/hosts/ansible/rtr.conf by the monitoring role. The
+// Icinga Host name changed from "rtr.ovh1" to "rtr" — services keying on
+// host.name were updated in the same PR.
 
 object Host "cr1.nl1" {
   address6 = "2a0c:b641:b50::a"

--- a/configs/mon/icinga2/services/nat64.conf
+++ b/configs/mon/icinga2/services/nat64.conf
@@ -20,5 +20,5 @@ apply Service "nat64-ipv4-reachability" {
   // 64:ff9b::0101:0101 == embedded 1.1.1.1
   vars.ping_address = "64:ff9b::0101:0101"
 
-  assign where host.name == "rtr.ovh1"
+  assign where host.name == "rtr"
 }

--- a/configs/mon/icinga2/services/wireguard.conf
+++ b/configs/mon/icinga2/services/wireguard.conf
@@ -9,7 +9,7 @@ apply Service "wg-rtr-to-nl1" {
   // rtr wg0 (::ff02::1) -> cr1.nl1 wg3 (::ff02::)
   vars.ping_address = "2a0c:b641:b50:ff02::"
 
-  assign where host.name == "rtr.ovh1"
+  assign where host.name == "rtr"
 }
 
 apply Service "wg-rtr-to-de1" {
@@ -20,7 +20,7 @@ apply Service "wg-rtr-to-de1" {
   // rtr wg1 (::ff05::1) -> cr1.de1 wg1 (::ff05::)
   vars.ping_address = "2a0c:b641:b50:ff05::"
 
-  assign where host.name == "rtr.ovh1"
+  assign where host.name == "rtr"
 }
 
 apply Service "wg-nl1-to-de1" {


### PR DESCRIPTION
## Summary

rtr was registered as `Host "rtr.ovh1"` via the hand-curated `configs/mon/icinga2/hosts/routers.conf`. Per CLAUDE.md's "Monitoring" section, every host should go through `monitoring_register: true` in its host_vars so the monitoring role manages the Host object end-to-end.

The mismatch made it awkward to add new service checks for rtr — other hosts get auto-rendered into `hosts/ansible/<host>.conf` with their `monitoring_extra_services`; rtr did not. PR for issue #20 wants to add three new rtr-specific service checks; this migration unblocks that and is the prerequisite.

## Change

- `ansible/inventory/host_vars/rtr.yml`:
  - `monitoring_register: true`
  - `monitoring_role: router`
  - `monitoring_display_name: "rtr (OVH FR)"`
  - `monitoring_check_vars` carrying `has_frr`, `underlay_address6`, `prom_instance_frr`, `site` — all the assign-rule vars from the legacy block.
- `configs/mon/icinga2/hosts/routers.conf` — remove the `rtr.ovh1` block; cr1.* are left alone (separate migrations).
- `configs/mon/icinga2/services/nat64.conf` — `assign where host.name == "rtr"` (was `"rtr.ovh1"`).
- `configs/mon/icinga2/services/wireguard.conf` — same swap (2 occurrences).
- `ansible/generated/rtr/icinga_host.conf` — rendered artifact.

## Render diff (key fields preserved)

| Field | Legacy `rtr.ovh1` | New `rtr` |
|-------|-------------------|-----------|
| Host name | `rtr.ovh1` | `rtr` |
| `address6` | `2a0c:b641:b50::d` (loopback) | `2a0c:b641:b50:2::1` (infra) |
| `display_name` | `rtr (OVH FR)` | `rtr (OVH FR)` |
| `vars.os` | `Debian` | `Debian` |
| `vars.role` | `router` | `router` |
| `vars.has_frr` | `true` | `true` |
| `vars.ssh_port` | `22` | `22` |
| `vars.underlay_address6` | `2001:41d0:303:48a::2` | `2001:41d0:303:48a::2` |
| `vars.prom_instance_node` | `[2a0c:b641:b50:2::1]:9100` | `[2a0c:b641:b50:2::1]:9100` |
| `vars.prom_instance_frr` | `[2a0c:b641:b50:2::1]:9342` | `[2a0c:b641:b50:2::1]:9342` |
| `vars.site` | `ovh1` | `ovh1` |
| `vars.disks` | (not in legacy) | `{ "disk /" = { mountpoint = "/" } }` (default) |

## Caveats

- **Icinga retention loss**: history under `rtr.ovh1` does not merge into `rtr`. Schedule during a quiet ops window.
- **Prometheus**: scrape job names reference `rtr.as215932.net`, not the Icinga display name, so no Prometheus changes are needed.
- **address6 swap**: legacy used the loopback (`::d`); new uses the infra address (`:2::1`). Both reachable; the infra address is what `prom_instance_node` already uses.

## Test plan

- [ ] `set -a; source ../secrets.local.sh; set +a`
- [ ] `cd ansible && ansible-playbook playbooks/monitoring.yml --tags apply -e '{"monitoring_apply":true}' --limit rtr`
- [ ] `ansible-playbook playbooks/icinga2.yml --tags apply -e '{"icinga2_apply":true}' --limit mon` (re-deploys the updated routers.conf + service files)
- [ ] In Icinga Web 2: confirm `rtr` appears, `rtr.ovh1` is gone. Services `nat64-ipv4-reachability`, `wg-rtr-to-nl1`, `wg-rtr-to-de1` should all assign to the new `rtr` host.
- [ ] `mcp__hyrule__icinga_get_host_state host=rtr` returns UP.

## Rollback

`git revert`. Re-apply both monitoring.yml and icinga2.yml on mon to restore the legacy state. The host object will end up named `rtr.ovh1` again with the same service assignments.

Closes #21.

Unblocks: PR for #20 (rtr ARP/default-route/jool stats checks).

## Summary by Sourcery

Migrate the rtr host from a legacy hand-managed Icinga2 host definition to the standard monitoring_register flow, renaming the Icinga host from rtr.ovh1 to rtr and updating dependent services accordingly.

Enhancements:
- Register rtr in Ansible host_vars with monitoring metadata so the monitoring role fully manages its Icinga2 Host object.
- Update WireGuard and NAT64 service definitions to target the renamed rtr host instead of the legacy rtr.ovh1 entry.
- Document the deprecation of the legacy rtr.ovh1 host in routers.conf in favor of the generated rtr host configuration.