### PR TITLE
[codex] Move customer services to hyrule.host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AS215932 Infrastructure Agent Guide
+
+## Domain Policy
+
+- `hyrule.host` is customer-facing Hyrule Cloud/product identity. Use it for the product site, public Hyrule Cloud API, and customer VM subdomains.
+- `servify.network` is infrastructure identity for nameservers, underlay and management references, provider relationships, internal UIs, and partner-facing hostnames.
+- `as215932.net` is AS215932 overlay/routing identity only. DNS records in this zone must point only at prefixes owned by AS215932.
+
+Do not blindly replace `servify.network`: nameservers, monitoring, Xen Orchestra, router hostnames, reverse DNS, Openprovider examples, and partner-facing infrastructure references are intentionally kept there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ This repo contains live router configs, service templates, provisioning scripts,
 - **Internal networking is IPv6-only** — no RFC1918. All VMs use public AS215932 addresses.
 - IPv4 exists only on dom0's WAN bridge (OVH-provided /32).
 - Domain policy:
-  - `hyrule.host`: customer-facing Hyrule Cloud/product services (`hyrule.host`, `cloud.hyrule.host`, `deploy.hyrule.host`).
-  - `servify.network`: infrastructure identity, including nameservers, underlay/management references, providers, internal UIs, and partner-facing hostnames.
-  - `as215932.net`: AS215932 overlay/routing identity only. DNS records in this zone must point only at prefixes owned by AS215932.
+  `AGENTS.md` is canonical. Keep customer-facing Hyrule Cloud identity under
+  `hyrule.host`, infrastructure identity under `servify.network`, and AS215932
+  overlay/routing identity under `as215932.net`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,10 @@ This repo contains live router configs, service templates, provisioning scripts,
 - **Prefix**: `2a0c:b641:b50::/44`
 - **Internal networking is IPv6-only** — no RFC1918. All VMs use public AS215932 addresses.
 - IPv4 exists only on dom0's WAN bridge (OVH-provided /32).
-- Domain: `servify.network` (public services), `as215932.net` (infrastructure names), `deploy.servify.network` (dynamic VM records)
+- Domain policy:
+  - `hyrule.host`: customer-facing Hyrule Cloud/product services (`hyrule.host`, `cloud.hyrule.host`, `deploy.hyrule.host`).
+  - `servify.network`: infrastructure identity, including nameservers, underlay/management references, providers, internal UIs, and partner-facing hostnames.
+  - `as215932.net`: AS215932 overlay/routing identity only. DNS records in this zone must point only at prefixes owned by AS215932.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ AS215932 is a solo project to build and operate a full-stack ISP with modern BGP
 
 ## Domain Policy
 
-- `hyrule.host` is customer-facing Hyrule Cloud/product identity: product site, public Hyrule Cloud API, and customer VM subdomains.
-- `servify.network` is infrastructure identity: nameservers, underlay/management references, provider relationships, internal UIs, and partner-facing hostnames.
-- `as215932.net` is AS215932 overlay/routing identity only. DNS records in this zone must point only at prefixes owned by AS215932.
+`AGENTS.md` is the canonical domain-policy reference for this repo. In short:
+`hyrule.host` is customer-facing Hyrule Cloud identity, `servify.network` is
+infrastructure identity, and `as215932.net` is AS215932 overlay/routing identity
+only.
 
 ### Internet Exchange Points
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ AS215932 is a solo project to build and operate a full-stack ISP with modern BGP
 - RPKI ROA configured
 - IRR objects registered (RIPE Database)
 
+## Domain Policy
+
+- `hyrule.host` is customer-facing Hyrule Cloud/product identity: product site, public Hyrule Cloud API, and customer VM subdomains.
+- `servify.network` is infrastructure identity: nameservers, underlay/management references, provider relationships, internal UIs, and partner-facing hostnames.
+- `as215932.net` is AS215932 overlay/routing identity only. DNS records in this zone must point only at prefixes owned by AS215932.
+
 ### Internet Exchange Points
 
 *Active IXP presence at multiple locations - see [PeeringDB](https://www.peeringdb.com/asn/215932) for current list*

--- a/ansible/generated/dns/knot.conf
+++ b/ansible/generated/dns/knot.conf
@@ -21,7 +21,7 @@ database:
 key:
   - id: hyrule-dns
     algorithm: hmac-sha256
-    secret: "vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8="
+    secret: "render-stub"
 
 # --- Primary: notifies + serves AXFR to secondaries -----------------------
 remote:
@@ -66,6 +66,12 @@ template:
 
 zone:
   - domain: servify.network
+    acl: [ api-update, caddy-update, irc-update, home-xfr, ns2-xfr ]
+    template: default
+  - domain: hyrule.host
+    acl: [ api-update, caddy-update, irc-update, home-xfr, ns2-xfr ]
+    template: default
+  - domain: deploy.hyrule.host
     acl: [ api-update, caddy-update, irc-update, home-xfr, ns2-xfr ]
     template: default
   - domain: as215932.net

--- a/ansible/generated/extmon/blackbox.yml
+++ b/ansible/generated/extmon/blackbox.yml
@@ -75,7 +75,29 @@ modules:
       query_type: SOA
       validate_answer_rrs:
         fail_if_not_matches_regexp:
-          - ".*ns1\\.servify.network\\..*"
+          - ".*ns1.servify.network\\..*"
+  dns_soa_hyrule_host:
+    prober: dns
+    timeout: 5s
+    dns:
+      preferred_ip_protocol: ip6
+      ip_protocol_fallback: true
+      query_name: hyrule.host
+      query_type: SOA
+      validate_answer_rrs:
+        fail_if_not_matches_regexp:
+          - ".*ns1.servify.network\\..*"
+  dns_soa_deploy_hyrule_host:
+    prober: dns
+    timeout: 5s
+    dns:
+      preferred_ip_protocol: ip6
+      ip_protocol_fallback: true
+      query_name: deploy.hyrule.host
+      query_type: SOA
+      validate_answer_rrs:
+        fail_if_not_matches_regexp:
+          - ".*ns1.servify.network\\..*"
   dns_soa_as215932_net:
     prober: dns
     timeout: 5s
@@ -86,4 +108,4 @@ modules:
       query_type: SOA
       validate_answer_rrs:
         fail_if_not_matches_regexp:
-          - ".*ns1\\.as215932.net\\..*"
+          - ".*ns1.servify.network\\..*"

--- a/ansible/generated/extmon/prometheus.yml
+++ b/ansible/generated/extmon/prometheus.yml
@@ -30,10 +30,10 @@ scrape_configs:
       module: [http_2xx_v6]
     static_configs:
       - targets:
-          - 'https://servify.network/'
-          - 'https://www.servify.network/'
-          - 'https://api.servify.network/healthz'
-          - 'https://hyrule.servify.network/'
+          - 'https://hyrule.host/'
+          - 'https://www.hyrule.host/'
+          - 'https://cloud.hyrule.host/health'
+          - 'https://api.hyrule.host/health'
           - 'https://mon.servify.network/'
     relabel_configs:
       - source_labels: [__address__]
@@ -141,6 +141,102 @@ scrape_configs:
       - targets: ['54.38.14.218:53']
         labels:
           zone: 'servify.network'
+          nameserver: 'ns2-v4'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-hyrule_host-ns1'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_hyrule_host]
+    static_configs:
+      - targets: ['[2a0c:b641:b50:2::10]:53']
+        labels:
+          zone: 'hyrule.host'
+          nameserver: 'ns1'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-hyrule_host-ns2-v6'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_hyrule_host]
+    static_configs:
+      - targets: ['[2001:41d0:304:300::7bfb]:53']
+        labels:
+          zone: 'hyrule.host'
+          nameserver: 'ns2-v6'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-hyrule_host-ns2-v4'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_hyrule_host]
+    static_configs:
+      - targets: ['54.38.14.218:53']
+        labels:
+          zone: 'hyrule.host'
+          nameserver: 'ns2-v4'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-deploy_hyrule_host-ns1'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_deploy_hyrule_host]
+    static_configs:
+      - targets: ['[2a0c:b641:b50:2::10]:53']
+        labels:
+          zone: 'deploy.hyrule.host'
+          nameserver: 'ns1'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-deploy_hyrule_host-ns2-v6'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_deploy_hyrule_host]
+    static_configs:
+      - targets: ['[2001:41d0:304:300::7bfb]:53']
+        labels:
+          zone: 'deploy.hyrule.host'
+          nameserver: 'ns2-v6'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: '127.0.0.1:9115'
+  - job_name: 'blackbox-dns-deploy_hyrule_host-ns2-v4'
+    metrics_path: /probe
+    params:
+      module: [dns_soa_deploy_hyrule_host]
+    static_configs:
+      - targets: ['54.38.14.218:53']
+        labels:
+          zone: 'deploy.hyrule.host'
           nameserver: 'ns2-v4'
     relabel_configs:
       - source_labels: [__address__]

--- a/ansible/generated/ns2/knot.conf
+++ b/ansible/generated/ns2/knot.conf
@@ -21,7 +21,7 @@ database:
 key:
   - id: hyrule-dns
     algorithm: hmac-sha256
-    secret: "vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8="
+    secret: "render-stub"
 
 # --- Secondary: pulls AXFR from primary -----------------------------------
 remote:
@@ -44,6 +44,8 @@ template:
 
 zone:
   - domain: servify.network
+  - domain: hyrule.host
+  - domain: deploy.hyrule.host
   - domain: as215932.net
   - domain: 0.5.b.0.1.4.6.b.c.0.a.2.ip6.arpa
 

--- a/ansible/inventory/group_vars/nameservers.yml
+++ b/ansible/inventory/group_vars/nameservers.yml
@@ -12,5 +12,7 @@ knot_tsig_secret: "{{ lookup('env', 'TSIG_SECRET') }}"
 # from /var/lib/knot/zones/<name>.zone; the secondary (ns2) AXFR-pulls.
 knot_zones:
   - name: servify.network
+  - name: hyrule.host
+  - name: deploy.hyrule.host
   - name: as215932.net
   - name: 0.5.b.0.1.4.6.b.c.0.a.2.ip6.arpa   # /48 = 12 nibbles of 2a0c:b641:0b50

--- a/ansible/inventory/host_vars/dns.yml
+++ b/ansible/inventory/host_vars/dns.yml
@@ -1,7 +1,7 @@
 ---
-# dns — Knot authoritative DNS (primary "ns1") for as215932.net, servify.network,
-# and reverse zones. Reachable from public internet (via DNAT on rtr for v4 +
-# direct on v6).
+# dns — Knot authoritative DNS (primary "ns1") for customer, infrastructure,
+# AS215932, and reverse zones. Reachable from public internet (via DNAT on rtr
+# for v4 + direct on v6).
 
 # --- Knot role ---
 knot_role: primary

--- a/ansible/inventory/host_vars/web.yml
+++ b/ansible/inventory/host_vars/web.yml
@@ -1,5 +1,5 @@
 ---
-# web — hyrule-web (uvicorn :8080 servify.network) + nginx (:8081 as215932.net).
+# web — hyrule-web (uvicorn :8080 hyrule.host) + nginx (:8081 as215932.net).
 
 firewall_extra_rules:
   - { proto: tcp, dport: 8080, src: "{{ peers.proxy.ipv6 }}", comment: "hyrule-web upstream from proxy" }

--- a/ansible/roles/extmon/defaults/main.yml
+++ b/ansible/roles/extmon/defaults/main.yml
@@ -24,10 +24,10 @@ extmon_alert_repeat_interval: 1h
 
 # Public HTTPS endpoints — full TLS handshake + 2xx/3xx response.
 extmon_http_targets:
-  - https://servify.network/
-  - https://www.servify.network/
-  - https://api.servify.network/healthz
-  - https://hyrule.servify.network/
+  - https://hyrule.host/
+  - https://www.hyrule.host/
+  - https://cloud.hyrule.host/health
+  - https://api.hyrule.host/health
   - https://mon.servify.network/
 
 # Pure ICMP-v4. Failover IPs that must be reachable from the open internet.
@@ -61,8 +61,14 @@ extmon_dns_targets:
     name: ns2-v4
 
 extmon_dns_zones:
-  - servify.network
-  - as215932.net
+  - name: servify.network
+    expected_soa_mname: ns1.servify.network
+  - name: hyrule.host
+    expected_soa_mname: ns1.servify.network
+  - name: deploy.hyrule.host
+    expected_soa_mname: ns1.servify.network
+  - name: as215932.net
+    expected_soa_mname: ns1.servify.network
 
 # --- OVH expiry collector (C/L0b) ---
 extmon_ovh_collector_interval: "*-*-* *:0/15:00"   # every 15 minutes

--- a/ansible/roles/extmon/templates/blackbox.yml.j2
+++ b/ansible/roles/extmon/templates/blackbox.yml.j2
@@ -67,15 +67,17 @@ modules:
         - send: "QUIT"
 
 {% for zone in extmon_dns_zones %}
-  dns_soa_{{ zone | replace('.', '_') }}:
+{% set zone_name = zone.name if zone is mapping else zone %}
+{% set expected_soa_mname = zone.expected_soa_mname | default('ns1.' ~ zone_name) %}
+  dns_soa_{{ zone_name | replace('.', '_') }}:
     prober: dns
     timeout: 5s
     dns:
       preferred_ip_protocol: ip6
       ip_protocol_fallback: true
-      query_name: {{ zone }}
+      query_name: {{ zone_name }}
       query_type: SOA
       validate_answer_rrs:
         fail_if_not_matches_regexp:
-          - ".*ns1\\.{{ zone }}\\..*"
+          - ".*{{ expected_soa_mname }}\\..*"
 {% endfor %}

--- a/ansible/roles/extmon/templates/prometheus.yml.j2
+++ b/ansible/roles/extmon/templates/prometheus.yml.j2
@@ -101,15 +101,16 @@ scrape_configs:
 
   # --- DNS auth checks: SOA queries against ns1 + ns2 for each managed zone. ---
 {% for zone in extmon_dns_zones %}
+{% set zone_name = zone.name if zone is mapping else zone %}
 {% for ns in extmon_dns_targets %}
-  - job_name: 'blackbox-dns-{{ zone | replace(".", "_") }}-{{ ns.name }}'
+  - job_name: 'blackbox-dns-{{ zone_name | replace(".", "_") }}-{{ ns.name }}'
     metrics_path: /probe
     params:
-      module: [dns_soa_{{ zone | replace('.', '_') }}]
+      module: [dns_soa_{{ zone_name | replace('.', '_') }}]
     static_configs:
       - targets: ['{{ ns.server }}']
         labels:
-          zone: '{{ zone }}'
+          zone: '{{ zone_name }}'
           nameserver: '{{ ns.name }}'
     relabel_configs:
       - source_labels: [__address__]

--- a/configs/Caddyfile.j2
+++ b/configs/Caddyfile.j2
@@ -13,8 +13,8 @@
     email {{ acme_email | default('admin@servify.network') }}
 }
 
-# API — api.servify.network
-api.servify.network {
+# API — cloud.hyrule.host (canonical) and api.hyrule.host (compatibility)
+cloud.hyrule.host, api.hyrule.host {
     tls {
         dns rfc2136 {
             server [2a0c:b641:b50:2::10]:53
@@ -46,11 +46,11 @@ api.servify.network {
     }
 }
 
-# Web frontend — servify.network (+ www redirect to apex).
+# Web frontend — hyrule.host (+ www redirect to apex).
 # Both subjects share one site block so the TLS/proxy/header config isn't
 # duplicated. Caddy issues per-subject certs (not a SAN). Matches the
 # as215932.net block below.
-servify.network, www.servify.network {
+hyrule.host, www.hyrule.host {
     tls {
         dns rfc2136 {
             server [2a0c:b641:b50:2::10]:53
@@ -61,8 +61,8 @@ servify.network, www.servify.network {
         propagation_delay 60s
     }
 
-    @www host www.servify.network
-    redir @www https://servify.network{uri} permanent
+    @www host www.hyrule.host
+    redir @www https://hyrule.host{uri} permanent
 
     reverse_proxy [2a0c:b641:b50:2::30]:8080 {
         transport http {
@@ -262,7 +262,7 @@ vault.as215932.net {
 }
 
 # Wildcard for customer VM subdomains (future — HTTPS proxy to VMs)
-# *.deploy.servify.network {
+# *.deploy.hyrule.host {
 #     tls {
 #         dns rfc2136 { ... }
 #     }

--- a/configs/as215932.net.zone
+++ b/configs/as215932.net.zone
@@ -20,7 +20,7 @@ $TTL 3600
 
 ; --- Mail for AS215932 operational role accounts ---
 @       IN  MX    10 mail.as215932.net.
-@       IN  TXT   "v=spf1 ip4:51.91.236.215 ip6:2a0c:b641:b50:2::90 -all"
+@       IN  TXT   "v=spf1 ip6:2a0c:b641:b50:2::90 -all"
 _dmarc  IN  TXT   "v=DMARC1; p=none; rua=mailto:noc@as215932.net; adkim=s; aspf=s"
 ; DKIM selector for Rspamd signing on mail.as215932.net.
 dkim._domainkey IN TXT ( "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxF/V0NkAuLkXFZ6WVPqTrdi1na7DZKHXFl605qBrhhgiFM6oR65kPivhwKcP7S+8PsbxAIzZb2irl1RUZqeTrYigsetugKyg7ONX1o5C9+JEO+BuY4ug6Lg9LRMy00q+DNKV7HxD"
@@ -42,7 +42,6 @@ mon     IN  AAAA  2a0c:b641:b50:2::50
 vpn     IN  AAAA  2a0c:b641:b50:2::60
 xoa     IN  AAAA  2a0c:b641:b50:2::70
 irc     IN  AAAA  2a0c:b641:b50:2::80
-mail    IN  A     51.91.236.215
 mail    IN  AAAA  2a0c:b641:b50:2::90
 noc     IN  AAAA  2a0c:b641:b50:2::a0
 

--- a/configs/deploy.hyrule.host.zone
+++ b/configs/deploy.hyrule.host.zone
@@ -1,0 +1,16 @@
+; /var/lib/knot/zones/deploy.hyrule.host.zone
+; Deploy to: dns VM (2a0c:b641:b50:2::10)
+
+$ORIGIN deploy.hyrule.host.
+$TTL 300
+
+@       IN  SOA   ns1.servify.network. admin.servify.network. (
+                  2026051501 ; serial (YYYYMMDDNN)
+                  3600       ; refresh (1h)
+                  900        ; retry (15m)
+                  604800     ; expire (7d)
+                  300 )      ; negative TTL (5m)
+
+; Dynamic customer VM AAAA records are written here by hyrule-cloud via RFC 2136.
+@       IN  NS    ns1.servify.network.
+@       IN  NS    ns2.servify.network.

--- a/configs/hyrule-cloud.env.j2
+++ b/configs/hyrule-cloud.env.j2
@@ -56,7 +56,7 @@ PAYMENT_PRICE_DOMAIN_MARKUP=1.00
 PAYMENT_DEV_BYPASS_SECRET={{ dev_bypass_secret | default('') }}
 
 # --- Hyrule ---
-HYRULE_DEPLOY_DOMAIN=deploy.servify.network
+HYRULE_DEPLOY_DOMAIN=deploy.hyrule.host
 
 # DNS (RFC 2136 dynamic updates to Knot DNS)
 HYRULE_DNS_SERVER=2a0c:b641:b50:2::10

--- a/configs/hyrule.host.zone
+++ b/configs/hyrule.host.zone
@@ -1,0 +1,32 @@
+; /var/lib/knot/zones/hyrule.host.zone
+; Deploy to: dns VM (2a0c:b641:b50:2::10)
+
+$ORIGIN hyrule.host.
+$TTL 3600
+
+@       IN  SOA   ns1.servify.network. admin.servify.network. (
+                  2026051501 ; serial (YYYYMMDDNN)
+                  3600       ; refresh (1h)
+                  900        ; retry (15m)
+                  604800     ; expire (7d)
+                  300 )      ; negative TTL (5m)
+
+; Nameservers are infrastructure identity, intentionally under servify.network.
+@       IN  NS    ns1.servify.network.
+@       IN  NS    ns2.servify.network.
+
+; Hyrule Cloud customer-facing product site via Caddy on proxy.
+@       IN  A     46.105.40.223
+@       IN  AAAA  2a0c:b641:b50:2::40
+www     IN  A     46.105.40.223
+www     IN  AAAA  2a0c:b641:b50:2::40
+
+; Hyrule Cloud API via Caddy on proxy. cloud is canonical; api is compatibility.
+cloud   IN  A     46.105.40.223
+cloud   IN  AAAA  2a0c:b641:b50:2::40
+api     IN  A     46.105.40.223
+api     IN  AAAA  2a0c:b641:b50:2::40
+
+; Delegate customer VM records to the deploy.hyrule.host zone served by Knot.
+deploy  IN  NS    ns1.servify.network.
+deploy  IN  NS    ns2.servify.network.

--- a/configs/icinga2/services/dns-v4-dnat.conf
+++ b/configs/icinga2/services/dns-v4-dnat.conf
@@ -14,7 +14,7 @@ apply Service "dns-v4-public-dnat" {
   check_interval = 2m
   retry_interval = 30s
 
-  vars.dns_lookup = "servify.network"
+  vars.dns_lookup = "hyrule.host"
   vars.dns_record_type = "SOA"
   vars.dns_server = "46.105.40.223"
 

--- a/configs/mon/icinga2/services/dns.conf
+++ b/configs/mon/icinga2/services/dns.conf
@@ -6,7 +6,7 @@ apply Service "dns-resolution" {
   check_interval = 1m
   retry_interval = 30s
 
-  vars.dns_lookup = "servify.network"
+  vars.dns_lookup = "hyrule.host"
   vars.dns_record_type = "AAAA"
   vars.dns_expected_answer = "2a0c:b641:b50:2::40"
   vars.dns_server = "2a0c:b641:b50:2::10"
@@ -20,7 +20,7 @@ apply Service "dns-soa" {
   check_interval = 5m
   retry_interval = 1m
 
-  vars.dns_lookup = "servify.network"
+  vars.dns_lookup = "hyrule.host"
   vars.dns_record_type = "SOA"
   vars.dns_server = "2a0c:b641:b50:2::10"
 

--- a/configs/mon/icinga2/services/http.conf
+++ b/configs/mon/icinga2/services/http.conf
@@ -16,8 +16,8 @@ apply Service "http-api-health" {
   retry_interval = 30s
   max_check_attempts = 3
 
-  vars.http_vhost = "api.servify.network"
-  vars.http_address = "api.servify.network"
+  vars.http_vhost = "cloud.hyrule.host"
+  vars.http_address = "cloud.hyrule.host"
   vars.http_uri = "/health"
   vars.http_ssl = true
   vars.http_sni = true
@@ -36,7 +36,7 @@ apply Service "http-api-health-backend" {
   vars.http_address = "2a0c:b641:b50:2::20"
   vars.http_port = 8402
   vars.http_uri = "/health"
-  vars.http_vhost = "api.servify.network"
+  vars.http_vhost = "cloud.hyrule.host"
   vars.http_ssl = false
   vars.http_ipv6 = true
   vars.http_timeout = 15
@@ -50,8 +50,8 @@ apply Service "http-web" {
   retry_interval = 30s
   max_check_attempts = 3
 
-  vars.http_vhost = "servify.network"
-  vars.http_address = "servify.network"
+  vars.http_vhost = "hyrule.host"
+  vars.http_address = "hyrule.host"
   vars.http_uri = "/"
   vars.http_ssl = true
   vars.http_sni = true
@@ -70,7 +70,7 @@ apply Service "http-web-backend" {
   vars.http_address = "2a0c:b641:b50:2::30"
   vars.http_port = 8080
   vars.http_uri = "/"
-  vars.http_vhost = "servify.network"
+  vars.http_vhost = "hyrule.host"
   vars.http_ssl = false
   vars.http_ipv6 = true
   vars.http_timeout = 15

--- a/configs/mon/icinga2/services/ssl.conf
+++ b/configs/mon/icinga2/services/ssl.conf
@@ -3,13 +3,13 @@
 // Check all public-facing TLS certificates via the proxy VM.
 // Caddy handles TLS termination for all subdomains.
 
-apply Service "ssl-servify" {
+apply Service "ssl-hyrule" {
   check_command = "ssl"
   check_interval = 12h
   retry_interval = 1h
 
-  vars.ssl_address = "servify.network"
-  vars.ssl_sni = "servify.network"
+  vars.ssl_address = "hyrule.host"
+  vars.ssl_sni = "hyrule.host"
   vars.ssl_port = 443
   vars.ssl_cert_valid_days_warn = 14
   vars.ssl_cert_valid_days_critical = 7
@@ -22,8 +22,8 @@ apply Service "ssl-api" {
   check_interval = 12h
   retry_interval = 1h
 
-  vars.ssl_address = "api.servify.network"
-  vars.ssl_sni = "api.servify.network"
+  vars.ssl_address = "cloud.hyrule.host"
+  vars.ssl_sni = "cloud.hyrule.host"
   vars.ssl_port = 443
   vars.ssl_cert_valid_days_warn = 14
   vars.ssl_cert_valid_days_critical = 7

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -153,8 +153,8 @@ scrape_configs:
       module: [http_2xx]
     static_configs:
       - targets:
-          - "https://servify.network/"
-          - "https://api.servify.network/health"
+          - "https://hyrule.host/"
+          - "https://cloud.hyrule.host/health"
           - "https://grafana.servify.network/api/health"
           - "https://mon.servify.network/"
           - "https://vault.as215932.net/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"

--- a/configs/rtr/unbound/as215932-stubs.conf
+++ b/configs/rtr/unbound/as215932-stubs.conf
@@ -2,8 +2,8 @@
 # Deploy to: rtr (2a0c:b641:b50:2::1)
 #
 # Short-circuits resolution of our own zones to Knot on the dns VM, bypassing
-# the public NS chain. Without this, queries for servify.network/as215932.net
-# walk root → .net → registrar NS list, which includes flaky openprovider
+# the public NS chain. Without this, queries for servify.network/hyrule.host/
+# as215932.net walk root → TLD → registrar NS list, which includes flaky openprovider
 # secondaries (intermittently unreachable). When one of those NSes is dead,
 # AAAA lookups stall ~10s and surface as "Socket timeout" on Icinga http checks.
 #
@@ -11,10 +11,22 @@
 
 server:
     domain-insecure: "servify.network"
+    domain-insecure: "hyrule.host"
+    domain-insecure: "deploy.hyrule.host"
     domain-insecure: "as215932.net"
 
 stub-zone:
     name: "servify.network"
+    stub-addr: 2a0c:b641:b50:2::10
+    stub-prime: no
+
+stub-zone:
+    name: "hyrule.host"
+    stub-addr: 2a0c:b641:b50:2::10
+    stub-prime: no
+
+stub-zone:
+    name: "deploy.hyrule.host"
     stub-addr: 2a0c:b641:b50:2::10
     stub-prime: no
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -317,8 +317,8 @@ Rolling back is the same pattern with a git ref:
 35. Create proxy VM via XO CloudConfig: 1 vCPU, 1GB, 10GB, infra network, `::40`
 36. Install Caddy (built with `xcaddy --with github.com/caddy-dns/rfc2136`)
 37. Deploy Caddyfile:
-    - `servify.network` → `http://[2a0c:b641:b50:2::30]:8080` (web)
-    - `api.servify.network` → `http://[2a0c:b641:b50:2::20]:8402` (api)
+    - `hyrule.host` → `http://[2a0c:b641:b50:2::30]:8080` (web)
+    - `cloud.hyrule.host` → `http://[2a0c:b641:b50:2::20]:8402` (api)
     - DNS-01 ACME via RFC 2136 against Knot DNS (`::10`)
 38. Deploy systemd unit, start service
 
@@ -356,8 +356,9 @@ firewall/NAT design instead. Use `2a0c:b641:b50:2::1` as the VM resolver;
 `dns`/`ns1` is authoritative-only.
 
 The dedicated OVH failover IPv4 for mail is `51.91.236.215`; its PTR is
-configured in OVH as `mail.as215932.net`. The DNS A record and SPF `ip4:`
-mechanism live in `configs/as215932.net.zone`.
+configured in OVH as `mail.as215932.net`. The DNS AAAA record and SPF `ip6:`
+mechanism live in `configs/as215932.net.zone`; `as215932.net` records must not
+point at addresses outside AS215932-owned prefixes.
 
 Render and review:
 
@@ -395,7 +396,7 @@ BGP policy: `TRANSIT-IN` (as-path filter), `TRANSIT-OUT` (prefix-list). iBGP pee
 ### Phase 10: Smoke Test
 
 ```bash
-./scripts/smoke-test.sh servify.network <dev-bypass-secret>
+./scripts/smoke-test.sh hyrule.host <dev-bypass-secret>
 ```
 
 ## Key Notes

--- a/docs/extmon.md
+++ b/docs/extmon.md
@@ -34,7 +34,7 @@ reaches Discord directly via outbound TLS — no inbound exposure required.
 
 Configured in [`roles/extmon/defaults/main.yml`](../ansible/roles/extmon/defaults/main.yml):
 
-- `extmon_http_targets` — public HTTPS endpoints (servify.network, api,
+- `extmon_http_targets` — public HTTPS endpoints (hyrule.host, cloud,
   hyrule, mon).
 - `extmon_icmp_v4_targets` — failover IPs that *must* be reachable from the
   open internet (`46.105.40.223`, `51.91.236.215`, `54.38.14.218`).

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -95,7 +95,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| proxy | TCP | 8080 | servify.network landing page |
+| proxy | TCP | 8080 | hyrule.host landing page |
 | proxy | TCP | 8081 | as215932.net info site |
 | mon | TCP | 9100 | node_exporter |
 | ops-prefix, vpn-clients | TCP | 22 | SSH |

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,8 +6,12 @@
 
 set -euo pipefail
 
-DOMAIN="${1:-hyrule.host}"
-API_DOMAIN="cloud.${DOMAIN}"
+CUSTOMER_DOMAIN="${1:-hyrule.host}"
+CUSTOMER_API_DOMAIN="cloud.${CUSTOMER_DOMAIN}"
+CUSTOMER_DEPLOY_DOMAIN="deploy.${CUSTOMER_DOMAIN}"
+INFRA_DOMAIN="servify.network"
+GRAFANA_DOMAIN="grafana.${INFRA_DOMAIN}"
+MON_DOMAIN="mon.${INFRA_DOMAIN}"
 DEV_BYPASS="${2:-}"
 PASS=0
 FAIL=0
@@ -28,44 +32,47 @@ check() {
 }
 
 echo "=== Hyrule Cloud Smoke Tests ==="
-echo "Domain: $DOMAIN"
-echo "API:    $API_DOMAIN"
+echo "Customer domain: $CUSTOMER_DOMAIN"
+echo "Customer API:    $CUSTOMER_API_DOMAIN"
+echo "Infra domain:    $INFRA_DOMAIN"
 echo ""
 
 # --- DNS ---
 echo "--- DNS ---"
-check "$DOMAIN AAAA record resolves" dig +short "$DOMAIN" AAAA | grep -q "2a0c:b641:b5"
-check "$API_DOMAIN AAAA record resolves" dig +short "$API_DOMAIN" AAAA | grep -q "2a0c:b641:b5"
-check "deploy.$DOMAIN NS record exists" dig +short "deploy.$DOMAIN" NS | grep -q .
+check "$CUSTOMER_DOMAIN AAAA record resolves" dig +short "$CUSTOMER_DOMAIN" AAAA | grep -q "2a0c:b641:b5"
+check "$CUSTOMER_API_DOMAIN AAAA record resolves" dig +short "$CUSTOMER_API_DOMAIN" AAAA | grep -q "2a0c:b641:b5"
+check "$CUSTOMER_DEPLOY_DOMAIN NS record exists" dig +short "$CUSTOMER_DEPLOY_DOMAIN" NS | grep -q .
 # Also check A records for dual-stack
-check "$DOMAIN A record resolves (dual-stack)" dig +short "$DOMAIN" A | grep -q .
+check "$CUSTOMER_DOMAIN A record resolves (dual-stack)" dig +short "$CUSTOMER_DOMAIN" A | grep -q .
 
 # --- HTTPS (prefer IPv6) ---
 echo ""
 echo "--- HTTPS ---"
-check "https://$DOMAIN returns 200 (IPv6)" curl -6 -sf "https://$DOMAIN/" -o /dev/null
-check "https://$API_DOMAIN/health returns 200 (IPv6)" curl -6 -sf "https://$API_DOMAIN/health" -o /dev/null
-check "https://$DOMAIN returns 200 (IPv4 fallback)" curl -4 -sf "https://$DOMAIN/" -o /dev/null
+check "https://$CUSTOMER_DOMAIN returns 200 (IPv6)" curl -6 -sf "https://$CUSTOMER_DOMAIN/" -o /dev/null
+check "https://$CUSTOMER_API_DOMAIN/health returns 200 (IPv6)" curl -6 -sf "https://$CUSTOMER_API_DOMAIN/health" -o /dev/null
+check "https://$CUSTOMER_DOMAIN returns 200 (IPv4 fallback)" curl -4 -sf "https://$CUSTOMER_DOMAIN/" -o /dev/null
 
 # --- API Endpoints ---
 echo ""
 echo "--- API Endpoints ---"
-check "GET /v1/pricing returns JSON" curl -6 -sf "https://$API_DOMAIN/v1/pricing" | python3 -m json.tool
-check "GET /v1/os/list returns JSON" curl -6 -sf "https://$API_DOMAIN/v1/os/list" | python3 -m json.tool
-check "x402 manifest at /.well-known/x402.json" curl -6 -sf "https://$API_DOMAIN/.well-known/x402.json" | python3 -m json.tool
+check "GET /v1/pricing returns JSON" curl -6 -sf "https://$CUSTOMER_API_DOMAIN/v1/pricing" | python3 -m json.tool
+check "GET /v1/os/list returns JSON" curl -6 -sf "https://$CUSTOMER_API_DOMAIN/v1/os/list" | python3 -m json.tool
+check "x402 manifest at /.well-known/x402.json" curl -6 -sf "https://$CUSTOMER_API_DOMAIN/.well-known/x402.json" | python3 -m json.tool
 
 # --- Web Frontend ---
 echo ""
 echo "--- Web Frontend ---"
-check "Homepage contains Hyrule" curl -6 -sf "https://$DOMAIN/" | grep -qi "hyrule"
-check "API proxy works (/api/v1/pricing)" curl -6 -sf "https://$DOMAIN/api/v1/pricing" | python3 -m json.tool
-check "Static assets load (htmx)" curl -6 -sf "https://$DOMAIN/static/htmx.min.js" -o /dev/null
+check "Homepage contains Hyrule" curl -6 -sf "https://$CUSTOMER_DOMAIN/" | grep -qi "hyrule"
+check "API proxy works (/api/v1/pricing)" curl -6 -sf "https://$CUSTOMER_DOMAIN/api/v1/pricing" | python3 -m json.tool
+check "Static assets load (htmx)" curl -6 -sf "https://$CUSTOMER_DOMAIN/static/htmx.min.js" -o /dev/null
 
 # --- Monitoring ---
 echo ""
 echo "--- Monitoring ---"
-check "grafana.servify.network returns 200 (IPv6)" curl -6 -sf "https://grafana.servify.network/api/health" -o /dev/null
-check "mon.servify.network returns 200 (IPv6)" curl -6 -sf "https://mon.servify.network/" -o /dev/null
+# Monitoring UIs remain under the infrastructure domain by policy; the
+# customer-domain argument above intentionally does not alter these checks.
+check "$GRAFANA_DOMAIN returns 200 (IPv6)" curl -6 -sf "https://$GRAFANA_DOMAIN/api/health" -o /dev/null
+check "$MON_DOMAIN returns 200 (IPv6)" curl -6 -sf "https://$MON_DOMAIN/" -o /dev/null
 check "Prometheus targets reachable" curl -6 -sf "http://[2a0c:b641:b50:2::50]:9090/api/v1/targets" -o /dev/null
 
 # --- VM Provisioning (requires dev bypass) ---
@@ -73,7 +80,7 @@ if [ -n "$DEV_BYPASS" ]; then
     echo ""
     echo "--- VM Provisioning ---"
 
-    CREATE_RESP=$(curl -6 -sf -X POST "https://$API_DOMAIN/v1/vm/create" \
+    CREATE_RESP=$(curl -6 -sf -X POST "https://$CUSTOMER_API_DOMAIN/v1/vm/create" \
         -H "Content-Type: application/json" \
         -H "X-DEV-BYPASS: $DEV_BYPASS" \
         -d '{
@@ -93,7 +100,7 @@ if [ -n "$DEV_BYPASS" ]; then
             # Poll for ready status (max 120s)
             echo "  Waiting for VM to become ready (max 120s)..."
             for i in $(seq 1 24); do
-                STATUS=$(curl -6 -sf "https://$API_DOMAIN/v1/vm/$VM_ID" | \
+                STATUS=$(curl -6 -sf "https://$CUSTOMER_API_DOMAIN/v1/vm/$VM_ID" | \
                     python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
                 if [ "$STATUS" = "ready" ]; then
                     break
@@ -106,14 +113,14 @@ if [ -n "$DEV_BYPASS" ]; then
                 ((PASS++))
 
                 # Check DNS AAAA record
-                HOSTNAME=$(curl -6 -sf "https://$API_DOMAIN/v1/vm/$VM_ID" | \
+                HOSTNAME=$(curl -6 -sf "https://$CUSTOMER_API_DOMAIN/v1/vm/$VM_ID" | \
                     python3 -c "import sys,json; print(json.load(sys.stdin).get('hostname',''))" 2>/dev/null || true)
                 if [ -n "$HOSTNAME" ]; then
                     check "DNS AAAA record for $HOSTNAME" dig +short "$HOSTNAME" AAAA | grep -q "2a0c:b641:b5"
                 fi
 
                 # Check IPv6 is from our prefix
-                VM_IP=$(curl -6 -sf "https://$API_DOMAIN/v1/vm/$VM_ID" | \
+                VM_IP=$(curl -6 -sf "https://$CUSTOMER_API_DOMAIN/v1/vm/$VM_ID" | \
                     python3 -c "import sys,json; print(json.load(sys.stdin).get('ipv6',''))" 2>/dev/null || true)
                 if [ -n "$VM_IP" ]; then
                     check "VM IPv6 is in AS215932 space" echo "$VM_IP" | grep -q "2a0c:b641:b5"
@@ -125,7 +132,7 @@ if [ -n "$DEV_BYPASS" ]; then
 
             # Cleanup
             echo "  Cleaning up test VM..."
-            curl -6 -sf -X DELETE "https://$API_DOMAIN/v1/vm/$VM_ID" \
+            curl -6 -sf -X DELETE "https://$CUSTOMER_API_DOMAIN/v1/vm/$VM_ID" \
                 -H "X-DEV-BYPASS: $DEV_BYPASS" >/dev/null 2>&1 || true
             green "Test VM cleanup requested"
             ((PASS++))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,8 +6,8 @@
 
 set -euo pipefail
 
-DOMAIN="${1:-servify.network}"
-API_DOMAIN="api.${DOMAIN}"
+DOMAIN="${1:-hyrule.host}"
+API_DOMAIN="cloud.${DOMAIN}"
 DEV_BYPASS="${2:-}"
 PASS=0
 FAIL=0
@@ -34,11 +34,11 @@ echo ""
 
 # --- DNS ---
 echo "--- DNS ---"
-check "servify.network AAAA record resolves" dig +short "$DOMAIN" AAAA | grep -q "2a0c:b641:b5"
-check "api.servify.network AAAA record resolves" dig +short "$API_DOMAIN" AAAA | grep -q "2a0c:b641:b5"
-check "deploy.servify.network NS record exists" dig +short "deploy.$DOMAIN" NS | grep -q .
+check "$DOMAIN AAAA record resolves" dig +short "$DOMAIN" AAAA | grep -q "2a0c:b641:b5"
+check "$API_DOMAIN AAAA record resolves" dig +short "$API_DOMAIN" AAAA | grep -q "2a0c:b641:b5"
+check "deploy.$DOMAIN NS record exists" dig +short "deploy.$DOMAIN" NS | grep -q .
 # Also check A records for dual-stack
-check "servify.network A record resolves (dual-stack)" dig +short "$DOMAIN" A | grep -q .
+check "$DOMAIN A record resolves (dual-stack)" dig +short "$DOMAIN" A | grep -q .
 
 # --- HTTPS (prefer IPv6) ---
 echo ""
@@ -64,8 +64,8 @@ check "Static assets load (htmx)" curl -6 -sf "https://$DOMAIN/static/htmx.min.j
 # --- Monitoring ---
 echo ""
 echo "--- Monitoring ---"
-check "grafana.servify.network returns 200 (IPv6)" curl -6 -sf "https://grafana.$DOMAIN/api/health" -o /dev/null
-check "mon.servify.network returns 200 (IPv6)" curl -6 -sf "https://mon.$DOMAIN/" -o /dev/null
+check "grafana.servify.network returns 200 (IPv6)" curl -6 -sf "https://grafana.servify.network/api/health" -o /dev/null
+check "mon.servify.network returns 200 (IPv6)" curl -6 -sf "https://mon.servify.network/" -o /dev/null
 check "Prometheus targets reachable" curl -6 -sf "http://[2a0c:b641:b50:2::50]:9090/api/v1/targets" -o /dev/null
 
 # --- VM Provisioning (requires dev bypass) ---


### PR DESCRIPTION
## Summary

- add hyrule.host and deploy.hyrule.host Knot zones while keeping servify.network nameservers as infrastructure identity
- move the Caddy customer-facing surface to hyrule.host, www.hyrule.host, cloud.hyrule.host, and compatibility api.hyrule.host
- update Hyrule Cloud env defaults, monitoring, smoke tests, docs, and agent guidance for the domain boundary policy
- enforce the as215932.net owned-prefix rule by removing the non-AS215932 mail A record and SPF ip4 mechanism

## Validation

- old customer servify.network hostname sweep returned no matches
- as215932.net A/ip4 sweep returned no matches
- git diff --check passed
- Knot render-only validation passed with TSIG_SECRET=render-stub and knot_apply=false
- Extmon render-only validation passed with extmon_apply=false

caddy validate was attempted against a temporary rendered Caddyfile, but the local Caddy binary lacks the required dns.providers.rfc2136 module, so production-equivalent Caddy validation could not be completed here.

No live deploy, DNS registrar update, or Caddy reload was performed.

## Summary by Sourcery

Move customer-facing Hyrule Cloud services from servify.network to the new hyrule.host domain while formalizing domain roles and tightening DNS policy for as215932.net.

New Features:
- Introduce hyrule.host and deploy.hyrule.host as managed Knot DNS zones and primary customer-facing domains for Hyrule Cloud web and API surfaces.

Enhancements:
- Update Caddy, monitoring (Icinga, Prometheus, extmon), and smoke-test tooling to target hyrule.host/cloud.hyrule.host endpoints instead of servify.network for customer traffic.
- Extend Unbound stub and insecure domain configuration to cover hyrule.host and deploy.hyrule.host for authoritative resolution via Knot.
- Clarify infrastructure vs product vs routing domain roles across configs and comments to keep servify.network as infrastructure identity.

Documentation:
- Document the domain policy for hyrule.host, servify.network, and as215932.net in README, CLAUDE, AGENTS, and operational docs, including the requirement that as215932.net records only reference AS215932-owned prefixes.
- Refresh deployment, monitoring, and extmon documentation to reflect hyrule.host-based endpoints and updated smoke-test usage.