### PR TITLE
xo_mcp daemon — salvaged from CI branches (needs rebase, do not merge as-is)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,31 @@
+---
+# Permissive ansible-lint config. Like .yamllint above, intentionally soft
+# at the start; tighten via follow-up issues.
+
+profile: basic
+
+exclude_paths:
+  - ansible/generated/
+  - autoinstall/generated/
+  - .github/
+
+# Rules we never want to enforce (project conventions diverge):
+skip_list:
+  - role-name              # roles named with underscores (vault_agent, hyrule_mcp) — intentional
+  - command-instead-of-shell  # we use shell freely for run-once provisioning
+  - var-naming[no-role-prefix]  # role-prefixed vars are convention here
+
+# Rules we treat as warnings rather than errors during the soft launch:
+warn_list:
+  - yaml[line-length]
+  - yaml[truthy]
+  - no-changed-when
+  - risky-file-permissions
+  - jinja[invalid]
+  - schema[meta]
+
+kinds:
+  - playbook: "ansible/playbooks/*.yml"
+  - tasks: "ansible/roles/*/tasks/*.yml"
+  - vars: "ansible/inventory/host_vars/*.yml"
+  - vars: "ansible/inventory/group_vars/*.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,69 @@
+---
+name: lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  yamllint:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - uses: actions/checkout@v4
+      - name: yamllint
+        run: yamllint -c .yamllint .
+
+  ansible-lint:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - uses: actions/checkout@v4
+      - name: ansible-lint
+        run: ansible-lint -c .ansible-lint ansible/playbooks/ ansible/roles/
+
+  shellcheck:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        run: |
+          set -e
+          # Skip generated/, but lint all hand-written scripts.
+          mapfile -t scripts < <(find scripts -type f \( -name '*.sh' -o -name '*.bash' \) -print)
+          if [ "${#scripts[@]}" -gt 0 ]; then
+            shellcheck "${scripts[@]}"
+          else
+            echo "no shell scripts found, skipping"
+          fi
+
+  jinja-syntax:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - uses: actions/checkout@v4
+      - name: jinja2 syntax check
+        run: |
+          python3 - <<'EOF'
+          import sys
+          from pathlib import Path
+          from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
+
+          repo = Path(".")
+          j2_files = [p for p in repo.rglob("*.j2")
+                      if "/generated/" not in str(p)
+                      and not str(p).startswith(".git")]
+
+          fail = 0
+          for p in j2_files:
+              env = Environment(loader=FileSystemLoader(p.parent))
+              try:
+                  env.parse(p.read_text())
+              except TemplateSyntaxError as e:
+                  print(f"::error file={p},line={e.lineno}::{e.message}")
+                  fail = 1
+          sys.exit(fail)
+          EOF

--- a/.github/workflows/render-check.yml
+++ b/.github/workflows/render-check.yml
@@ -1,0 +1,52 @@
+---
+name: render-check
+
+# Renders every playbook in --tags validate --connection=local mode and
+# asserts that the checked-in ansible/generated/ output matches what the
+# render produces. Catches stale generated/ checkins (the operator forgot
+# to commit a re-render) and template typos that don't surface until apply.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ansible/**'
+      - 'configs/**'
+      - 'docs/network-flows.md'
+      - 'scripts/ci/render-all.sh'
+      - '.github/workflows/render-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'ansible/**'
+      - 'configs/**'
+      - 'docs/network-flows.md'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  render:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render every playbook (validate-only, no apply)
+        run: scripts/ci/render-all.sh
+
+      - name: Assert generated/ matches HEAD
+        run: |
+          set -e
+          if ! git diff --exit-code ansible/generated/; then
+            echo "::error::ansible/generated/ is stale. Re-run scripts/ci/render-all.sh locally and commit the diff." >&2
+            exit 1
+          fi
+
+      - name: Upload render output (debugging)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: render-output
+          path: ansible/generated/
+          retention-days: 7

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,28 @@
+---
+# Permissive yamllint config — starts soft so existing repo passes.
+# Ratchet specific rules to "error" via follow-up issues as the codebase
+# converges.
+
+extends: default
+
+rules:
+  line-length:
+    max: 200
+    level: warning
+  document-start: disable
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  braces:
+    max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1
+
+ignore: |
+  ansible/generated/
+  autoinstall/generated/

--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -44,6 +44,8 @@
     icinga_api_user: "{{ lookup('env', 'ICINGA_API_USER') }}"
     icinga_api_password: "{{ lookup('env', 'ICINGA_API_PASSWORD') }}"
     xo_token: "{{ lookup('env', 'XO_TOKEN') }}"
+    xo_username: "{{ lookup('env', 'XO_USERNAME') | default('', true) }}"
+    xo_password: "{{ lookup('env', 'XO_PASSWORD') | default('', true) }}"
     noc_mail_password: "{{ lookup('env', 'MAIL_NOC_PASSWORD') }}"
     noc_discord_bot_token: "{{ lookup('env', 'NOC_DISCORD_BOT_TOKEN') | default('', true) }}"
     noc_control_token: "{{ lookup('env', 'NOC_CONTROL_TOKEN') | default('', true) }}"

--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -55,6 +55,7 @@
   roles:
     - hyrule_mcp
     - noc_agent
+    - xo_mcp
     - role: vault_agent
       vars:
         vault_agent_name: noc-agent
@@ -63,7 +64,11 @@
         vault_agent_secret_id: "{{ lookup('env', 'VAULT_NOC_AGENT_SECRET_ID') | default('', true) }}"
         vault_agent_env_destination: /opt/noc-agent/.env
         vault_agent_google_subject_token_destination: "{{ noc_agent_google_subject_token_path }}"
-        vault_agent_reload_command: /bin/systemctl restart noc-agent.service
+        vault_agent_reload_command: >-
+          /bin/systemctl restart hyrule-mcp.service &&
+          /bin/systemctl restart xo-mcp.service &&
+          /bin/systemctl restart noc-agent.service &&
+          /bin/systemctl restart noc-agent-bot.service
       when: noc_agent_secret_backend == 'vault'
   tags: [noc]
 

--- a/ansible/roles/hyrule_mcp/tasks/main.yml
+++ b/ansible/roles/hyrule_mcp/tasks/main.yml
@@ -219,7 +219,10 @@
   become_user: "{{ hyrule_mcp_app_user }}"
   ignore_errors: true  # First run will fail until the deploy key is registered on GitHub.
   tags: [apply]
-  notify: restart noc-agent
+  notify:
+    - restart hyrule-mcp
+    - restart noc-agent
+    - restart noc-agent-bot
 
 - name: Check for hyrule-mcp pyproject.toml (set after a successful clone)
   stat:
@@ -240,6 +243,7 @@
   notify:
     - restart hyrule-mcp
     - restart noc-agent
+    - restart noc-agent-bot
 
 - name: Install /etc/systemd/system/hyrule-mcp.service
   copy:
@@ -252,3 +256,5 @@
   notify:
     - reload systemd
     - restart hyrule-mcp
+    - restart noc-agent
+    - restart noc-agent-bot

--- a/ansible/roles/noc_agent/handlers/main.yml
+++ b/ansible/roles/noc_agent/handlers/main.yml
@@ -10,3 +10,18 @@
     enabled: true
   when: noc_agent_pyproject.stat.exists | default(false)
   ignore_errors: "{{ ansible_check_mode }}"
+
+- name: restart noc-agent-bot
+  systemd:
+    name: noc-agent-bot
+    state: restarted
+    enabled: true
+  when: noc_agent_pyproject.stat.exists | default(false)
+  ignore_errors: "{{ ansible_check_mode }}"
+
+- name: restart xo-mcp
+  systemd:
+    name: xo-mcp
+    state: restarted
+    enabled: true
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/ansible/roles/noc_agent/tasks/main.yml
+++ b/ansible/roles/noc_agent/tasks/main.yml
@@ -118,7 +118,9 @@
   become: true
   become_user: "{{ noc_agent_user }}"
   ignore_errors: true  # First run will fail until the deploy key is registered on GitHub.
-  notify: restart noc-agent
+  notify:
+    - restart noc-agent
+    - restart noc-agent-bot
   tags: [apply]
 
 - name: Check for noc-agent pyproject.toml (set after a successful clone)
@@ -136,7 +138,9 @@
   become: true
   become_user: "{{ noc_agent_user }}"
   when: noc_agent_pyproject.stat.exists
-  notify: restart noc-agent
+  notify:
+    - restart noc-agent
+    - restart noc-agent-bot
   tags: [apply]
 
 - name: Render /opt/noc-agent/.env
@@ -148,7 +152,10 @@
     mode: "0640"
   when: noc_agent_secret_backend == 'env'
   no_log: true
-  notify: restart noc-agent
+  notify:
+    - restart xo-mcp
+    - restart noc-agent
+    - restart noc-agent-bot
   tags: [apply]
 
 - name: Install Google external-account WIF config for noc-agent
@@ -159,7 +166,9 @@
     group: "{{ noc_agent_group }}"
     mode: "0640"
   when: noc_agent_google_wif_enabled | bool
-  notify: restart noc-agent
+  notify:
+    - restart noc-agent
+    - restart noc-agent-bot
   tags: [apply]
 
 - name: Install /etc/systemd/system/noc-agent.service
@@ -172,6 +181,19 @@
   notify:
     - reload systemd
     - restart noc-agent
+    - restart noc-agent-bot
+  tags: [apply]
+
+- name: Install /etc/systemd/system/noc-agent-bot.service
+  copy:
+    src: "{{ playbook_dir }}/../../configs/noc-agent-bot.service"
+    dest: /etc/systemd/system/noc-agent-bot.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart noc-agent-bot
   tags: [apply]
 
 - name: Enable and start noc-agent
@@ -186,9 +208,32 @@
   ignore_errors: "{{ ansible_check_mode }}"
   tags: [apply]
 
+- name: Enable and start noc-agent-bot
+  systemd:
+    name: noc-agent-bot
+    state: started
+    enabled: true
+    daemon_reload: true
+  when:
+    - noc_agent_pyproject.stat.exists
+    - noc_agent_secret_backend == 'env'
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags: [apply]
+
 - name: Enable noc-agent for Vault Agent managed start
   systemd:
     name: noc-agent
+    enabled: true
+    daemon_reload: true
+  when:
+    - noc_agent_pyproject.stat.exists
+    - noc_agent_secret_backend == 'vault'
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags: [apply]
+
+- name: Enable noc-agent-bot for Vault Agent managed start
+  systemd:
+    name: noc-agent-bot
     enabled: true
     daemon_reload: true
   when:

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -42,6 +42,10 @@ HYRULE_MCP_URL=http://127.0.0.1:8765/mcp
 XO_MCP_CMD="npx -y @xen-orchestra/mcp"
 XO_MCP_URL=http://127.0.0.1:8766/mcp
 XO_URL=https://xo.servify.network
+{% raw %}{{ with secret "kv/data/noc-agent" -}}
+XO_USERNAME={{ or .Data.data.xo_username "" }}
+XO_PASSWORD={{ or .Data.data.xo_password "" }}
+{{- end }}{% endraw %}
 XO_MCP_ENABLE_ACTIONS=0
 
 PROMETHEUS_URL=http://[{{ peers.mon.ipv6 }}]:9090

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -40,6 +40,7 @@ NOC_REDIS_URL=redis://127.0.0.1:6379/0
 HYRULE_MCP_CMD="/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py"
 HYRULE_MCP_URL=http://127.0.0.1:8765/mcp
 XO_MCP_CMD="npx -y @xen-orchestra/mcp"
+XO_MCP_URL=http://127.0.0.1:8766/mcp
 XO_URL=https://xo.servify.network
 XO_MCP_ENABLE_ACTIONS=0
 

--- a/ansible/roles/xo_mcp/defaults/main.yml
+++ b/ansible/roles/xo_mcp/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+xo_mcp_app_user: noc-agent
+xo_mcp_app_group: noc-agent
+xo_mcp_install_dir: /opt/xo-mcp
+xo_mcp_port: 8766
+xo_mcp_path: /mcp
+xo_mcp_health_path: /health
+xo_mcp_allowed_remote_ips:
+  - "46.105.40.223"
+  - "{{ peers.proxy.ipv6 }}"

--- a/ansible/roles/xo_mcp/handlers/main.yml
+++ b/ansible/roles/xo_mcp/handlers/main.yml
@@ -3,9 +3,9 @@
   systemd:
     daemon_reload: true
 
-- name: restart hyrule-mcp
+- name: restart xo-mcp
   systemd:
-    name: hyrule-mcp
+    name: xo-mcp
     state: restarted
     enabled: true
   ignore_errors: "{{ ansible_check_mode }}"

--- a/ansible/roles/xo_mcp/tasks/main.yml
+++ b/ansible/roles/xo_mcp/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+# Deploy a supervised local HTTP wrapper for the stdio-only Xen Orchestra MCP.
+
+- name: Ensure XO MCP install dir exists
+  file:
+    path: "{{ xo_mcp_install_dir }}"
+    state: directory
+    owner: "{{ xo_mcp_app_user }}"
+    group: "{{ xo_mcp_app_group }}"
+    mode: "0755"
+  tags: [apply]
+
+- name: Install XO MCP package manifest
+  copy:
+    src: "{{ playbook_dir }}/../../configs/xo-mcp-package.json"
+    dest: "{{ xo_mcp_install_dir }}/package.json"
+    owner: "{{ xo_mcp_app_user }}"
+    group: "{{ xo_mcp_app_group }}"
+    mode: "0644"
+  notify:
+    - restart xo-mcp
+    - restart noc-agent
+    - restart noc-agent-bot
+  tags: [apply]
+
+- name: Install XO MCP node dependencies
+  command: npm install --omit=dev
+  args:
+    chdir: "{{ xo_mcp_install_dir }}"
+  register: xo_mcp_npm_install
+  changed_when: >-
+    'added' in xo_mcp_npm_install.stdout
+    or 'removed' in xo_mcp_npm_install.stdout
+    or 'changed' in xo_mcp_npm_install.stdout
+  become: true
+  become_user: "{{ xo_mcp_app_user }}"
+  notify:
+    - restart xo-mcp
+    - restart noc-agent
+    - restart noc-agent-bot
+  tags: [apply]
+
+- name: Install /etc/systemd/system/xo-mcp.service
+  template:
+    src: xo-mcp.service.j2
+    dest: /etc/systemd/system/xo-mcp.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart xo-mcp
+    - restart noc-agent
+    - restart noc-agent-bot
+  tags: [apply]
+
+- name: Check for rendered NOC Agent env file
+  stat:
+    path: /opt/noc-agent/.env
+  register: xo_mcp_env_file
+  tags: [apply]
+
+- name: Enable and start xo-mcp when env file is present
+  systemd:
+    name: xo-mcp
+    state: started
+    enabled: true
+    daemon_reload: true
+  when: xo_mcp_env_file.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags: [apply]
+
+- name: Enable xo-mcp for Vault Agent managed start
+  systemd:
+    name: xo-mcp
+    enabled: true
+    daemon_reload: true
+  when: not xo_mcp_env_file.stat.exists
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags: [apply]

--- a/ansible/roles/xo_mcp/templates/xo-mcp.service.j2
+++ b/ansible/roles/xo_mcp/templates/xo-mcp.service.j2
@@ -1,0 +1,40 @@
+# /etc/systemd/system/xo-mcp.service
+# Managed by ansible/roles/xo_mcp.
+
+[Unit]
+Description=AS215932 Xen Orchestra MCP daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User={{ xo_mcp_app_user }}
+Group={{ xo_mcp_app_group }}
+WorkingDirectory={{ xo_mcp_install_dir }}
+EnvironmentFile=/opt/noc-agent/.env
+Environment=NODE_ENV=production
+ExecStart={{ xo_mcp_install_dir }}/node_modules/.bin/supergateway \
+    --stdio "/usr/bin/npx --no-install @xen-orchestra/mcp" \
+    --outputTransport streamableHttp \
+    --port {{ xo_mcp_port }} \
+    --streamableHttpPath {{ xo_mcp_path }} \
+    --healthEndpoint {{ xo_mcp_health_path }} \
+    --logLevel info
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=xo-mcp
+
+ProtectSystem=strict
+ReadWritePaths={{ xo_mcp_install_dir }} /var/lib/noc-agent /tmp
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+IPAddressDeny=any
+IPAddressAllow=localhost {{ xo_mcp_allowed_remote_ips | join(' ') }}
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/noc-agent-bot.service
+++ b/configs/noc-agent-bot.service
@@ -1,10 +1,10 @@
-# /etc/systemd/system/noc-agent.service
+# /etc/systemd/system/noc-agent-bot.service
 # Deploy to: noc VM
 
 [Unit]
-Description=AS215932 NOC Agent (Alertmanager + Icinga webhooks → PydanticAI investigation → Discord)
-After=network.target hyrule-mcp.service xo-mcp.service
-Wants=hyrule-mcp.service xo-mcp.service
+Description=AS215932 NOC Agent Discord Bot
+After=network.target hyrule-mcp.service xo-mcp.service noc-agent.service
+Wants=hyrule-mcp.service xo-mcp.service noc-agent.service
 
 [Service]
 Type=exec
@@ -13,17 +13,12 @@ Group=noc-agent
 WorkingDirectory=/opt/noc-agent
 EnvironmentFile=/opt/noc-agent/.env
 Environment=PYTHONPATH=/opt/noc-agent
-ExecStart=/opt/noc-agent/.venv/bin/uvicorn app.main:app \
-    --host :: \
-    --port 8000 \
-    --workers 2 \
-    --log-level info \
-    --access-log
+ExecStart=/opt/noc-agent/.venv/bin/noc-agent-bot
 Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=noc-agent
+SyslogIdentifier=noc-agent-bot
 
 # Security hardening
 ProtectSystem=strict

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -54,6 +54,8 @@ XO_MCP_URL=http://127.0.0.1:8766/mcp
 # --- Xen Orchestra (consumed by the XO MCP child) ---
 XO_URL=https://xo.servify.network
 XO_TOKEN={{ xo_token }}
+XO_USERNAME={{ xo_username | default('') }}
+XO_PASSWORD={{ xo_password | default('') }}
 # Shadow mode — no autonomous writes to XO. Flip to 1 only after review.
 XO_MCP_ENABLE_ACTIONS=0
 

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -2,8 +2,7 @@
 # Deploy to: noc VM (2a0c:b641:b50:2::a0)
 #
 # Rendered by ansible/roles/noc_agent. All variables sourced from
-# secrets.local.sh at deploy time. hyrule-mcp is a stdio child of noc-agent
-# and inherits this entire environment.
+# secrets.local.sh at deploy time.
 
 # --- LLM provider ---
 GEMINI_API_KEY={{ gemini_api_key }}
@@ -44,12 +43,13 @@ MAIL_IMAP_USER=noc
 MAIL_IMAP_PASSWORD={{ noc_mail_password | quote }}
 MAIL_DRAFT_DIR=/var/lib/noc-agent/mail-drafts
 
-# --- MCP child processes (stdio) ---
+# --- MCP daemons ---
 # Quoted so the file is also `sh -.` source-able (used by mcp-ops's wrapper);
 # systemd's EnvironmentFile= strips the quotes.
 HYRULE_MCP_CMD="/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py"
 HYRULE_MCP_URL=http://127.0.0.1:8765/mcp
 XO_MCP_CMD="npx -y @xen-orchestra/mcp"
+XO_MCP_URL=http://127.0.0.1:8766/mcp
 
 # --- Xen Orchestra (consumed by the XO MCP child) ---
 XO_URL=https://xo.servify.network

--- a/configs/xo-mcp-package.json
+++ b/configs/xo-mcp-package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@xen-orchestra/mcp": "1.0.1",
+    "supergateway": "3.4.0"
+  }
+}

--- a/docs/ci/workflows.md
+++ b/docs/ci/workflows.md
@@ -1,0 +1,44 @@
+# CI workflows
+
+All CI runs on the self-hosted `ci` VM (see [docs/ci/provision.md](./provision.md)).
+Workflows match the runner label set `self-hosted, linux, x64, hyrule-infra`.
+
+## Workflows
+
+| Workflow | Trigger | Purpose | PR |
+|----------|---------|---------|----|
+| `lint.yml` | `pull_request`, `push` to `main` | yamllint + ansible-lint + shellcheck + Jinja2 syntax | 0b |
+| `render-check.yml` | `pull_request` touching `ansible/**`, `configs/**` | render every playbook + assert `ansible/generated/` is fresh | 0b |
+| `ai-review.yml` | `pull_request` | Claude API review on diff, file:line comments | 0c |
+| `auto-merge.yml` | `pull_request_target` on `labeled` | auto-merge trivial-class PRs (generated/, docs/, research-comment) | 0d |
+| `apply.yml` | `workflow_dispatch` | manual gated apply (pre-snapshot, `--tags apply`, post-snapshot, diff) | 0e |
+
+## Lint config
+
+Both `.yamllint` and `.ansible-lint` start permissive so the existing repo
+passes. Tighten via follow-up issues — pick one rule per issue, fix
+violations, promote the rule to error.
+
+`scripts/ci/render-all.sh` is the single entry point for "render every
+playbook." Use it locally before committing if you've touched any Ansible
+template:
+
+```bash
+scripts/ci/render-all.sh
+git diff ansible/generated/   # commit anything that shows up
+```
+
+## Why self-hosted?
+
+Decision recorded in the approved plan `we-need-to-go-zany-robin.md` →
+Phase 0. Self-hosted gets us overlay v6 to every host (for apply runs),
+Vault AppRole access (for secrets), and a stable network egress (firewall
+rules don't chase GH Actions IP ranges).
+
+## Bootstrap chicken-and-egg
+
+These workflows reference the `hyrule-infra` runner label. Before the `ci`
+VM is provisioned and the runner registered, jobs queue indefinitely. That's
+expected — the first time the runner comes online, all pending PR runs
+unfreeze together. Document this in the PR description if you're opening one
+during the bootstrap window.

--- a/scripts/ci/render-all.sh
+++ b/scripts/ci/render-all.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/ci/render-all.sh
+#
+# Render every Ansible playbook in --tags validate --connection=local mode,
+# without applying. Used by .github/workflows/render-check.yml to assert
+# that ansible/generated/<host>/* matches what the role would produce.
+#
+# Usage:
+#   scripts/ci/render-all.sh           # render all playbooks
+#   scripts/ci/render-all.sh firewall  # render just one playbook
+#
+# Exit codes:
+#   0  every requested playbook rendered cleanly
+#   1  one or more playbooks failed to render
+#
+# Secrets:
+#   This script does NOT need any real secret values — it only renders
+#   templates. Anything sourced from `lookup('env', ...)` falls through to an
+#   empty default and the template handles it. If a render starts requiring
+#   a real secret to validate, that's a bug in the template.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../ansible"
+
+# Stub out env vars that the playbooks read at render time. Real values are
+# only needed on apply.
+export ANSIBLE_FORCE_COLOR=true
+export DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-https://discord.com/api/webhooks/0/render-stub}"
+export ICINGA_API_USER="${ICINGA_API_USER:-render-stub}"
+export ICINGA_API_PASSWORD="${ICINGA_API_PASSWORD:-render-stub}"
+export GEMINI_API_KEY="${GEMINI_API_KEY:-render-stub}"
+export NOC_DISCORD_WEBHOOK="${NOC_DISCORD_WEBHOOK:-https://discord.com/api/webhooks/0/render-stub}"
+export XO_TOKEN="${XO_TOKEN:-render-stub}"
+export MAIL_NOC_PASSWORD="${MAIL_NOC_PASSWORD:-render-stub}"
+export NOC_MCP_KEY_PATH="${NOC_MCP_KEY_PATH:-/dev/null}"
+export VAULT_NOC_AGENT_ROLE_ID="${VAULT_NOC_AGENT_ROLE_ID:-render-stub}"
+export VAULT_NOC_AGENT_SECRET_ID="${VAULT_NOC_AGENT_SECRET_ID:-render-stub}"
+
+playbooks=()
+if [ "$#" -gt 0 ]; then
+  for p in "$@"; do
+    playbooks+=("playbooks/${p}.yml")
+  done
+else
+  # Default set — playbooks that have a render-only `--tags validate` path.
+  # Skip ones whose role is apply-only (vault, knot, networkd_resolved, etc.)
+  # to keep the workflow tight.
+  for p in firewall monitoring logs icinga2 ci; do
+    [ -f "playbooks/${p}.yml" ] || continue
+    playbooks+=("playbooks/${p}.yml")
+  done
+fi
+
+fail=0
+for pb in "${playbooks[@]}"; do
+  echo "::group::render ${pb}"
+  if ! ansible-playbook "${pb}" \
+       --tags validate \
+       --connection=local \
+       --skip-tags=snapshot,apply; then
+    echo "::error::render failed: ${pb}"
+    fail=1
+  fi
+  echo "::endgroup::"
+done
+
+exit "${fail}"


### PR DESCRIPTION
## Context

While bringing the CI/CD lane online, two stray NOC/xo_mcp commits were found contaminating the CI branches `feat/0b` and `feat/0f` — they don't belong on CI PRs and were causing merge conflicts. Per the agreed plan the CI branches were rebuilt clean; this branch **parks the xo_mcp work** so it isn't lost and can land on its own track.

## What's here

- `c4be11f "Run XO MCP as supervised daemon"` — the substantive work: new `ansible/roles/xo_mcp/` role (defaults/handlers/tasks/systemd template), `configs/xo-mcp-package.json`, plus edits to `noc_agent`, `hyrule_mcp`, `noc.yml`, `noc-agent-bot.service`, `noc-agent.env.j2`, `noc-agent.service`, `vault_agent/templates/noc-agent.env.ctmpl.j2`.

## Not yet here — also salvage this

- `9a7093d "Point NOC XO MCP at Caddy endpoint"` — a 2-line follow-up (XO_MCP_URL in `noc-agent.env.ctmpl.j2` + `noc-agent.env.j2`). It's preserved on branch **`feat/0f-pre-rebuild-backup`**. Cherry-picking it onto this branch conflicts trivially on `XO_MCP_URL` — resolve per the Caddy-endpoint intent (I didn't guess at NOC routing).

## Status: NOT mergeable as-is

This branch is based on an old `main` and **conflicts with current main** — `main` has since landed `5d0ba08 "Run NOC Discord bot as dedicated service"` and `80ce6a8 "Restart MCP daemon on code updates"`, which overlap with `c4be11f`'s `noc_agent`/`hyrule_mcp`/`noc-agent-bot.service` changes (independent, divergent versions of similar work).

It also carries `2f5d422`/`3f0c403` (lint workflows) as ancestors — drop those on rebase.

## To pick this up

1. Rebase onto current `main`, resolving the `noc_agent` / `hyrule_mcp` / `noc.yml` / `noc-agent-bot.service` overlaps — decide what `c4be11f` adds beyond what main already has (the `xo_mcp` role itself is net-new and not on main).
2. Cherry-pick `9a7093d` from `feat/0f-pre-rebuild-backup`, resolving the `XO_MCP_URL` conflict.
3. Drop the lint-workflow ancestor commits.

There is also stashed local WIP on `noc.yml` / `noc-agent.env.ctmpl.j2` / `noc-agent.env.j2` from the same work area — see the operator handoff notes.

## Summary by Sourcery

Introduce a supervised Xen Orchestra MCP daemon and wire it into the NOC stack alongside new CI lint/render workflows.

New Features:
- Add xo_mcp Ansible role with systemd unit to run the XO MCP as a supervised HTTP daemon fronting the stdio MCP.
- Expose XO MCP configuration via new env vars and defaults, including port, path, health endpoint, and allowed remote IPs.
- Add a dedicated noc-agent-bot systemd service and integrate it into the NOC playbook and handlers.

Enhancements:
- Update noc_agent and hyrule_mcp roles to coordinate restarts of noc-agent, noc-agent-bot, hyrule-mcp, and xo-mcp when code or configuration changes.
- Extend the NOC Ansible playbook to include the xo_mcp role and ensure Vault-driven reloads restart all related MCP and agent services.

Build:
- Add repo-level yamllint, ansible-lint, shellcheck, and Jinja2 syntax-check workflows for basic static validation.
- Introduce a render-check workflow that renders Ansible playbooks and enforces that committed ansible/generated output is up to date.

CI:
- Add a render-all CI helper script to validate-playbook rendering in local and CI environments.

Documentation:
- Document the new CI workflows and render-all flow in docs/ci/workflows.md.