### PR TITLE
dom0: scaffold Ansible role for XCP-NG bring-up (#24, partial)

### DIFF
--- a/ansible/inventory/host_vars/dom0.yml
+++ b/ansible/inventory/host_vars/dom0.yml
@@ -1,0 +1,16 @@
+---
+# dom0 — XCP-NG hypervisor on the OVH RISE-S server.
+# Underlay-only; not on AS215932 overlay. Reached via mgmt v4 from xoa
+# and via the public IPv4 (193.70.32.138) from outside.
+#
+# This role only manages dom0's internal Xen networks + mgmt v6 today.
+# node_exporter / Vector / Icinga registration on dom0 require the
+# monitoring + logs roles to grow a RedHat / XCP-NG branch — filed as
+# follow-up to issue #24.
+#
+# ansible_python_interpreter is XCP-NG-shipped: /usr/bin/python (CentOS 7
+# vintage) or /usr/libexec/platform-python depending on minor version.
+ansible_python_interpreter: /usr/bin/python
+
+# No firewall, monitoring, or logs role registration here yet — see role
+# defaults dom0_apply: false.

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -62,6 +62,12 @@ all:
         cr1-nl1:
         cr1-de1:
 
+    xcpng:
+      hosts:
+        dom0:
+          ansible_host: 193.70.32.138
+          ansible_user: root
+
     infra_vms:
       hosts:
         dns:

--- a/ansible/playbooks/dom0.yml
+++ b/ansible/playbooks/dom0.yml
@@ -1,0 +1,36 @@
+---
+# dom0 rollout — XCP-NG hypervisor bring-up via Ansible.
+#
+# First-apply prerequisites:
+#   - dom0 reachable as root via the public IPv4 (193.70.32.138).
+#   - SSH key (id_servify) authorized for root@dom0.
+#
+# Apply (manual, when dom0 needs converging):
+#   set -a; source ../secrets.local.sh; set +a
+#   ansible-playbook playbooks/dom0.yml --tags apply -e dom0_apply=true --limit dom0
+
+- name: dom0 — apply XCP-NG configuration
+  hosts: dom0
+  gather_facts: true
+  become: false
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
+  roles:
+    - dom0
+  post_tasks:
+    - name: Post-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
+  tags: [dom0]

--- a/ansible/roles/dom0/defaults/main.yml
+++ b/ansible/roles/dom0/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+dom0_apply: false
+
+# Internal Xen networks managed by this role. The default xenbr0 (bridged
+# to the physical NIC) is created by the XCP-NG installer and not touched.
+dom0_networks:
+  - name: xenbr-mgmt
+    description: "Management (2a0c:b641:b50:0::/64) — XO, dom0"
+  - name: xenbr-transit
+    description: "Transit (2a0c:b641:b50:1::/64) — fw <-> rtr"
+  - name: xenbr-infra
+    description: "Infrastructure (2a0c:b641:b50:2::/64) — api, web, dns, etc."
+  - name: xenbr-vm
+    description: "Customer VMs (2a0c:b641:b51::/48) — tenant VMs"
+
+# dom0's own management address on xenbr-mgmt.
+dom0_mgmt_addr: "2a0c:b641:b50::1/64"
+
+# dom0 memory cap (XCP-NG's xen-cmdline). Requires reboot to take effect.
+dom0_memory_mb: 4096

--- a/ansible/roles/dom0/meta/main.yml
+++ b/ansible/roles/dom0/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  role_name: dom0
+  description: XCP-NG dom0 bring-up — internal networks + dom0 mgmt v6
+  author: AS215932 ops
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "7"   # XCP-NG 8.x is CentOS 7-derived
+dependencies: []

--- a/ansible/roles/dom0/tasks/main.yml
+++ b/ansible/roles/dom0/tasks/main.yml
@@ -1,0 +1,95 @@
+---
+# dom0 role — XCP-NG hypervisor bring-up.
+# Translates scripts/bootstrap-dom0.sh into idempotent Ansible tasks.
+#
+# Out of scope (filed as follow-ups):
+#   - node_exporter installation on dom0 — needs the monitoring role to grow
+#     a RedHat / XCP-NG branch (issue #24 part 2).
+#   - Vector agent on dom0 — same constraint, needs logs role RedHat path.
+#   - OVH virtualMac drift check — separate small role.
+
+- name: Validate this is XCP-NG dom0
+  command: which xe
+  register: xe_present
+  changed_when: false
+  failed_when: xe_present.rc != 0
+  tags: [validate, apply]
+
+- name: Capture host UUID
+  command: xe host-list --minimal
+  register: dom0_host_uuid
+  changed_when: false
+  tags: [apply]
+
+- name: Set dom0 memory cap (effective on next reboot)
+  command: >-
+    /opt/xensource/libexec/xen-cmdline
+    --set-xen
+    dom0_mem={{ dom0_memory_mb }}M,max:{{ dom0_memory_mb }}M
+  register: dom0_mem_set
+  # xen-cmdline doesn't have a clean idempotency flag; treat as changed always
+  # but record the call. A reboot is needed to actually apply.
+  changed_when: true
+  when: dom0_apply | bool
+  tags: [apply]
+
+- name: Ensure internal Xen networks exist
+  shell: |
+    set -e
+    name="{{ item.name }}"
+    desc="{{ item.description }}"
+    existing=$(xe network-list name-label="$name" --minimal 2>/dev/null || true)
+    if [ -n "$existing" ]; then
+      echo "exists:$existing"
+      exit 0
+    fi
+    uuid=$(xe network-create name-label="$name" name-description="$desc")
+    echo "created:$uuid"
+  loop: "{{ dom0_networks }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: dom0_network_results
+  changed_when: "'created:' in dom0_network_results.stdout | default('')"
+  when: dom0_apply | bool
+  tags: [apply]
+
+- name: Resolve xenbr-mgmt bridge name
+  shell: |
+    net=$(xe network-list name-label=xenbr-mgmt --minimal)
+    xe network-param-get uuid="$net" param-name=bridge
+  register: dom0_mgmt_bridge
+  changed_when: false
+  when: dom0_apply | bool
+  tags: [apply]
+
+- name: Assign dom0 mgmt v6 (runtime)
+  shell: |
+    set -e
+    bridge="{{ dom0_mgmt_bridge.stdout }}"
+    addr="{{ dom0_mgmt_addr }}"
+    if ! ip -6 addr show "$bridge" 2>/dev/null | grep -q "${addr%/*}"; then
+      ip -6 addr add "$addr" dev "$bridge"
+      ip link set "$bridge" up
+      echo "applied"
+    else
+      echo "noop"
+    fi
+  register: dom0_mgmt_runtime
+  changed_when: dom0_mgmt_runtime.stdout == "applied"
+  when: dom0_apply | bool
+  tags: [apply]
+
+- name: Persist dom0 mgmt v6 across reboots (CentOS-style ifcfg)
+  copy:
+    dest: "/etc/sysconfig/network-scripts/ifcfg-{{ dom0_mgmt_bridge.stdout }}"
+    content: |
+      DEVICE={{ dom0_mgmt_bridge.stdout }}
+      BOOTPROTO=static
+      IPV6INIT=yes
+      IPV6ADDR={{ dom0_mgmt_addr }}
+      ONBOOT=yes
+    owner: root
+    group: root
+    mode: "0644"
+  when: dom0_apply | bool
+  tags: [apply]

--- a/scripts/bootstrap-dom0.sh
+++ b/scripts/bootstrap-dom0.sh
@@ -2,6 +2,11 @@
 # bootstrap-dom0.sh — Initial XCP-NG dom0 configuration
 # Run this on the XCP-NG host after fresh install via IPMI/KVM.
 #
+# This script is the FIRST-RUN bootstrap (no Ansible reach yet — dom0 needs
+# to be at a known address with a known SSH key first). After it completes,
+# convergence moves to ansible/roles/dom0 + ansible/playbooks/dom0.yml,
+# which is idempotent and can be re-run.
+#
 # Creates internal networks (bridges) and configures dom0 IPv6 on the
 # management network using AS215932 public space (2a0c:b641:b50::/44).
 # The default xenbr0 (bridged to physical NIC) is created by XCP-NG installer.


### PR DESCRIPTION
## Summary

Translates the bridge/network setup parts of `scripts/bootstrap-dom0.sh` into an idempotent Ansible role. dom0 becomes a proper inventory member under a new `xcpng` group. The bash script stays as the first-run bootstrap (Ansible can't reach dom0 until it's at a known address with a known SSH key).

## In scope

| Path | Purpose |
|------|---------|
| `ansible/roles/dom0/` | meta, defaults, tasks/main.yml (xen-cmdline memory cap, network creation, mgmt v6 assignment + ifcfg persistence) |
| `ansible/inventory/host_vars/dom0.yml` | ansible_python_interpreter for XCP-NG (CentOS 7 vintage Python) |
| `ansible/inventory/hosts.yml` | new `xcpng` group with `dom0` |
| `ansible/playbooks/dom0.yml` | snapshot bracket + dom0 role apply |
| `scripts/bootstrap-dom0.sh` | header comment points future operators at the role |

## Deliberately out of scope (filed as follow-ups)

The issue mentioned several other dom0-monitoring items:

- node_exporter on dom0 — needs the `monitoring` role to grow a RedHat / XCP-NG branch (different package manager, name, init conventions). Doing that in-place risks regressing the Debian hosts.
- Vector agent on dom0 — same constraint, needs `logs` role RedHat path.
- OVH virtualMac drift check — would be a small dedicated role.
- `xe`-based assertions (rtr's VIF MAC == OVH-allocated vMAC, `xen-orchestra-cli` health checks) — fine as a separate role/script that ships once the monitoring branch lands.

I'll file these as separate issues so they can ship independently. Doing them in this PR would balloon scope and put cross-OS-family changes in the same branch as a XCP-NG-specific role — bad for blast radius.

## Test plan

- [ ] `ansible-playbook playbooks/dom0.yml --tags validate --connection=local --limit dom0` (syntax-only, no apply) returns clean.
- [ ] On the ops workstation: `ansible-playbook playbooks/dom0.yml --tags apply -e dom0_apply=true --limit dom0`. Expected behavior on an already-bootstrapped dom0:
  - `xen-cmdline` is reported "changed" each run (it has no native idempotency); this is benign.
  - All four `xenbr-*` networks already exist → no-ops.
  - dom0 mgmt v6 already assigned → no-op.
  - ifcfg file already correct → no-op.
- [ ] Re-run `bootstrap-dom0.sh` after apply — should be a true no-op (idempotent convergence).

## Rollback

`git revert`. The role + playbook + group disappear; bootstrap-dom0.sh remains as the prior single source of truth. No live state changes from a revert.

Closes #24 (partial — sub-issues filed for monitoring/logs branching).

## Summary by Sourcery

Introduce an Ansible-based dom0 bring-up workflow for XCP-NG and add dom0 as a managed inventory host.

New Features:
- Add dom0 Ansible role to manage XCP-NG internal networks, dom0 IPv6 management address, and memory cap configuration.
- Add dom0-specific playbook that wraps the dom0 role with pre/post firewall snapshotting.
- Register dom0 in the Ansible inventory under a new xcpng group with host-specific variables for interpreter and connectivity.

Enhancements:
- Document the bootstrap-dom0.sh script as first-run only and delegate ongoing convergence to the new dom0 Ansible role.