### PR TITLE
monitoring: check the ci runner via Prometheus, not by_ssh

### DIFF
--- a/ansible/generated/ci/icinga_host.conf
+++ b/ansible/generated/ci/icinga_host.conf
@@ -17,12 +17,3 @@ object Host "ci" {
   vars.disks["disk /"] = { mountpoint = "/" }
 }
 
-object Service "github-runner-online" {
-  host_name = "ci"
-  check_command = "by_ssh"
-  check_interval = 5m
-  retry_interval = 1m
-  notes = "Runner service is active and connected to GitHub"
-  vars.by_ssh_command = "systemctl is-active --quiet github-runner.service"
-}
-

--- a/ansible/inventory/host_vars/ci.yml
+++ b/ansible/inventory/host_vars/ci.yml
@@ -12,16 +12,10 @@ firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }
 
 # Monitoring — register on mon (new host, not in legacy infra-vms.conf).
+# The runner-health check lives in configs/mon/icinga2/services/github-runner.conf
+# (Prometheus query on node_systemd_unit_state) — no by_ssh trust plumbing needed.
 monitoring_register: true
 monitoring_role: ci
-monitoring_extra_services:
-  - name: github-runner-online
-    check_command: by_ssh
-    interval: 5m
-    retry: 1m
-    notes: "Runner service is active and connected to GitHub"
-    vars:
-      by_ssh_command: "systemctl is-active --quiet github-runner.service"
 
 # Logs — ship journald to log VM.
 logs_register: true

--- a/configs/mon/icinga2/services/github-runner.conf
+++ b/configs/mon/icinga2/services/github-runner.conf
@@ -1,0 +1,38 @@
+// /etc/icinga2/conf.d/services/github-runner.conf — self-hosted GitHub Actions
+// runner health via Prometheus (node_exporter systemd collector). No SSH, no
+// remote plugin exec — node_systemd_unit_state{...,state="active"} is 1 when
+// the runner service is up, 0 otherwise.
+
+object CheckCommand "prom_systemd_unit" {
+  command = [ PluginDir + "/check_prom_query" ]
+
+  arguments = {
+    "-u" = "$prom_url$"
+    "-q" = {{
+      var inst = macro("$prom_instance$")
+      var unit = macro("$systemd_unit$")
+      return "node_systemd_unit_state{instance=\"" + inst + "\",name=\"" + unit + "\",state=\"active\"}"
+    }}
+    "-w" = "1"
+    "-c" = "1"
+    "-o" = "lt"
+    "-n" = "active"
+    "-f" = "%d"
+  }
+
+  vars.prom_url = "http://localhost:9090"
+}
+
+apply Service "github-runner" {
+  check_command = "prom_systemd_unit"
+  check_interval = 2m
+  retry_interval = 1m
+
+  notes = "Self-hosted GitHub Actions runner service is active"
+
+  vars.prom_instance = host.vars.prom_instance_node
+  vars.systemd_unit = "github-runner.service"
+
+  // ci is the only runner today; key on a host var when a second one lands.
+  assign where host.name == "ci"
+}


### PR DESCRIPTION
## Summary

The `github-runner-online` Icinga check (shipped in `host_vars/ci.yml` with feat/0a) was `by_ssh`, but the by_ssh trust plumbing — a `nagios` SSH key + `known_hosts` on `mon` — isn't on `main` (PR #51's territory). It sat `UNKNOWN`: *"Host key verification failed"*.

Replaced with a Prometheus-query check, matching the repo's existing pattern (`disk.conf`, `postgres.conf` wrap the `check_prom_query` plugin):

- New `configs/mon/icinga2/services/github-runner.conf` — `prom_systemd_unit` CheckCommand + `apply Service "github-runner"` querying `node_systemd_unit_state{name="github-runner.service",state="active"}` (CRIT when 0). ci's node_exporter already exposes this and `mon` already scrapes it — verified live.
- `host_vars/ci.yml` — dropped the `monitoring_extra_services` by_ssh block.
- `ansible/generated/ci/icinga_host.conf` — regenerated without the stale service.

No SSH, no new trust plumbing.

## Test plan

- [x] `ansible-playbook playbooks/monitoring.yml --tags validate --limit ci` renders clean
- [ ] CI: lint + render-check + Sourcery green (this PR is also the first end-to-end exercise of the lane)
- [ ] After apply: `github-runner` service shows `OK` on `mon`; old `github-runner-online` gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the CI runner health check to use a Prometheus-based Icinga service instead of an SSH-based check and clean up related configuration.

New Features:
- Add a dedicated Icinga service configuration that monitors the GitHub Actions runner via a Prometheus systemd unit query.

Enhancements:
- Document the new Prometheus-based runner health check location in the CI host vars.
- Simplify monitoring configuration by relying on existing Prometheus/node_exporter data instead of remote SSH checks.

Chores:
- Regenerate the CI Icinga host configuration to remove the obsolete SSH-based runner check.