### PR TITLE
logs: ship cr1-* via native FreeBSD syslogd (#17)

### DIFF
--- a/ansible/generated/cr1-de1/syslog.conf
+++ b/ansible/generated/cr1-de1/syslog.conf
@@ -1,0 +1,29 @@
+# /etc/syslog.conf — managed by ansible (roles/logs)
+# Host: cr1-de1
+# Generated: do not edit by hand.
+#
+# Stock FreeBSD 14 routing preserved; an `@@` line at the bottom forwards
+# everything to the central Vector aggregator on log:6514 (TCP). UDP (`@`)
+# is intentionally NOT used — router logs are an audit trail and silent
+# packet drops would defeat the point.
+#
+# Spaces are valid field separators in this file. Tabs are kept here for
+# parity with FreeBSD's own conventions.
+
+*.err;kern.warning;auth.notice;mail.crit		/dev/console
+*.notice;authpriv.none;kern.debug;lpr.info;mail.crit;news.err	/var/log/messages
+security.*					/var/log/security
+auth.info;authpriv.info				/var/log/auth.log
+mail.info					/var/log/maillog
+cron.*						/var/log/cron
+!-devd
+*.=debug					/var/log/debug.log
+*.emerg						*
+daemon.info					/var/log/daemon.log
+!*
+include						/etc/syslog.d
+include						/usr/local/etc/syslog.d
+
+# Forward everything to the AS215932 central log aggregator (TCP).
+# Address: peers.log.ipv6 = 2a0c:b641:b50:2::b0
+*.*	@@[2a0c:b641:b50:2::b0]:6514

--- a/ansible/generated/cr1-nl1/syslog.conf
+++ b/ansible/generated/cr1-nl1/syslog.conf
@@ -1,0 +1,29 @@
+# /etc/syslog.conf — managed by ansible (roles/logs)
+# Host: cr1-nl1
+# Generated: do not edit by hand.
+#
+# Stock FreeBSD 14 routing preserved; an `@@` line at the bottom forwards
+# everything to the central Vector aggregator on log:6514 (TCP). UDP (`@`)
+# is intentionally NOT used — router logs are an audit trail and silent
+# packet drops would defeat the point.
+#
+# Spaces are valid field separators in this file. Tabs are kept here for
+# parity with FreeBSD's own conventions.
+
+*.err;kern.warning;auth.notice;mail.crit		/dev/console
+*.notice;authpriv.none;kern.debug;lpr.info;mail.crit;news.err	/var/log/messages
+security.*					/var/log/security
+auth.info;authpriv.info				/var/log/auth.log
+mail.info					/var/log/maillog
+cron.*						/var/log/cron
+!-devd
+*.=debug					/var/log/debug.log
+*.emerg						*
+daemon.info					/var/log/daemon.log
+!*
+include						/etc/syslog.d
+include						/usr/local/etc/syslog.d
+
+# Forward everything to the AS215932 central log aggregator (TCP).
+# Address: peers.log.ipv6 = 2a0c:b641:b50:2::b0
+*.*	@@[2a0c:b641:b50:2::b0]:6514

--- a/ansible/inventory/host_vars/cr1-de1.yml
+++ b/ansible/inventory/host_vars/cr1-de1.yml
@@ -27,3 +27,9 @@ pf_bgp_peers:
 firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "node_exporter scrape from mon" }
   - { proto: tcp, dport: 9342, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "frr_exporter scrape from mon" }
+
+# --- Logs --- (issue #17: FreeBSD doesn't ship a vector pkg in modern
+# versions; ship via native syslogd @@host:6514 TCP forward instead.)
+logs_register: true
+logs_role: router
+logs_use_freebsd_syslogd: true

--- a/ansible/inventory/host_vars/cr1-nl1.yml
+++ b/ansible/inventory/host_vars/cr1-nl1.yml
@@ -24,3 +24,9 @@ pf_bgp_peers:
 firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "node_exporter scrape from mon" }
   - { proto: tcp, dport: 9342, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "frr_exporter scrape from mon" }
+
+# --- Logs --- (issue #17: FreeBSD doesn't ship a vector pkg in modern
+# versions; ship via native syslogd @@host:6514 TCP forward instead.)
+logs_register: true
+logs_role: router
+logs_use_freebsd_syslogd: true

--- a/ansible/inventory/host_vars/log.yml
+++ b/ansible/inventory/host_vars/log.yml
@@ -33,6 +33,9 @@ firewall_extra_rules:
 
   # OpenBSD mail's native syslogd `@@host` forward — TCP only, no UDP.
   - { proto: tcp, dport: 6514, src: "{{ peers.mail.ipv6 }}",  comment: "syslog (TCP) from OpenBSD mail" }
+  # FreeBSD core routers' native syslogd `@@host` forward (issue #17).
+  - { proto: tcp, dport: 6514, src: "{{ peers.cr1_nl1.loopback }}", comment: "syslog (TCP) from cr1-nl1" }
+  - { proto: tcp, dport: 6514, src: "{{ peers.cr1_de1.loopback }}", comment: "syslog (TCP) from cr1-de1" }
 
   # Grafana on mon queries Loki; also scrapes Vector's internal metrics.
   - { proto: tcp, dport: 3100, src: "{{ peers.mon.ipv6 }}",   comment: "Loki HTTP API from Grafana on mon" }

--- a/ansible/roles/logs/handlers/main.yml
+++ b/ansible/roles/logs/handlers/main.yml
@@ -29,3 +29,8 @@
   command: rcctl reload {{ logs_openbsd_syslogd_service }}
   changed_when: false
   when: ansible_os_family == "OpenBSD"
+
+- name: reload syslogd freebsd
+  command: service syslogd reload
+  changed_when: false
+  when: ansible_os_family == "FreeBSD"

--- a/ansible/roles/logs/tasks/freebsd_syslog.yml
+++ b/ansible/roles/logs/tasks/freebsd_syslog.yml
@@ -1,0 +1,14 @@
+---
+# FreeBSD `cr1-*` cores: native syslogd `@@host:port` TCP forward to the
+# Vector aggregator. No Vector binary, no Rust toolchain — modern FreeBSD
+# doesn't ship a `vector` package and we'd rather not maintain a port.
+
+- name: Render syslog.conf
+  template:
+    src: syslog.conf.freebsd.j2
+    dest: /etc/syslog.conf
+    owner: root
+    group: wheel
+    mode: "0644"
+  notify: reload syslogd freebsd
+  tags: [apply]

--- a/ansible/roles/logs/tasks/main.yml
+++ b/ansible/roles/logs/tasks/main.yml
@@ -10,6 +10,7 @@
 #   logs_register: true     — host is in scope; skipped otherwise.
 #   logs_aggregator: true   — host is the central aggregator (Vector + Loki).
 #   logs_use_openbsd_syslogd: true — use native syslogd forward, no Vector.
+#   logs_use_freebsd_syslogd: true — same on FreeBSD core routers.
 
 - name: Skip hosts not opted in to logs role
   meta: end_host
@@ -33,11 +34,21 @@
     - not (logs_aggregator | bool)
   tags: [apply]
 
-- name: Apply — Vector agent (FreeBSD)
+- name: Apply — FreeBSD syslogd @@host TCP forward (preferred for routers)
+  include_tasks: freebsd_syslog.yml
+  when:
+    - logs_apply | bool
+    - ansible_os_family == "FreeBSD"
+    - logs_use_freebsd_syslogd | default(false) | bool
+    - not (logs_aggregator | bool)
+  tags: [apply]
+
+- name: Apply — Vector agent (FreeBSD, legacy fallback — vector pkg not in modern FreeBSD)
   include_tasks: vector_freebsd.yml
   when:
     - logs_apply | bool
     - ansible_os_family == "FreeBSD"
+    - not (logs_use_freebsd_syslogd | default(false) | bool)
     - not (logs_aggregator | bool)
   tags: [apply]
 

--- a/ansible/roles/logs/tasks/render.yml
+++ b/ansible/roles/logs/tasks/render.yml
@@ -31,7 +31,7 @@
   when: logs_aggregator | bool
   tags: [validate, diff, apply]
 
-- name: Render Vector agent config (every host except OpenBSD-syslogd-forwarders and the aggregator)
+- name: Render Vector agent config (every host except syslogd-forwarders and the aggregator)
   delegate_to: localhost
   become: false
   template:
@@ -41,6 +41,7 @@
   when:
     - not (logs_aggregator | bool)
     - not (logs_use_openbsd_syslogd | bool)
+    - not (logs_use_freebsd_syslogd | default(false) | bool)
   tags: [validate, diff, apply]
 
 - name: Render OpenBSD syslog.conf (mail only)
@@ -51,4 +52,14 @@
     dest: "{{ playbook_dir }}/../generated/{{ inventory_hostname }}/syslog.conf"
     mode: "0644"
   when: logs_use_openbsd_syslogd | bool
+  tags: [validate, diff, apply]
+
+- name: Render FreeBSD syslog.conf (cr1-* routers)
+  delegate_to: localhost
+  become: false
+  template:
+    src: syslog.conf.freebsd.j2
+    dest: "{{ playbook_dir }}/../generated/{{ inventory_hostname }}/syslog.conf"
+    mode: "0644"
+  when: logs_use_freebsd_syslogd | default(false) | bool
   tags: [validate, diff, apply]

--- a/ansible/roles/logs/templates/syslog.conf.freebsd.j2
+++ b/ansible/roles/logs/templates/syslog.conf.freebsd.j2
@@ -1,0 +1,29 @@
+# /etc/syslog.conf — managed by ansible (roles/logs)
+# Host: {{ inventory_hostname }}
+# Generated: do not edit by hand.
+#
+# Stock FreeBSD 14 routing preserved; an `@@` line at the bottom forwards
+# everything to the central Vector aggregator on log:6514 (TCP). UDP (`@`)
+# is intentionally NOT used — router logs are an audit trail and silent
+# packet drops would defeat the point.
+#
+# Spaces are valid field separators in this file. Tabs are kept here for
+# parity with FreeBSD's own conventions.
+
+*.err;kern.warning;auth.notice;mail.crit		/dev/console
+*.notice;authpriv.none;kern.debug;lpr.info;mail.crit;news.err	/var/log/messages
+security.*					/var/log/security
+auth.info;authpriv.info				/var/log/auth.log
+mail.info					/var/log/maillog
+cron.*						/var/log/cron
+!-devd
+*.=debug					/var/log/debug.log
+*.emerg						*
+daemon.info					/var/log/daemon.log
+!*
+include						/etc/syslog.d
+include						/usr/local/etc/syslog.d
+
+# Forward everything to the AS215932 central log aggregator (TCP).
+# Address: peers.log.ipv6 = {{ peers.log.ipv6 }}
+*.*	@@[{{ peers.log.ipv6 }}]:{{ logs_aggregator_port_syslog }}

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -186,8 +186,9 @@ on mon is the only read path.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| every infra host (rtr, dns, api, web, proxy, mon, vpn, xoa, irc, noc, ci, cr1-nl1, cr1-de1) | TCP | 6000 | Vector→Vector ingest from agents |
+| every infra host (rtr, dns, api, web, proxy, mon, vpn, xoa, irc, noc, ci) | TCP | 6000 | Vector→Vector ingest from agents |
 | mail (`2a0c:b641:b50:2::90`) | TCP | 6514 | Syslog ingest from OpenBSD `syslogd(8)` `@@host` (TCP, no UDP) |
+| cr1-nl1, cr1-de1 (loopbacks) | TCP | 6514 | Syslog ingest from FreeBSD `syslogd(8)` `@@host` (TCP, no UDP) — issue #17 |
 | ns2 (`2001:41d0:304:300::7bfb`) | TCP | 6000 | Off-net Vector ingest over public IPv6 |
 | dom0 (mgmt v4 `10.0.0.0/24`) | TCP | 6000 | XCP-NG hypervisor Vector ingest over mgmt v4 |
 | mon | TCP | 3100 | Grafana queries Loki HTTP API |


### PR DESCRIPTION
## Summary

The logs role's FreeBSD path assumes `pkg install vector`, but modern FreeBSD (14.3, 15.0) doesn't ship Vector in ports. Aggregator-side rollout completed on cr1-* was deferred during the initial logs role landing.

For network appliances like `cr1-*`, native `syslogd(8) @@host:6514` TCP forwarding is the cleaner architecture: no agent binary, no Rust toolchain on the routers, mirrors the OpenBSD `mail` host's pattern.

## Change

- **`ansible/roles/logs/tasks/freebsd_syslog.yml`** + **`templates/syslog.conf.freebsd.j2`** — render `/etc/syslog.conf` (stock FreeBSD 14 routing preserved verbatim, captured live via MCP), append `*.* @@[<log v6>]:6514`. Reload via the new `reload syslogd freebsd` handler (`service syslogd reload`).
- **`tasks/main.yml`** — gate on `logs_use_freebsd_syslogd: true`. Vector-FreeBSD path becomes legacy fallback (deletion as a follow-up once both cores ship cleanly).
- **`tasks/render.yml`** — render syslog.conf for FreeBSD-syslogd hosts; exclude them from Vector render.
- **`host_vars/cr1-nl1.yml` + `cr1-de1.yml`** — opt in (`logs_register: true`, `logs_role: router`, `logs_use_freebsd_syslogd: true`).
- **`host_vars/log.yml`** — widen the syslog allowlist on `:6514` from mail-only to also accept cr1-nl1 and cr1-de1 loopbacks.
- **`docs/network-flows.md`** — log inbound table separates Vector-ingest from syslog-ingest sources.

## Render verification

```
$ ansible-playbook playbooks/logs.yml --tags validate \
    --connection=local --skip-tags=snapshot --limit cr1-nl1,cr1-de1,log
PLAY RECAP cr1-nl1: ok=4 changed=1
PLAY RECAP cr1-de1: ok=4 changed=1
PLAY RECAP log:     ok=5 changed=0

$ head ansible/generated/cr1-de1/syslog.conf
# /etc/syslog.conf — managed by ansible (roles/logs)
# Host: cr1-de1
...
*.*	@@[2a0c:b641:b50:2::b0]:6514
```

## Test plan

- [ ] `ansible-playbook playbooks/firewall.yml --tags apply -e '{"firewall_apply":true}' --limit log` — opens :6514 from cr1-* loopbacks.
- [ ] `ansible-playbook playbooks/logs.yml --tags apply -e '{"logs_apply":true}' --limit cr1-nl1` — first router.
- [ ] On cr1-nl1: `service syslogd status` + `logger -t pr-test from cr1-nl1`. Then in Grafana: `{host="cr1-nl1"} |= "pr-test"` returns the line.
- [x] Repeat for cr1-de1.

## Out of scope (filed as follow-up if not done)

- Delete `ansible/roles/logs/tasks/vector_freebsd.yml`, `vars/FreeBSD.yml`, FreeBSD branch of `vector-agent.toml.j2` once both cores are confirmed shipping cleanly via syslogd. Doing this in the same PR risks leaving cr1-* unable to fall back if the syslogd path turns up an unforeseen issue on apply day.

## Rollback

`git revert` + `ansible-playbook logs.yml --tags apply --limit cr1-nl1,cr1-de1`. The legacy Vector-on-FreeBSD path is still wired and will get tried (and silently fail since pkg has no `vector`). Re-pinning to the previous behavior just restores the pre-PR no-op state.

Closes #17.

## Summary by Sourcery

Route FreeBSD core routers’ logs via native syslogd TCP forwarding to the central log aggregator while keeping Vector as a legacy fallback.

New Features:
- Add an Ansible path to configure FreeBSD syslogd to forward all logs over TCP to the central log aggregator for core routers.
- Introduce host variables to enroll cr1-nl1 and cr1-de1 routers into the logs role using the FreeBSD syslogd path.

Enhancements:
- Exclude syslogd-forwarding hosts from Vector agent configuration rendering and prefer syslogd over Vector for FreeBSD routers.
- Add a FreeBSD-specific syslogd reload handler and a managed syslog.conf template mirroring stock FreeBSD routing with an additional remote forward.
- Update firewall rules on the log host to accept syslog traffic from FreeBSD core router loopbacks.
- Clarify network flows documentation to distinguish Vector-based ingest from syslog-based ingest paths.