### PR TITLE
CI 0f: runner Vault secret delivery + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for AS215932/network-operations.
+# GitHub auto-requests review from these owners on matching PRs. Pairs with
+# the branch-protection required-approval rule (docs/ci/workflows.md).
+
+*                       @AS215932/ops
+
+# Live router + firewall configs — the highest-blast-radius paths.
+/configs/rtr/           @AS215932/ops
+/configs/cr1-de1/       @AS215932/ops
+/configs/cr1-nl1/       @AS215932/ops
+/ansible/roles/firewall/ @AS215932/ops

--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -37,6 +37,20 @@ github_runner_name: "{{ inventory_hostname }}-runner"
 # across reboots, so this is only needed once.
 github_runner_registration_token: ""
 
+# Vault Agent secret delivery for apply.yml runs. The runner authenticates
+# with its own AppRole and Vault Agent renders github_runner_secrets_env,
+# which .github/workflows/apply.yml sources so ansible-playbook --tags apply
+# picks up the secrets its target playbooks read from the environment.
+# AppRole bootstrap: docs/runbooks/bootstrap-runner-vault.md.
+github_runner_vault_enabled: true
+github_runner_vault_role_id: "{{ lookup('env', 'VAULT_CI_RUNNER_ROLE_ID') | default('', true) }}"
+github_runner_vault_secret_id: "{{ lookup('env', 'VAULT_CI_RUNNER_SECRET_ID') | default('', true) }}"
+github_runner_secrets_env: /etc/github-runner/secrets.env
+# secrets.env is read fresh by apply.yml on every job, not from the runner's
+# process environment — so a secret rotation needs no runner restart (and a
+# restart would kill in-flight CI jobs). Keep this a no-op.
+github_runner_vault_reload_command: /bin/true
+
 # Toolchain installed on the runner (consumed by workflows). Kept minimal —
 # workflows install role-specific deps as needed.
 github_runner_packages:

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -125,3 +125,29 @@
     enabled: true
     daemon_reload: true
   tags: [apply]
+
+# Vault Agent renders /etc/github-runner/secrets.env so apply.yml can source
+# the secrets its target playbooks expect in the environment. The generic
+# vault_agent role drives this; we hand it the runner's own AppRole, template,
+# and config dir. First apply needs VAULT_CI_RUNNER_ROLE_ID / _SECRET_ID set
+# (see docs/runbooks/bootstrap-runner-vault.md); afterwards the AppRole files
+# on the host persist and re-applies converge without them.
+- name: Set up Vault Agent for runner secret delivery
+  include_role:
+    name: vault_agent
+  vars:
+    vault_agent_name: github-runner
+    vault_agent_role_id: "{{ github_runner_vault_role_id }}"
+    vault_agent_secret_id: "{{ github_runner_vault_secret_id }}"
+    vault_agent_templates:
+      - src: github-runner.env.ctmpl.j2
+        name: github-runner.env.ctmpl
+        destination: "{{ github_runner_secrets_env }}"
+        group: "{{ github_runner_group }}"
+        reload_command: "{{ github_runner_vault_reload_command }}"
+    vault_agent_extra_dirs:
+      - path: "{{ github_runner_secrets_env | dirname }}"
+        group: "{{ github_runner_group }}"
+        mode: "0750"
+  when: github_runner_vault_enabled | bool
+  tags: [apply]

--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -14,3 +14,27 @@ vault_agent_google_subject_token_destination: /run/noc-agent/google-subject.jwt
 vault_agent_reload_command: /bin/systemctl try-restart noc-agent.service
 vault_agent_hashicorp_repo_url: "https://apt.releases.hashicorp.com"
 vault_agent_hashicorp_gpg_url: "https://apt.releases.hashicorp.com/gpg"
+
+# Secret templates Vault Agent renders. Each entry: src (Jinja2 template in
+# this role's templates/), name (ctmpl filename written into the template
+# dir), destination (final rendered file), group (chgrp target on the
+# destination), reload_command (run after each render). The default pair
+# reproduces the noc-agent behaviour exactly; other consumers — e.g.
+# github_runner — pass their own list.
+vault_agent_templates:
+  - src: noc-agent.env.ctmpl.j2
+    name: noc-agent.env.ctmpl
+    destination: "{{ vault_agent_env_destination }}"
+    group: noc-agent
+    reload_command: "{{ vault_agent_reload_command }}"
+  - src: google-subject.jwt.ctmpl.j2
+    name: google-subject.jwt.ctmpl
+    destination: "{{ vault_agent_google_subject_token_destination }}"
+    group: noc-agent
+    reload_command: "{{ vault_agent_reload_command }}"
+
+# Extra directories the consumer needs created beyond the Vault Agent
+# config/run/template dirs. Default = noc-agent's runtime dirs.
+vault_agent_extra_dirs:
+  - { path: /etc/noc-agent, group: noc-agent, mode: "0750" }
+  - { path: /run/noc-agent, group: noc-agent, mode: "0750" }

--- a/ansible/roles/vault_agent/tasks/main.yml
+++ b/ansible/roles/vault_agent/tasks/main.yml
@@ -41,12 +41,12 @@
     owner: root
     group: "{{ item.group | default('root') }}"
     mode: "{{ item.mode }}"
-  loop:
-    - { path: "{{ vault_agent_config_dir }}", mode: "0750" }
-    - { path: "{{ vault_agent_template_dir }}", mode: "0750" }
-    - { path: "{{ vault_agent_run_dir }}", mode: "0750" }
-    - { path: "/etc/noc-agent", group: "noc-agent", mode: "0750" }
-    - { path: "/run/noc-agent", group: "noc-agent", mode: "0750" }
+  loop: >-
+    {{ [
+         {'path': vault_agent_config_dir, 'mode': '0750'},
+         {'path': vault_agent_template_dir, 'mode': '0750'},
+         {'path': vault_agent_run_dir, 'mode': '0750'},
+       ] + vault_agent_extra_dirs }}
   tags: [apply]
 
 - name: Install Vault AppRole role_id
@@ -73,23 +73,16 @@
   notify: restart vault agent
   tags: [apply]
 
-- name: Render NOC Agent env template for Vault Agent
+- name: Render secret templates for Vault Agent
   template:
-    src: noc-agent.env.ctmpl.j2
-    dest: "{{ vault_agent_template_dir }}/noc-agent.env.ctmpl"
+    src: "{{ item.src }}"
+    dest: "{{ vault_agent_template_dir }}/{{ item.name }}"
     owner: root
     group: root
     mode: "0640"
-  notify: restart vault agent
-  tags: [apply]
-
-- name: Render Google subject token template for Vault Agent
-  template:
-    src: google-subject.jwt.ctmpl.j2
-    dest: "{{ vault_agent_template_dir }}/google-subject.jwt.ctmpl"
-    owner: root
-    group: root
-    mode: "0640"
+  loop: "{{ vault_agent_templates }}"
+  loop_control:
+    label: "{{ item.name }}"
   notify: restart vault agent
   tags: [apply]
 

--- a/ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2
@@ -1,0 +1,15 @@
+# {{ github_runner_secrets_env }}
+# Rendered by Vault Agent from kv/data/ci-runner. Do not edit by hand.
+#
+# Sourced by .github/workflows/apply.yml so `ansible-playbook --tags apply`
+# picks up the secrets its target playbooks read from the environment.
+# When a playbook comes into CI scope and needs a new secret, add the key to
+# the kv/data/ci-runner Vault entry and a matching line here — keep this list
+# to what apply runs actually consume.
+
+{% raw %}{{ with secret "kv/data/ci-runner" -}}
+DISCORD_WEBHOOK_URL={{ .Data.data.discord_webhook_url }}
+ICINGA_API_USER={{ .Data.data.icinga_api_user }}
+ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
+ICINGA_NOC_AGENT_API_PASSWORD={{ or .Data.data.icinga_noc_agent_api_password "" }}
+{{- end }}{% endraw %}

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -30,26 +30,19 @@ auto_auth {
   }
 }
 
+{% for t in vault_agent_templates %}
 template {
-  source      = "{{ vault_agent_template_dir }}/noc-agent.env.ctmpl"
-  destination = "{{ vault_agent_env_destination }}"
+  source      = "{{ vault_agent_template_dir }}/{{ t.name }}"
+  destination = "{{ t.destination }}"
   perms       = 0640
-  command     = "/bin/sh -c 'chgrp noc-agent {{ vault_agent_env_destination }} && chmod 0640 {{ vault_agent_env_destination }} && {{ vault_agent_reload_command }}'"
+  command     = "/bin/sh -c 'chgrp {{ t.group }} {{ t.destination }} && chmod 0640 {{ t.destination }} && {{ t.reload_command }}'"
 
   wait {
     min = "2s"
     max = "10s"
   }
 }
+{% if not loop.last %}
 
-template {
-  source      = "{{ vault_agent_template_dir }}/google-subject.jwt.ctmpl"
-  destination = "{{ vault_agent_google_subject_token_destination }}"
-  perms       = 0640
-  command     = "/bin/sh -c 'chgrp noc-agent {{ vault_agent_google_subject_token_destination }} && chmod 0640 {{ vault_agent_google_subject_token_destination }} && {{ vault_agent_reload_command }}'"
-
-  wait {
-    min = "2s"
-    max = "10s"
-  }
-}
+{% endif %}
+{% endfor %}

--- a/configs/vault/policies/github-runner.hcl
+++ b/configs/vault/policies/github-runner.hcl
@@ -1,0 +1,16 @@
+# Vault policy for the CI runner.
+# Deploy path: applied to Vault as policy `github-runner`, bound to the
+# AppRole role `ci-runner`. See docs/runbooks/bootstrap-runner-vault.md.
+#
+# Grants read-only access to the single KV entry Vault Agent on the `ci` VM
+# renders into /etc/github-runner/secrets.env for apply.yml runs. Scope is
+# deliberately narrow — the runner can apply playbooks but cannot read any
+# other workload's secrets.
+
+path "kv/data/ci-runner" {
+  capabilities = ["read"]
+}
+
+path "kv/metadata/ci-runner" {
+  capabilities = ["read"]
+}

--- a/docs/ci/workflows.md
+++ b/docs/ci/workflows.md
@@ -9,9 +9,12 @@ Workflows match the runner label set `self-hosted, linux, x64, hyrule-infra`.
 |----------|---------|---------|----|
 | `lint.yml` | `pull_request`, `push` to `main` | yamllint + ansible-lint + shellcheck + Jinja2 syntax | 0b |
 | `render-check.yml` | `pull_request` touching `ansible/**`, `configs/**` | render every playbook + assert `ansible/generated/` is fresh | 0b |
-| `ai-review.yml` | `pull_request` | Claude API review on diff, file:line comments | 0c |
-| `auto-merge.yml` | `pull_request_target` on `labeled` | auto-merge trivial-class PRs (generated/, docs/, research-comment) | 0d |
 | `apply.yml` | `workflow_dispatch` | manual gated apply (pre-snapshot, `--tags apply`, post-snapshot, diff) | 0e |
+
+AI review is handled by the repo's **hosted review service** (configured in
+GitHub repo settings), not a workflow we maintain — there is no `ai-review.yml`.
+There is also no auto-merge: every PR, including rendered-artifact and
+docs-only ones, gets a human merge click.
 
 ## Lint config
 
@@ -42,3 +45,28 @@ VM is provisioned and the runner registered, jobs queue indefinitely. That's
 expected — the first time the runner comes online, all pending PR runs
 unfreeze together. Document this in the PR description if you're opening one
 during the bootstrap window.
+
+## First-time bootstrap
+
+The foundation PRs lint and render-check *themselves*, so the first merges
+can't be gated by checks that don't exist on `main` yet. Bootstrap order:
+
+1. **Provision the `ci` VM and register the runner** —
+   [docs/ci/provision.md](./provision.md). Until this is done, every workflow
+   job queues.
+2. **Wire the runner's Vault AppRole** —
+   [docs/runbooks/bootstrap-runner-vault.md](../runbooks/bootstrap-runner-vault.md),
+   so `apply.yml` can source `/etc/github-runner/secrets.env`.
+3. **Merge the foundation PRs in order, with admin bypass** (branch
+   protection isn't on yet, so this is just the normal merge button):
+   `0a` (ci VM + `github_runner` role) → `0b` (lint + render-check) →
+   `0e` (apply) → `0f` (runner Vault wiring + CODEOWNERS).
+4. **Enable branch protection on `main`** once `0f` is merged and no
+   foundation PRs are in flight. Require the `lint` and `render-check`
+   status checks plus the hosted review service's check (read its exact
+   context name off a recent PR's checks list first), and set
+   `required_approving_review_count: 1` — since there is no auto-merge,
+   every PR needs a human approval.
+
+`enforce_admins` should stay **off** so a broken workflow can still be
+force-merged to unblock the lane.

--- a/docs/runbooks/bootstrap-runner-vault.md
+++ b/docs/runbooks/bootstrap-runner-vault.md
@@ -1,0 +1,100 @@
+# Bootstrap: CI runner Vault AppRole
+
+One-time setup so the `ci` VM's Vault Agent can render
+`/etc/github-runner/secrets.env`, which `.github/workflows/apply.yml` sources
+for `ansible-playbook --tags apply` runs.
+
+This is a prerequisite for the first `playbooks/ci.yml --tags apply` that
+includes the `vault_agent` role (i.e. after the PR that wires it in lands).
+Without it, the `vault_agent` role's bootstrap assertion fails because no
+AppRole credentials are present.
+
+## Prerequisites
+
+- `vault` CLI authenticated against `https://vault.as215932.net` with a token
+  that can write policies and manage the AppRole auth mount.
+- The `ci` VM provisioned and the runner registered (see
+  [docs/ci/provision.md](../ci/provision.md)).
+
+## 1. Write the policy
+
+The policy file is version-controlled at
+[configs/vault/policies/github-runner.hcl](../../configs/vault/policies/github-runner.hcl).
+
+```bash
+vault policy write github-runner configs/vault/policies/github-runner.hcl
+```
+
+## 2. Create the AppRole
+
+```bash
+# AppRole auth is already mounted (noc-agent uses it). Create the ci-runner role.
+vault write auth/approle/role/ci-runner \
+    token_policies="github-runner" \
+    token_ttl=1h \
+    token_max_ttl=4h \
+    secret_id_ttl=0 \
+    secret_id_num_uses=0
+```
+
+`secret_id_ttl=0` keeps the secret_id non-expiring — the runner is a
+long-lived host, not an ephemeral workload. If you prefer rotation, set a
+finite TTL and record the next rotation date here so it doesn't expire
+silently.
+
+## 3. Populate the KV entry
+
+Vault Agent renders from `kv/data/ci-runner` (see
+[github-runner.env.ctmpl.j2](../../ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2)).
+Seed it with the secrets apply runs currently consume:
+
+```bash
+vault kv put kv/ci-runner \
+    discord_webhook_url="https://discord.com/api/webhooks/..." \
+    icinga_api_user="..." \
+    icinga_api_password="..." \
+    icinga_noc_agent_api_password="..."
+```
+
+When a playbook enters CI scope and needs another secret, add the key here
+and a matching line in the ctmpl template — keep both in lockstep.
+
+## 4. Fetch role_id + secret_id
+
+```bash
+vault read -field=role_id   auth/approle/role/ci-runner/role-id
+vault write -f -field=secret_id auth/approle/role/ci-runner/secret-id
+```
+
+Put both in `secrets.local.sh` so the next apply picks them up:
+
+```sh
+export VAULT_CI_RUNNER_ROLE_ID=...
+export VAULT_CI_RUNNER_SECRET_ID=...
+```
+
+## 5. Apply
+
+```bash
+cd ansible
+set -a; source ../secrets.local.sh; set +a
+ansible-playbook playbooks/ci.yml --tags apply \
+    -e github_runner_apply=true --limit ci
+```
+
+The `vault_agent` role installs `vault-agent-github-runner.service`, writes
+the AppRole files under `/etc/vault-agent.d/`, and renders
+`/etc/github-runner/secrets.env`. After the first apply the AppRole files
+persist on the host, so subsequent applies converge without the env vars.
+
+## Verify
+
+```bash
+ssh root@2a0c:b641:b50:2::d0 systemctl status vault-agent-github-runner
+ssh root@2a0c:b641:b50:2::d0 'ls -l /etc/github-runner/secrets.env'   # 0640 runner:runner
+```
+
+Then run the `apply.yml` smoke test from
+[docs/ci/deploy-runbook.md](../ci/deploy-runbook.md) — the "Source
+Vault-rendered secrets" step should find the file and not emit the
+`secrets.env not found` warning.


### PR DESCRIPTION
## Summary

Closes the last repo-side gap in the CI/CD foundation: `apply.yml` sources `/etc/github-runner/secrets.env`, but nothing rendered it. Also adds two operational-hygiene items.

- **`vault_agent` role generalized** — it was hardcoded for `noc-agent` (fixed ctmpl pair, `noc-agent` user/group, two literal `template{}` blocks). Now driven by a `vault_agent_templates` list + `vault_agent_extra_dirs`; the defaults reproduce the noc-agent pair **byte-identically** (verified by rendering old vs. new with Ansible's Jinja settings).
- **`github_runner` role** includes `vault_agent` with its own AppRole, a new `github-runner.env.ctmpl.j2` (renders Discord webhook + Icinga creds from `kv/data/ci-runner`), and `/etc/github-runner` as its config dir. `reload_command` is `/bin/true` on purpose — `secrets.env` is read fresh per apply job, so a rotation needs no runner restart (restarting would kill in-flight CI jobs).
- **`configs/vault/policies/github-runner.hcl`** — read-only on `kv/ci-runner`, nothing else.
- **`docs/runbooks/bootstrap-runner-vault.md`** — one-time AppRole setup; a prerequisite for the first `ci.yml` apply that includes this wiring.
- **`.github/CODEOWNERS`** — `@AS215932/ops`, with explicit entries on the highest-blast-radius paths.
- **`docs/ci/workflows.md`** — adds the first-time bootstrap sequence; drops the `ai-review.yml`/`auto-merge.yml` rows (AI review is the repo's hosted service; there is no auto-merge — every PR gets a human merge click).

## Depends on / stacking

Branched on `feat/0a` with `feat/0b` merged in (the `github_runner` role and `docs/ci/workflows.md` live there). Merge order: **0a → 0b → 0e → 0f**. The diff collapses to just the 0f commits once 0a/0b are on `main`.

## Heads-up — pre-existing lint failure (not introduced here)

`ansible-lint -c .ansible-lint ansible/playbooks/ ansible/roles/` exits 2 **on `main` already** (11 `syntax-check` errors — unskippable — plus 46 `name[casing]`). feat/0b's `.ansible-lint` does not actually make the existing repo pass, contrary to its stated "start permissive" intent. This PR adds **zero** new violations. It needs fixing in feat/0b (or a dedicated PR) before branch protection can require the `lint` check — flagging rather than ballooning this PR.

## Test plan

- [x] `yamllint -c .yamllint` clean on all changed files
- [x] `ansible-lint` on `vault_agent` + `github_runner` roles — no new violations
- [x] noc `vault-agent.hcl` renders byte-identical pre/post the loop refactor
- [ ] After the `ci` VM + Vault AppRole bootstrap: `ansible-playbook playbooks/ci.yml --tags apply --limit ci` renders `/etc/github-runner/secrets.env` (0640 runner:runner)
- [ ] `apply.yml` smoke test no longer warns `secrets.env not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a self-hosted GitHub Actions runner host and CI workflows, backed by Vault-delivered secrets, and wire it into the existing Ansible and infrastructure inventory.

New Features:
- Add a generic github_runner Ansible role and playbook to provision and manage a self-hosted GitHub Actions runner on the new ci host.
- Introduce Vault-backed secret delivery for the CI runner via an extended vault_agent role and a dedicated github-runner Vault policy and template.
- Add lint and render-check GitHub Actions workflows that run on the self-hosted runner, plus a helper script to render all Ansible playbooks in validate-only mode.

Enhancements:
- Generalize the vault_agent role to support an arbitrary list of secret templates and extra directories, making it reusable beyond the noc-agent consumer.
- Extend network, inventory, firewall, monitoring, and logging configuration to include the new ci VM and its flows.
- Document CI provisioning, Vault AppRole bootstrap for the runner, and the end-to-end CI workflow and bootstrap process.
- Add CODEOWNERS configuration to codify operational ownership of key paths.

CI:
- Add lint and render-check GitHub Actions workflows that run on the self-hosted runner and gate changes touching Ansible, configs, and related docs.

Deployment:
- Introduce configuration and playbooks to deploy and operate the ci VM as a self-hosted GitHub Actions runner with Vault-managed secrets for apply runs.

Documentation:
- Add CI provisioning and Vault AppRole bootstrap runbooks and a CI workflows overview documenting runner labels, bootstrap order, and branch protection expectations.
- Update network flow documentation to describe the new ci host, its traffic patterns, and its log shipping to the log node.

Tests:
- Add a render-all helper script and render-check workflow to ensure Ansible-generated artifacts stay in sync with templates and configuration changes.