### PR TITLE
vault_agent: parameterize systemd ExecStartPre dirs

### DIFF
--- a/ansible/roles/vault_agent/templates/vault-agent.service.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.service.j2
@@ -10,9 +10,13 @@ Wants=network-online.target
 Type=simple
 User=root
 Group=root
-ExecStartPre=/bin/mkdir -p /run/noc-agent
-ExecStartPre=/bin/chgrp noc-agent /run/noc-agent
-ExecStartPre=/bin/chmod 0750 /run/noc-agent
+{# Recreate the consumer's volatile (/run) dirs on boot — tmpfs is wiped.
+   Persistent dirs (e.g. /etc/*) are handled by the role's file task. #}
+{% for d in vault_agent_extra_dirs if d.path.startswith('/run/') %}
+ExecStartPre=/bin/mkdir -p {{ d.path }}
+ExecStartPre=/bin/chgrp {{ d.group | default('root') }} {{ d.path }}
+ExecStartPre=/bin/chmod {{ d.mode | default('0750') }} {{ d.path }}
+{% endfor %}
 ExecStart=/usr/bin/vault agent -config={{ vault_agent_config_dir }}/{{ vault_agent_name }}.hcl
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always


### PR DESCRIPTION
## Summary

Follow-up to the vault_agent role generalization (#57). That PR parameterized `defaults`, `tasks`, and `vault-agent.hcl.j2` but **missed `vault-agent.service.j2`** — its `ExecStartPre` lines still hardcoded `/run/noc-agent` + `chgrp noc-agent`. The `github-runner` consumer's unit therefore ran `chgrp noc-agent` on the `ci` host (no `noc-agent` group) and failed at startup.

Fix: loop `ExecStartPre` over the `/run/*` entries of `vault_agent_extra_dirs` (persistent `/etc/*` dirs are already handled by the role's file task, so they don't need boot-time recreation).

- **noc-agent**: rendered unit is **byte-identical** (verified — its `vault_agent_extra_dirs` has exactly one `/run/` entry).
- **github-runner**: no `ExecStartPre` dir lines (its only extra dir is `/etc/github-runner`, persistent).

## Test plan

- [x] noc-agent unit renders byte-identical (local Jinja diff)
- [ ] CI green
- [ ] After merge + `ci.yml` re-apply: `vault-agent-github-runner.service` starts, renders `/etc/github-runner/secrets.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parameterize the vault-agent systemd unit's ExecStartPre directory setup to respect the role's configurable extra directories.

New Features:
- Allow vault-agent systemd units to create and set permissions on volatile /run directories based on the vault_agent_extra_dirs configuration.

Bug Fixes:
- Prevent vault-agent consumers from failing at startup due to hardcoded /run/noc-agent directory and group assumptions in the systemd unit template.