### PR TITLE
vault-agent: bypass Caddy via internal IPv6

### DIFF
--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 vault_agent_name: noc-agent
-vault_agent_vault_addr: "https://vault.as215932.net"
+# Direct internal IPv6 so the secrets plane survives a Caddy/proxy outage.
+# The public hostname stays for external consumers (CI, ops workstation);
+# infra-side renewals run over the AS215932 /64, where MITM requires
+# already being inside the subnet — tls_skip_verify is acceptable.
+vault_agent_vault_addr: "https://[{{ peers.vault.ipv6 }}]:8200"
+vault_agent_vault_tls_skip_verify: true
 vault_agent_config_dir: "/etc/vault-agent.d"
 vault_agent_run_dir: "/run/vault-agent"
 vault_agent_role_id: ""

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -5,7 +5,7 @@ pid_file = "{{ vault_agent_run_dir }}/{{ vault_agent_name }}.pid"
 
 vault {
   address = "{{ vault_agent_vault_addr }}"
-{% if vault_agent_vault_tls_skip_verify | default(false) | bool %}
+{% if vault_agent_vault_tls_skip_verify | bool %}
   tls_skip_verify = true
 {% endif %}
 

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -5,6 +5,9 @@ pid_file = "{{ vault_agent_run_dir }}/{{ vault_agent_name }}.pid"
 
 vault {
   address = "{{ vault_agent_vault_addr }}"
+{% if vault_agent_vault_tls_skip_verify | default(false) | bool %}
+  tls_skip_verify = true
+{% endif %}
 
   retry {
     num_retries = 12

--- a/configs/mon/blackbox.yml
+++ b/configs/mon/blackbox.yml
@@ -34,3 +34,18 @@ modules:
       fail_if_ssl: false
       tls_config:
         insecure_skip_verify: false
+
+  # Same as http_2xx but accepts self-signed / SAN-mismatch certs. Used for
+  # internal-IPv6 probes against services whose cert SAN only lists the
+  # public hostname (e.g. Vault on [::c0]:8200 — see vault_agent_vault_addr).
+  http_2xx_skip_verify:
+    prober: http
+    timeout: 10s
+    http:
+      preferred_ip_protocol: ip6
+      ip_protocol_fallback: false
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      fail_if_ssl: false
+      tls_config:
+        insecure_skip_verify: true

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -166,6 +166,25 @@ scrape_configs:
       - target_label: __address__
         replacement: "[::1]:9115"
 
+  # Internal Vault probe — goes direct to [::c0]:8200, bypassing Caddy.
+  # Pair this with the public probe above to distinguish "Caddy down"
+  # (public fails, internal ok) from "Vault down" (both fail). Cert SAN
+  # doesn't cover the literal IPv6, so this uses http_2xx_skip_verify.
+  - job_name: blackbox-vault-internal
+    metrics_path: /probe
+    params:
+      module: [http_2xx_skip_verify]
+    static_configs:
+      - targets:
+          - "https://[2a0c:b641:b50:2::c0]:8200/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: "[::1]:9115"
+
   # --- Centralized logging pipeline (log VM at ::b0) ---
   # Vector exposes its own internal metrics on :8686 (parallel to node_exporter
   # on :9100, scraped via the node-infra job above). Loki exposes ingester /

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -170,6 +170,12 @@ scrape_configs:
   # Pair this with the public probe above to distinguish "Caddy down"
   # (public fails, internal ok) from "Vault down" (both fail). Cert SAN
   # doesn't cover the literal IPv6, so this uses http_2xx_skip_verify.
+  #
+  # The address below is the same value as `peers.vault.ipv6` in
+  # ansible/inventory/group_vars/all.yml; prometheus.yml is not
+  # Ansible-templated today (every scrape target here is a literal v6
+  # address — same convention as the surrounding node-* / blackbox jobs),
+  # so if Vault ever moves, update both locations together.
   - job_name: blackbox-vault-internal
     metrics_path: /probe
     params:


### PR DESCRIPTION
## Summary

- Switch the `vault-agent` role default from `https://vault.as215932.net` (Caddy-fronted) to `https://[{{ peers.vault.ipv6 }}]:8200` (direct internal IPv6) with `tls_skip_verify=true`.
- New `http_2xx_skip_verify` blackbox module + `blackbox-vault-internal` Prometheus job to pair with the existing public probe — together they distinguish "Caddy down" from "Vault down".

## Why now

On 2026-05-15 a Caddy outage cascaded into a NOC Agent failure: vault-agent on `noc` couldn't renew leases that back `/opt/noc-agent/.env`, the LLM API key went stale, `/health/model` returned 503, and triage aborted with *"infrastructure dependency failed"* — exactly when it was most needed. Same chain affects every other vault-agent consumer (`mon`, `api`, `web`, github-runner).

Internal vault-agent traffic now stays on the AS215932 `/64` and is independent of the public TLS frontend.

## Risk / scope

- Traffic stays on the internal AS215932 subnet, where an attacker would already need to be inside to MITM — `tls_skip_verify=true` is acceptable. Cert SAN does not cover `[::c0]`.
- Public `vault.as215932.net` Caddy route stays intact for CI runner, ops workstation, and the existing public blackbox probe.
- Companion PRs (monitoring user, model-health alert enrichment) land separately.

## Test plan

- [ ] `ansible-playbook playbooks/vault.yml --check --diff --limit noc` shows the new `vault-agent.hcl` (`address = "https://[2a0c:b641:b50:2::c0]:8200"`, `tls_skip_verify = true`).
- [ ] Apply on noc first, watch `journalctl -u vault-agent -f` — confirm it authenticates against `[::c0]:8200`, no Caddy hops.
- [ ] Stop Caddy on proxy (`systemctl stop caddy`), wait one lease renewal cycle (~4–5 min per the noc-agent vault restart loop memory), confirm `/opt/noc-agent/.env` still renders and `/health/model` stays 200.
- [ ] Restart Caddy; confirm public `https://vault.as215932.net/v1/sys/health` probe stays green; new `blackbox-vault-internal` job also reports `probe_success=1`.
- [ ] Roll out to remaining consumers (mon, api, web, vault-side github-runner) after noc soaks for one renewal cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route vault-agent traffic over internal IPv6 and add monitoring for internal Vault health alongside the existing public probe.

New Features:
- Add an internal Vault blackbox probe job that targets the Vault service directly over IPv6 and bypasses Caddy.
- Introduce an http_2xx_skip_verify blackbox module to allow probing services with self-signed or SAN-mismatched TLS certificates.
- Allow vault-agent to optionally skip TLS verification when connecting to Vault via a configurable flag.

Enhancements:
- Change the default vault-agent Vault address to use the internal IPv6 endpoint instead of the public Caddy-fronted hostname.