### PR TITLE
Add fleet-wide ICMPv6 reachability service (#12)

### DIFF
--- a/configs/mon/icinga2/services/host-ping6.conf
+++ b/configs/mon/icinga2/services/host-ping6.conf
@@ -1,0 +1,22 @@
+// /etc/icinga2/conf.d/services/host-ping6.conf — fleet-wide ICMPv6 reachability.
+//
+// Today reachability is approximated by `node-up` (Prometheus scrape state)
+// and the host-default check_command (also ping6). When the scrape itself is
+// reachable but the host's overlay v6 path is degraded, node-up alone can
+// miss the failure. This service explicitly probes ICMPv6 from mon and
+// alerts independently — splits "host process down" from "host unreachable".
+//
+// Runs on every host with an `address6` attribute that has not opted out
+// via `vars.skip_ping6 = true` (e.g. mon itself, off-overlay probes).
+
+apply Service "ping6" {
+  import "generic-service"
+
+  check_command = "ping6"
+  check_interval = 1m
+  retry_interval = 30s
+
+  // Address comes from the Host object's `address6` attribute by default.
+
+  assign where host.address6 && !host.vars.skip_ping6
+}


### PR DESCRIPTION
## Summary

Adds an `apply Service "ping6"` to every host with `address6` set. Today the host-level `check_command = "ping6"` is bundled into the host state; this surfaces the ICMPv6 reachability as its own service line in Icinga Web 2 — separates "host process down" (node_up) from "host unreachable" (ping6).

`assign where host.address6 && !host.vars.skip_ping6` — opt-out via the host's vars block if needed (no current opt-outs). dom0 is unaffected (v4-only via `address`).

## Test plan

- [ ] `ansible-playbook playbooks/icinga2.yml --tags apply -e '{"icinga2_apply":true}' --limit mon`
- [ ] In Icinga Web 2: every host (excl. dom0) gains a `ping6` service row, all OK.
- [ ] Smoke negative: temporarily set `vars.skip_ping6 = true` on one host, re-apply, confirm the service vanishes.

## Rollback

`git revert`. Service definitions disappear; host check_command continues to do binary reachability.

Closes #12.

## Summary by Sourcery

New Features:
- Add a ping6 service check applied to all hosts with address6 set, exposing ICMPv6 reachability as a dedicated service in Icinga2 with a host-level opt-out flag.