### PR TITLE
rtr Icinga checks: gateway ARP / default-route / jool success delta (#20)

### DIFF
--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -54,6 +54,18 @@ monitoring_check_vars:
   prom_instance_frr: "[{{ peers.rtr.ipv6 }}]:9342"
   site: "ovh1"
 
+# Per-host by_ssh check scripts (issue #20). Deployed to
+# /usr/local/lib/nagios/plugins/ — mon's icinga2 by_ssh services reference them
+# at that absolute path. See configs/mon/icinga2/services/rtr-checks.conf.
+monitoring_check_scripts:
+  - check_jool_success_delta.sh
+
+# mon's nagios user pubkey, added to rtr's root authorized_keys for the
+# by_ssh checks. Set MONITORING_BY_SSH_PUBKEY in secrets.local.sh until
+# the icinga2 role lands a Vault-rendered pubkey distribution path.
+monitoring_by_ssh_user: root
+monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
+
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true
 logs_role: router

--- a/ansible/roles/monitoring/tasks/check_scripts.yml
+++ b/ansible/roles/monitoring/tasks/check_scripts.yml
@@ -1,0 +1,25 @@
+---
+# Install per-host by_ssh check scripts under /usr/local/lib/nagios/plugins/.
+# Driven by `monitoring_check_scripts: ["foo.sh", "bar.sh", ...]` in
+# host_vars/<host>.yml. Each script is sourced from configs/mon/icinga2/scripts/
+# in the repo. The same path is also copied to mon as part of the icinga2 role,
+# so the script lives in one canonical location.
+
+- name: Ensure check plugin dir exists
+  file:
+    path: /usr/local/lib/nagios/plugins
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags: [apply]
+
+- name: Install monitoring check scripts
+  copy:
+    src: "{{ playbook_dir }}/../../configs/mon/icinga2/scripts/{{ item }}"
+    dest: "/usr/local/lib/nagios/plugins/{{ item }}"
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ monitoring_check_scripts }}"
+  tags: [apply]

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -14,3 +14,27 @@
   include_tasks: register.yml
   when: monitoring_register | bool
   tags: [validate, diff, apply]
+
+# Per-host by_ssh check scripts installed under /usr/local/lib/nagios/plugins/.
+# Only hosts that opt in via `monitoring_check_scripts` get them. The
+# CheckCommand on mon references the absolute path.
+- name: Install monitoring check scripts on host
+  include_tasks: check_scripts.yml
+  when:
+    - monitoring_apply | default(false) | bool
+    - monitoring_check_scripts | default([]) | length > 0
+  tags: [apply]
+
+# mon's nagios user needs a key in authorized_keys on hosts that get
+# by_ssh services. Gated to keep the trust surface narrow.
+- name: Authorize mon's nagios SSH key for by_ssh checks
+  authorized_key:
+    user: "{{ monitoring_by_ssh_user | default('root') }}"
+    key: "{{ monitoring_by_ssh_pubkey }}"
+    comment: "icinga2 by_ssh from mon"
+    state: present
+  when:
+    - monitoring_apply | default(false) | bool
+    - monitoring_by_ssh_pubkey is defined
+    - monitoring_by_ssh_pubkey | length > 0
+  tags: [apply]

--- a/configs/mon/icinga2/scripts/check_jool_success_delta.sh
+++ b/configs/mon/icinga2/scripts/check_jool_success_delta.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# check_jool_success_delta.sh — Icinga2 check executed via by_ssh on rtr.
+#
+# Tracks JSTAT_SUCCESS over time. If Jool is responding but no successful
+# translations have happened since the last invocation, alert WARNING.
+# A flat counter is the strongest signal that "NAT64 is plumbed but no
+# overlay traffic is reaching it" — that's how the cr1-de1 NDP outage
+# would have shown up if we'd had this check during it.
+#
+# State stored under /var/lib/icinga2/jool-success-prev. Owned by the
+# nagios user (the by_ssh login).
+#
+# Exit codes:
+#   0 OK
+#   1 WARNING — no SUCCESS deltas since previous run
+#   2 CRITICAL — jool not responsive (binary missing, instance not found)
+#   3 UNKNOWN — first run / state file just created
+
+set -eu
+
+INSTANCE="${JOOL_INSTANCE:-nat64}"
+STATE_DIR="${JOOL_STATE_DIR:-/var/lib/icinga2}"
+STATE_FILE="${STATE_DIR}/jool-${INSTANCE}-success-prev"
+
+if ! command -v jool >/dev/null 2>&1; then
+    echo "CRITICAL: jool binary not on PATH"
+    exit 2
+fi
+
+raw=$(jool -i "${INSTANCE}" stats display 2>&1) || {
+    echo "CRITICAL: jool stats failed: ${raw}"
+    exit 2
+}
+
+current=$(printf '%s\n' "${raw}" | awk -F': ' '$1 == "JSTAT_SUCCESS" { print $2 }')
+if [ -z "${current}" ]; then
+    echo "CRITICAL: JSTAT_SUCCESS missing from jool output"
+    exit 2
+fi
+
+if [ ! -f "${STATE_FILE}" ]; then
+    mkdir -p "${STATE_DIR}"
+    printf '%s\n' "${current}" > "${STATE_FILE}"
+    echo "UNKNOWN: first run, baseline JSTAT_SUCCESS=${current}"
+    exit 3
+fi
+
+prev=$(cat "${STATE_FILE}")
+delta=$((current - prev))
+printf '%s\n' "${current}" > "${STATE_FILE}"
+
+if [ "${delta}" -le 0 ]; then
+    pool6_mismatch=$(printf '%s\n' "${raw}" | awk -F': ' '$1 == "JSTAT_POOL6_MISMATCH" { print $2 }')
+    echo "WARNING: JSTAT_SUCCESS=${current} unchanged since previous run (delta=${delta}) — POOL6_MISMATCH=${pool6_mismatch:-?}"
+    exit 1
+fi
+
+echo "OK: JSTAT_SUCCESS=${current} (delta=+${delta} since last run)"
+exit 0

--- a/configs/mon/icinga2/services/rtr-checks.conf
+++ b/configs/mon/icinga2/services/rtr-checks.conf
@@ -1,0 +1,47 @@
+// /etc/icinga2/conf.d/services/rtr-checks.conf
+//
+// Defense-in-depth tripwires for rtr's local v4 plumbing and NAT64 health.
+// Catches the same failure class as #18 (NAT64 outage) earlier and from
+// a different angle than the dataplane probe (`nat64-ipv4-reachability`).
+//
+// All three use the by_ssh CheckCommand from mon → rtr; mon's nagios user
+// must have an authorized_keys entry on rtr. The connection details are
+// inherited from rtr's host vars (vars.ssh_port etc.).
+//
+// Filed by issue #20. The host.name match changed from "rtr.ovh1" to "rtr"
+// in PR for issue #21 (monitoring_register migration).
+
+apply Service "rtr-ipv4-gateway-arp" {
+  check_command = "by_ssh"
+  check_interval = 1m
+  retry_interval = 30s
+
+  vars.by_ssh_command = "ping -c2 -W2 -I enX4 193.70.32.254 >/dev/null"
+  notes = "rtr's WAN default gateway is reachable on the underlay interface (catches enX4 down, ARP failure)."
+
+  assign where host.name == "rtr"
+}
+
+apply Service "rtr-ipv4-default-route" {
+  check_command = "by_ssh"
+  check_interval = 1m
+  retry_interval = 30s
+
+  vars.by_ssh_command = "ip -4 route show default | grep -q '193.70.32.254'"
+  notes = "rtr has the expected v4 default route via OVH gateway 193.70.32.254 (catches FRR or systemd-networkd misconfig)."
+
+  assign where host.name == "rtr"
+}
+
+apply Service "rtr-jool-success-delta" {
+  check_command = "by_ssh"
+  check_interval = 5m
+  retry_interval = 1m
+
+  // Wrapper script tracks the JSTAT_SUCCESS counter over time. Deployed
+  // via the monitoring role at /usr/local/lib/nagios/plugins/.
+  vars.by_ssh_command = "/usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
+  notes = "JSTAT_SUCCESS counter should advance between checks — flat counter signals NAT64 pipeline broken (jool down, pool4/pool6 mismatch, VRF leak missing)."
+
+  assign where host.name == "rtr"
+}


### PR DESCRIPTION
## Summary

Defense-in-depth tripwires for rtr's local v4 plumbing and NAT64 health, all running by_ssh from mon. Catches the same failure class as the post-#18 NAT64 outage from a different angle than the dataplane probe (`nat64-ipv4-reachability`).

Three checks, all keyed on `host.name == "rtr"` (depends on PR #50 / issue #21 for the rename).

| Service | Interval | Command | What it catches |
|---------|----------|---------|-----------------|
| `rtr-ipv4-gateway-arp` | 1m | `ping -c2 -W2 -I enX4 193.70.32.254` | enX4 down, ARP cache failure for the WAN gateway |
| `rtr-ipv4-default-route` | 1m | `ip -4 route show default \| grep -q '193.70.32.254'` | FRR or systemd-networkd dropping the v4 default |
| `rtr-jool-success-delta` | 5m | `/usr/local/lib/nagios/plugins/check_jool_success_delta.sh` | jool plumbed but no successful translations happening (process up, but pool/VRF broken) |

## jool schema recon

The issue body referenced `JSTAT_64_DROP*` / `JSTAT_FAILED*` counters, but live jool 4.x on rtr doesn't emit those keys. Verified via MCP:

```
$ mcp__hyrule__ssh_run_command host=rtr cmd='jool -i nat64 stats display'
JSTAT_RECEIVED6: 30761823
JSTAT_RECEIVED4: 1621329
JSTAT_SUCCESS: 34274
JSTAT_POOL6_MISMATCH: 30140631
JSTAT_BIB4_NOT_FOUND: 342101
... (no JSTAT_64_DROP* or JSTAT_FAILED* keys)
```

The wrapper script tracks the simpler "is jool doing translation work" signal via `JSTAT_SUCCESS` delta. Catches the major failure modes (jool dead, pool exhaustion, VRF leak missing) without false positives on benign drop-counter noise like POOL6_MISMATCH (which counts every legitimate non-NAT64-prefix v6 packet).

## Wiring

- `ansible/roles/monitoring/tasks/main.yml` — two new conditional blocks:
  - `monitoring_check_scripts: [..]` → installs scripts to `/usr/local/lib/nagios/plugins/` on the host.
  - `monitoring_by_ssh_pubkey` → adds an `authorized_keys` entry for `monitoring_by_ssh_user` (default root). Both gated so other hosts don't accidentally get the trust.
- `ansible/roles/monitoring/tasks/check_scripts.yml` — new tasks file (copy loop).
- `ansible/inventory/host_vars/rtr.yml` — opt-in.
- `configs/mon/icinga2/scripts/check_jool_success_delta.sh` — wrapper.
- `configs/mon/icinga2/services/rtr-checks.conf` — Service definitions.

## Required env var (until Vault rendering lands)

`MONITORING_BY_SSH_PUBKEY` — the pubkey from mon's `nagios` user. Generate once on mon:

```bash
ssh mon 'sudo -u nagios ssh-keygen -t ed25519 -N "" -f /var/spool/icinga2/.ssh/id_ed25519 -C nagios@mon-icinga2-by_ssh'
ssh mon 'sudo -u nagios cat /var/spool/icinga2/.ssh/id_ed25519.pub'
# Add to secrets.local.sh:
export MONITORING_BY_SSH_PUBKEY='ssh-ed25519 AAAA... nagios@mon-icinga2-by_ssh'
```

Filing as a follow-up to render via Vault once the icinga2 role lands `kv/icinga2-by-ssh`.

## Test plan

- [ ] Merge PR #50 first.
- [ ] Generate and export `MONITORING_BY_SSH_PUBKEY` on the ops workstation.
- [ ] `ansible-playbook playbooks/monitoring.yml --tags apply -e '{"monitoring_apply":true}' --limit rtr` — installs script + pubkey.
- [ ] `ansible-playbook playbooks/icinga2.yml --tags apply -e '{"icinga2_apply":true}' --limit mon` — pushes the new service files.
- [ ] In Icinga Web 2: all three new services appear under `rtr` as OK within ~2 intervals.
- [ ] Manual smoke (from any host): `ssh nagios@rtr /usr/local/lib/nagios/plugins/check_jool_success_delta.sh` → first run UNKNOWN, second OK with delta>0.

## Rollback

`git revert`. Removes the services + the by_ssh trust. The jool stats script can stay on rtr (no harm); ship a follow-up if cleanup wanted.

Closes #20. Depends on #50 (issue #21).

## Summary by Sourcery

Add new Icinga by_ssh monitoring checks for rtr’s IPv4 gateway and NAT64 health and migrate rtr to the standard Ansible-driven monitoring host definition.

New Features:
- Introduce three rtr-specific Icinga services to monitor IPv4 gateway ARP, default route presence, and Jool NAT64 translation activity via by_ssh.
- Add a Jool JSTAT_SUCCESS delta check script to detect stalled NAT64 translation despite the service being up.

Enhancements:
- Migrate rtr from a hand-written Icinga host definition to the generic monitoring_register flow with structured host vars and updated host.name bindings.
- Extend the monitoring Ansible role to distribute per-host check scripts and configure SSH key-based access for by_ssh checks from mon.

Documentation:
- Document rtr’s host migration away from routers.conf and explain the new by_ssh-based monitoring setup in inline comments.