### PR TITLE
ci: dedicated `ci` deploy user — stop SSHing as root

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -80,11 +80,16 @@ jobs:
             echo "::warning::/etc/github-runner/secrets.env not found — apply may fail on env-var lookups"
           fi
 
+      # -e ansible_user=ci: the runner connects as the dedicated `ci` deploy
+      # user on every host (created + NOPASSWD-root by the ci_runner_key role)
+      # and escalates with sudo — never root, never the operator's svag. An
+      # extra-var so it overrides per-host ansible_user (rtr/xoa=root, etc.).
       - name: Pre-deploy Icinga snapshot
         working-directory: ansible
         run: |
           ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
             --tags snapshot \
+            -e ansible_user=ci \
             -e snapshot_phase=pre
 
       - name: Render-only (dry run)
@@ -103,6 +108,7 @@ jobs:
         run: |
           ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
             --tags apply \
+            -e ansible_user=ci \
             -e "${{ inputs.playbook }}_apply=true" \
             ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
 
@@ -112,6 +118,7 @@ jobs:
         run: |
           ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
             --tags snapshot \
+            -e ansible_user=ci \
             -e snapshot_phase=post
 
       - name: Capture snapshot diff

--- a/ansible/roles/ci_runner_key/defaults/main.yml
+++ b/ansible/roles/ci_runner_key/defaults/main.yml
@@ -5,3 +5,9 @@ ci_runner_key_pub_path: "{{ ci_runner_key_path }}.pub"
 # Restricts the key so it only works when the connection comes from ci's
 # overlay address — a leaked key is useless from anywhere else.
 ci_runner_key_from_address: "{{ peers.ci.ipv6 }}"
+
+# Dedicated deploy user the ci runner connects as — never root, never the
+# operator's svag. Gets NOPASSWD root (sudo on Linux, doas on BSD) so
+# apply.yml's playbooks can escalate. apply.yml passes -e ansible_user=ci.
+ci_runner_user: ci
+ci_runner_user_shell: /bin/bash

--- a/ansible/roles/ci_runner_key/meta/main.yml
+++ b/ansible/roles/ci_runner_key/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: ci_runner_key
   author: AS215932 ops
-  description: Distribute id_ci.pub to all AS215932 hosts (restricted to the ci VM source)
+  description: Set up the ci deploy user + id_ci.pub on all AS215932 hosts (restricted to the ci VM source)
   license: proprietary
   min_ansible_version: "2.14"
   platforms:

--- a/ansible/roles/ci_runner_key/tasks/main.yml
+++ b/ansible/roles/ci_runner_key/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-# Add id_ci.pub to authorized_keys on every host. The user the key is
-# authorized for is determined by ssh_users in group_vars/all.yml (root for
-# rtr/xoa, svag elsewhere). The key is restricted via from="..." to only
-# accept connections originating from ci's overlay address.
+# Set up CI runner SSH access on this host: a dedicated `ci` deploy user with
+# NOPASSWD root, and id_ci.pub authorized for it — from="<ci-ipv6>"-restricted
+# so a leaked key is useless from anywhere else. apply.yml connects as this
+# user (-e ansible_user=ci) and escalates with sudo/doas; it never logs in as
+# root or as the operator's svag.
 
 - name: Read id_ci public key from controller
   slurp:
@@ -13,16 +14,57 @@
   become: false
   tags: [apply]
 
-- name: Determine target SSH user for this host
-  set_fact:
-    ci_runner_target_user: "{{ ssh_users[inventory_hostname] | default(ssh_users.default) }}"
+- name: Ensure the ci deploy user exists
+  user:
+    name: "{{ ci_runner_user }}"
+    shell: "{{ ci_runner_user_shell }}"
+    create_home: true
+    state: present
   tags: [apply]
 
-- name: Authorize id_ci for {{ ci_runner_target_user }} (restricted to ci's address)
+- name: Authorize id_ci for the ci deploy user (restricted to ci's address)
   authorized_key:
-    user: "{{ ci_runner_target_user }}"
+    user: "{{ ci_runner_user }}"
     key: "{{ ci_runner_key_pub.content | b64decode | trim }}"
     key_options: 'from="{{ ci_runner_key_from_address }}",no-port-forwarding,no-X11-forwarding,no-agent-forwarding'
     state: present
     comment: "ci runner on ci.as215932.net (managed by ansible/roles/ci_runner_key)"
+  tags: [apply]
+
+- name: Grant the ci deploy user NOPASSWD sudo (Linux)
+  copy:
+    dest: /etc/sudoers.d/ci-runner
+    content: "{{ ci_runner_user }} ALL=(ALL) NOPASSWD:ALL\n"
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"
+  when: ansible_os_family not in ["FreeBSD", "OpenBSD"]
+  tags: [apply]
+
+- name: Grant the ci deploy user NOPASSWD doas (BSD)
+  lineinfile:
+    path: "{{ '/usr/local/etc/doas.conf' if ansible_os_family == 'FreeBSD' else '/etc/doas.conf' }}"
+    line: "permit nopass {{ ci_runner_user }} as root"
+    create: true
+    owner: root
+    group: wheel
+    mode: "0644"
+    validate: "doas -C %s"
+  when: ansible_os_family in ["FreeBSD", "OpenBSD"]
+  tags: [apply]
+
+# PR #62 authorized id_ci for the host's normal SSH user (svag/root via
+# ssh_users) before the dedicated user existed — drop that stale entry.
+- name: Determine the legacy SSH user id_ci was previously authorized for
+  set_fact:
+    ci_runner_legacy_user: "{{ ssh_users[inventory_hostname] | default(ssh_users.default) }}"
+  tags: [apply]
+
+- name: Remove id_ci from the legacy user's authorized_keys
+  authorized_key:
+    user: "{{ ci_runner_legacy_user }}"
+    key: "{{ ci_runner_key_pub.content | b64decode | trim }}"
+    state: absent
+  when: ci_runner_legacy_user != ci_runner_user
   tags: [apply]

--- a/ansible/roles/firewall/tasks/snapshot.yml
+++ b/ansible/roles/firewall/tasks/snapshot.yml
@@ -4,12 +4,14 @@
 #
 # Skipped silently if mon is unreachable or the script doesn't exist yet;
 # this keeps the firewall play usable before the icinga_master role lands.
+#
+# Connects as mon's inventory user (svag from the workstation, ci from the
+# runner) and escalates with sudo — never a hardcoded root login, which only
+# ever worked with the operator's broadly-authorized id_servify.
 
 - name: "{{ snapshot_phase | capitalize }}-deploy Icinga snapshot"
   delegate_to: mon
-  become: false
-  vars:
-    ansible_user: root
+  become: true
   shell: |
     if [ -x /usr/local/bin/icinga-snapshot ]; then
       /usr/local/bin/icinga-snapshot {{ snapshot_phase }} firewall-rollout


### PR DESCRIPTION
## Summary

The `apply.yml` smoke test failed (twice) at the pre-deploy Icinga snapshot: `root@2a0c:b641:b50:2::50: Permission denied`. Root cause: `ansible/roles/firewall/tasks/snapshot.yml` hardcoded `vars: ansible_user: root` for the `mon` connection, overriding the inventory's `svag`. The runner SSHed `root@mon`, but `id_ci` is only authorized for `svag` (via `ssh_users`). That `root` login only ever worked from the operator workstation because `id_servify` is broadly authorized — it was wrong in principle and broken for the runner.

Fix — the runner gets its **own** user, never root, never the operator's `svag`:

- **`ci_runner_key` role** now creates a dedicated **`ci`** user on every host with **NOPASSWD root** (`sudo` on Linux, `doas` on BSD) and authorizes `id_ci` for it, `from="<ci-ipv6>"`-restricted. Drops the legacy `svag`/`root` authorization PR #62 added.
- **`snapshot.yml`** — remove the `ansible_user: root` override, `become: true`. Connects as the host's inventory user and escalates with sudo.
- **`apply.yml`** — pass `-e ansible_user=ci` so the runner connects as the dedicated user on every host (an extra-var, so it beats per-host `ansible_user` overrides like `rtr`/`xoa=root`).

## Test plan

- [x] `ansible-lint` / `yamllint` clean on the changed role + files
- [ ] CI green
- [ ] After merge: apply `ci-runner-key.yml` fleet-wide (creates the `ci` user), re-run the `apply.yml` smoke test — pre-deploy snapshot SSHes to `mon` as `ci` and escalates cleanly

## Notes

- FreeBSD core routers (`cr1-*`) will fail the `ci` user creation for the same reason as #64 (`ansible_become: false`) — tracked there; not a blocker for the smoke test (which only touches `mon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated non-root `ci` deploy user for CI-driven Ansible runs and update firewall snapshots and the apply workflow to use it.

New Features:
- Create a dedicated `ci` deploy user on all hosts with NOPASSWD root escalation for CI runs.

Bug Fixes:
- Fix CI firewall snapshot failures by removing hardcoded root SSH logins and using the appropriate inventory user with privilege escalation.

Enhancements:
- Refine the `ci_runner_key` role to provision the `ci` user, manage its sudo/doas permissions, and clean up legacy key authorizations.
- Update the apply GitHub Actions workflow to consistently connect as the `ci` deploy user via Ansible extra-vars.

CI:
- Adjust the apply workflow to pass `-e ansible_user=ci` for snapshot and apply steps, ensuring CI uses the dedicated deploy user.