### PR TITLE
monitoring: dedicated user for icinga2 by_ssh, fixes Host key verification failed on cr1.*

### DIFF
--- a/ansible/inventory/host_vars/cr1-de1.yml
+++ b/ansible/inventory/host_vars/cr1-de1.yml
@@ -28,6 +28,13 @@ firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "node_exporter scrape from mon" }
   - { proto: tcp, dport: 9342, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "frr_exporter scrape from mon" }
 
+# mon's icinga2 by_ssh pubkey, authorized for the dedicated `monitoring`
+# user. Provisioned by the monitoring role on next apply; until then the
+# egress-* checks fail with "Host key verification failed" because no
+# user/known_hosts pairing exists. Set MONITORING_BY_SSH_PUBKEY in
+# secrets.local.sh.
+monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
+
 # --- Logs --- (issue #17: FreeBSD doesn't ship a vector pkg in modern
 # versions; ship via native syslogd @@host:6514 TCP forward instead.)
 logs_register: true

--- a/ansible/inventory/host_vars/cr1-nl1.yml
+++ b/ansible/inventory/host_vars/cr1-nl1.yml
@@ -25,6 +25,13 @@ firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "node_exporter scrape from mon" }
   - { proto: tcp, dport: 9342, src: "{{ peers.mon.ipv6 }}", family: inet6, comment: "frr_exporter scrape from mon" }
 
+# mon's icinga2 by_ssh pubkey, authorized for the dedicated `monitoring`
+# user. Provisioned by the monitoring role on next apply; until then the
+# egress-* checks fail with "Host key verification failed" because no
+# user/known_hosts pairing exists. Set MONITORING_BY_SSH_PUBKEY in
+# secrets.local.sh.
+monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
+
 # --- Logs --- (issue #17: FreeBSD doesn't ship a vector pkg in modern
 # versions; ship via native syslogd @@host:6514 TCP forward instead.)
 logs_register: true

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -60,10 +60,12 @@ monitoring_check_vars:
 monitoring_check_scripts:
   - check_jool_success_delta.sh
 
-# mon's nagios user pubkey, added to rtr's root authorized_keys for the
-# by_ssh checks. Set MONITORING_BY_SSH_PUBKEY in secrets.local.sh until
-# the icinga2 role lands a Vault-rendered pubkey distribution path.
-monitoring_by_ssh_user: root
+# mon's icinga2 by_ssh pubkey, authorized for the dedicated `monitoring`
+# user (created by the monitoring role). The role default is now
+# `monitoring` — no per-host override needed. Privileged checks (jool)
+# are wrapped in sudo, gated by the sudoers-monitoring drop. Set
+# MONITORING_BY_SSH_PUBKEY in secrets.local.sh until the icinga2 role
+# lands a Vault-rendered pubkey distribution path.
 monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
 
 # --- Logs --- (ships journald to log VM via Vector)

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -32,3 +32,9 @@ monitoring_disks:
 # on mon. Required keys: name, check_command. Optional: vars (dict), interval, retry, notes.
 # Hostname and address derive automatically from the host being registered.
 monitoring_extra_services: []
+
+# by_ssh known_hosts target on mon. Debian's icinga2 package runs as the
+# `nagios` user but stores SSH state under /var/lib/icinga2; the daemon's
+# HOME is set to this directory. Override per-inventory if the package
+# changes layout.
+monitoring_by_ssh_known_hosts_path: /var/lib/icinga2/.ssh/known_hosts

--- a/ansible/roles/monitoring/tasks/by_ssh_user.yml
+++ b/ansible/roles/monitoring/tasks/by_ssh_user.yml
@@ -18,14 +18,19 @@
     home: "{{ monitoring_user_home }}"
     create_home: yes
     comment: "icinga2 by_ssh remote user (managed by hyrule-infra)"
+  register: monitoring_user
   tags: [apply]
 
+# Use the primary group the OS assigned to the monitoring user (looked up
+# from the `user` task's return value). Don't hardcode `group: monitoring`
+# — on some platforms `useradd -r` puts a system user in a shared system
+# group, and on FreeBSD `pw` may assign a different gid name.
 - name: Ensure monitoring user .ssh dir exists
   file:
     path: "{{ monitoring_user_home }}/.ssh"
     state: directory
     owner: monitoring
-    group: monitoring
+    group: "{{ monitoring_user.group }}"
     mode: "0700"
   tags: [apply]
 

--- a/ansible/roles/monitoring/tasks/by_ssh_user.yml
+++ b/ansible/roles/monitoring/tasks/by_ssh_user.yml
@@ -1,0 +1,49 @@
+---
+# Dedicated `monitoring` system user for icinga2 by_ssh checks.
+#
+# Replaces the older convention of authorizing root@<host> (rtr) and the
+# never-existed `nagios` user (cr1.*). Human SSH stays as svag, root,
+# etc. — those are untouched. This user has nologin shell and is only
+# reachable via the by_ssh pubkey provisioned below.
+#
+# Privileged checks (FRR vtysh, jool stats, etc.) get a sudoers/doas drop
+# scoped to /usr/local/lib/nagios/plugins/* so the trust surface stays
+# narrow.
+
+- name: Ensure dedicated monitoring user exists
+  user:
+    name: monitoring
+    system: yes
+    shell: "{{ monitoring_user_shell }}"
+    home: "{{ monitoring_user_home }}"
+    create_home: yes
+    comment: "icinga2 by_ssh remote user (managed by hyrule-infra)"
+  tags: [apply]
+
+- name: Ensure monitoring user .ssh dir exists
+  file:
+    path: "{{ monitoring_user_home }}/.ssh"
+    state: directory
+    owner: monitoring
+    group: monitoring
+    mode: "0700"
+  tags: [apply]
+
+- name: Authorize mon's icinga2 by_ssh pubkey for the monitoring user
+  authorized_key:
+    user: monitoring
+    key: "{{ monitoring_by_ssh_pubkey }}"
+    comment: "icinga2 by_ssh from mon"
+    state: present
+  tags: [apply]
+
+- name: Drop privilege-escalation rule for plugin scripts
+  template:
+    src: "{{ monitoring_user_privesc_template }}"
+    dest: "{{ monitoring_user_privesc_dest }}"
+    owner: root
+    group: "{{ 'wheel' if ansible_os_family == 'FreeBSD' else 'root' }}"
+    mode: "{{ monitoring_user_privesc_mode }}"
+    validate: "{{ '/usr/sbin/visudo -cf %s' if ansible_os_family != 'FreeBSD' else omit }}"
+  when: monitoring_user_privesc_template is defined
+  tags: [apply]

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -25,14 +25,29 @@
     - monitoring_check_scripts | default([]) | length > 0
   tags: [apply]
 
-# mon's nagios user needs a key in authorized_keys on hosts that get
-# by_ssh services. Gated to keep the trust surface narrow.
-- name: Authorize mon's nagios SSH key for by_ssh checks
-  authorized_key:
-    user: "{{ monitoring_by_ssh_user | default('root') }}"
-    key: "{{ monitoring_by_ssh_pubkey }}"
-    comment: "icinga2 by_ssh from mon"
+# Provision the dedicated `monitoring` system user on hosts that get
+# by_ssh services, install mon's icinga2 pubkey, and drop the per-OS
+# privesc rule. Gated to keep the trust surface narrow.
+- name: Provision by_ssh remote user (monitoring)
+  include_tasks: by_ssh_user.yml
+  when:
+    - monitoring_apply | default(false) | bool
+    - monitoring_by_ssh_pubkey is defined
+    - monitoring_by_ssh_pubkey | length > 0
+  tags: [apply]
+
+# Pre-populate mon's icinga2 known_hosts with the public host keys of every
+# by_ssh target. Without this, the first connection from icinga2 fails
+# strict host-key checking with "Host key verification failed" (issue
+# observed on cr1.nl1 / cr1.de1 — they had never been keyscanned). Runs
+# delegated to mon so the keyscan happens from mon's network position.
+- name: Populate mon's icinga2 known_hosts for by_ssh
+  known_hosts:
+    path: "{{ monitoring_by_ssh_known_hosts_path }}"
+    name: "{{ ansible_host | default(inventory_hostname) }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t ed25519,rsa -T 5 ' ~ (ansible_host | default(inventory_hostname))) }}"
     state: present
+  delegate_to: "{{ monitoring_mon_host }}"
   when:
     - monitoring_apply | default(false) | bool
     - monitoring_by_ssh_pubkey is defined

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -39,17 +39,34 @@
 # Pre-populate mon's icinga2 known_hosts with the public host keys of every
 # by_ssh target. Without this, the first connection from icinga2 fails
 # strict host-key checking with "Host key verification failed" (issue
-# observed on cr1.nl1 / cr1.de1 — they had never been keyscanned). Runs
-# delegated to mon so the keyscan happens from mon's network position.
+# observed on cr1.nl1 / cr1.de1 — they had never been keyscanned). The
+# keyscan runs *on mon* (delegate_to + command, not lookup('pipe', ...)
+# which would execute on the controller) so the host keys reflect what
+# mon will actually see when it later opens the by_ssh connection.
+- name: Scan target host keys from mon
+  command: "ssh-keyscan -t ed25519,rsa -T 5 {{ ansible_host | default(inventory_hostname) }}"
+  delegate_to: "{{ monitoring_mon_host }}"
+  register: by_ssh_host_keyscan
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  when:
+    - monitoring_apply | default(false) | bool
+    - monitoring_by_ssh_pubkey is defined
+    - monitoring_by_ssh_pubkey | length > 0
+  tags: [apply]
+
 - name: Populate mon's icinga2 known_hosts for by_ssh
   known_hosts:
     path: "{{ monitoring_by_ssh_known_hosts_path }}"
     name: "{{ ansible_host | default(inventory_hostname) }}"
-    key: "{{ lookup('pipe', 'ssh-keyscan -t ed25519,rsa -T 5 ' ~ (ansible_host | default(inventory_hostname))) }}"
+    key: "{{ by_ssh_host_keyscan.stdout }}"
     state: present
   delegate_to: "{{ monitoring_mon_host }}"
   when:
     - monitoring_apply | default(false) | bool
     - monitoring_by_ssh_pubkey is defined
     - monitoring_by_ssh_pubkey | length > 0
+    - by_ssh_host_keyscan.stdout is defined
+    - by_ssh_host_keyscan.stdout | length > 0
   tags: [apply]

--- a/ansible/roles/monitoring/templates/doas-monitoring.conf.j2
+++ b/ansible/roles/monitoring/templates/doas-monitoring.conf.j2
@@ -1,0 +1,9 @@
+# {{ monitoring_user_privesc_dest }}
+# Managed by ansible/roles/monitoring. Scoped to the nagios-plugins dir
+# so icinga2 by_ssh checks that need root can call exactly those scripts
+# via `doas` and nothing else.
+#
+# doas requires an explicit cmd path; wildcards in cmd are not supported,
+# so each privileged plugin must be enumerated here. The current cr1.*
+# egress check (plain ping6) does not need root and is not listed.
+permit nopass monitoring as root cmd /usr/local/lib/nagios/plugins/check_jool_success_delta.sh

--- a/ansible/roles/monitoring/templates/sudoers-monitoring.j2
+++ b/ansible/roles/monitoring/templates/sudoers-monitoring.j2
@@ -1,0 +1,6 @@
+# {{ monitoring_user_privesc_dest }}
+# Managed by ansible/roles/monitoring. Scoped to the nagios-plugins dir
+# so icinga2 by_ssh checks that need root (FRR vtysh, jool stats, etc.)
+# can call exactly those scripts via `sudo` and nothing else.
+monitoring ALL=(root) NOPASSWD: /usr/local/lib/nagios/plugins/*
+Defaults!/usr/local/lib/nagios/plugins/* !requiretty

--- a/ansible/roles/monitoring/vars/Debian.yml
+++ b/ansible/roles/monitoring/vars/Debian.yml
@@ -2,3 +2,12 @@
 monitoring_pkg: prometheus-node-exporter
 monitoring_node_service: prometheus-node-exporter
 monitoring_node_env_path: /etc/default/prometheus-node-exporter
+
+# Dedicated by_ssh remote user. Created by the monitoring role when
+# monitoring_by_ssh_pubkey is set; the icinga2 daemon on mon logs in as
+# this user to run by_ssh checks. Per-OS shell path differs.
+monitoring_user_shell: /usr/sbin/nologin
+monitoring_user_home: /var/lib/monitoring
+monitoring_user_privesc_template: sudoers-monitoring.j2
+monitoring_user_privesc_dest: /etc/sudoers.d/monitoring
+monitoring_user_privesc_mode: "0440"

--- a/ansible/roles/monitoring/vars/FreeBSD.yml
+++ b/ansible/roles/monitoring/vars/FreeBSD.yml
@@ -2,3 +2,10 @@
 monitoring_pkg: node_exporter
 monitoring_node_service: node_exporter
 monitoring_node_env_path: /etc/rc.conf.d/node_exporter
+
+# Dedicated by_ssh remote user (FreeBSD variant). doas, not sudo.
+monitoring_user_shell: /usr/sbin/nologin
+monitoring_user_home: /var/db/monitoring
+monitoring_user_privesc_template: doas-monitoring.conf.j2
+monitoring_user_privesc_dest: /usr/local/etc/doas.d/monitoring.conf
+monitoring_user_privesc_mode: "0440"

--- a/configs/mon/icinga2/scripts/check_jool_success_delta.sh
+++ b/configs/mon/icinga2/scripts/check_jool_success_delta.sh
@@ -7,8 +7,9 @@
 # overlay traffic is reaching it" — that's how the cr1-de1 NDP outage
 # would have shown up if we'd had this check during it.
 #
-# State stored under /var/lib/icinga2/jool-success-prev. Owned by the
-# nagios user (the by_ssh login).
+# State stored under /var/lib/icinga2/jool-success-prev. Invoked via sudo
+# from the `monitoring` by_ssh user (jool stats need root); state file
+# is written as root.
 #
 # Exit codes:
 #   0 OK

--- a/configs/mon/icinga2/services/cr-bogon-egress.conf
+++ b/configs/mon/icinga2/services/cr-bogon-egress.conf
@@ -15,7 +15,7 @@ apply Service "egress-cloudflare-v6" {
   retry_interval = 1m
 
   vars.by_ssh_command = "ping6 -c 10 -W 1 -q 2606:4700:4700::1111 >/dev/null"
-  vars.by_ssh_logname = "nagios"
+  vars.by_ssh_logname = "monitoring"
   notes = "Cloudflare v6 reachability from core router (regresses if pf.bogons6 blocks outbound NDP)."
 
   assign where host.vars.os == "FreeBSD" && host.vars.role == "router"
@@ -27,7 +27,7 @@ apply Service "egress-ns2-v6" {
   retry_interval = 1m
 
   vars.by_ssh_command = "ping6 -c 10 -W 1 -q 2001:41d0:304:300::7bfb >/dev/null"
-  vars.by_ssh_logname = "nagios"
+  vars.by_ssh_logname = "monitoring"
   notes = "ns2 (off-net secondary DNS) reachability from core router."
 
   assign where host.vars.os == "FreeBSD" && host.vars.role == "router"

--- a/configs/mon/icinga2/services/rtr-checks.conf
+++ b/configs/mon/icinga2/services/rtr-checks.conf
@@ -4,9 +4,10 @@
 // Catches the same failure class as #18 (NAT64 outage) earlier and from
 // a different angle than the dataplane probe (`nat64-ipv4-reachability`).
 //
-// All three use the by_ssh CheckCommand from mon → rtr; mon's nagios user
-// must have an authorized_keys entry on rtr. The connection details are
-// inherited from rtr's host vars (vars.ssh_port etc.).
+// All three use the by_ssh CheckCommand from mon → rtr, logging in as the
+// dedicated `monitoring` user (provisioned by ansible/roles/monitoring).
+// Privileged commands are wrapped in sudo — see sudoers-monitoring.j2,
+// which scopes the privesc to /usr/local/lib/nagios/plugins/*.
 //
 // Filed by issue #20. The host.name match changed from "rtr.ovh1" to "rtr"
 // in PR for issue #21 (monitoring_register migration).
@@ -17,6 +18,7 @@ apply Service "rtr-ipv4-gateway-arp" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ping -c2 -W2 -I enX4 193.70.32.254 >/dev/null"
+  vars.by_ssh_logname = "monitoring"
   notes = "rtr's WAN default gateway is reachable on the underlay interface (catches enX4 down, ARP failure)."
 
   assign where host.name == "rtr"
@@ -28,6 +30,7 @@ apply Service "rtr-ipv4-default-route" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ip -4 route show default | grep -q '193.70.32.254'"
+  vars.by_ssh_logname = "monitoring"
   notes = "rtr has the expected v4 default route via OVH gateway 193.70.32.254 (catches FRR or systemd-networkd misconfig)."
 
   assign where host.name == "rtr"
@@ -39,8 +42,11 @@ apply Service "rtr-jool-success-delta" {
   retry_interval = 1m
 
   // Wrapper script tracks the JSTAT_SUCCESS counter over time. Deployed
-  // via the monitoring role at /usr/local/lib/nagios/plugins/.
-  vars.by_ssh_command = "/usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
+  // via the monitoring role at /usr/local/lib/nagios/plugins/. Requires
+  // root to read jool netlink stats; sudo is granted by the
+  // sudoers-monitoring drop, scoped to this plugin dir only.
+  vars.by_ssh_command = "sudo /usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
+  vars.by_ssh_logname = "monitoring"
   notes = "JSTAT_SUCCESS counter should advance between checks — flat counter signals NAT64 pipeline broken (jool down, pool4/pool6 mismatch, VRF leak missing)."
 
   assign where host.name == "rtr"

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -108,6 +108,28 @@ Rule shape:
 For pf-only constructs that don't fit the data model (e.g. `match all scrub`,
 new transit pass rules), use `firewall_extra_raw_pf:` (string) in host_vars.
 
+## Monitoring user — dedicated `monitoring` system account on every host
+
+The `monitoring` role provisions a dedicated `monitoring` system user
+(nologin shell, home under `/var/lib/monitoring` on Linux,
+`/var/db/monitoring` on FreeBSD) on any host where
+`monitoring_by_ssh_pubkey` is set. mon's icinga2 daemon SSHes in as this
+user for `by_ssh` checks; the pubkey is dropped into
+`~monitoring/.ssh/authorized_keys`. Human SSH (`svag`, `root`) is
+untouched.
+
+Privileged checks (FRR vtysh, jool stats) need root. A scoped
+sudoers (Linux) / doas (FreeBSD) drop allows `monitoring` to invoke
+exactly `/usr/local/lib/nagios/plugins/*` as root, nothing else. In
+Icinga, those `vars.by_ssh_command` strings prepend `sudo`. The new
+convention replaces the old per-host `monitoring_by_ssh_user: root`
+override on rtr (now removed) and the never-existed `nagios` user on
+cr1.*.
+
+The first connection from icinga2 to a new by_ssh target fails with
+*"Host key verification failed"* until mon's `~icinga2/.ssh/known_hosts`
+is populated; the role does this via `ssh-keyscan` delegated to mon.
+
 ## Memory ops should know about
 
 - [SSH user is heterogeneous](../../.claude/projects/-home-svag-Dev/memory/project_as215932_ssh_users.md): rtr/xoa accept root, others use svag.

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -284,6 +284,8 @@ exceptions are:
 | ns2 → log | out | 6000 tcp | Off-net Vector agent → aggregator over public IPv6 |
 | dom0 → log | out | 6000 tcp | Hypervisor Vector agent → aggregator over mgmt v4 |
 | mon → log | out | 3100, 8686 tcp | Grafana query + Vector metrics scrape |
+| noc, mon, api, web → vault | out | 8200 tcp | vault-agent → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
+| mon → routers | out | 22 tcp (by_ssh) | icinga2 by_ssh checks, logged in as the dedicated `monitoring` system user. Privileged plugins (jool stats) are wrapped in `sudo`/`doas`, scoped to `/usr/local/lib/nagios/plugins/*` by the role-rendered drop. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Introduce a dedicated `monitoring` system user (nologin shell, isolated home) on every host that gets icinga2 by_ssh checks. Created and managed by the `monitoring` role.
- Scoped sudoers (Linux) / doas (FreeBSD) drop limits privileged plugin execution to `/usr/local/lib/nagios/plugins/*`.
- Pre-populate mon's `~icinga2/.ssh/known_hosts` via ssh-keyscan (delegated to mon) so the first by_ssh connection to a new target doesn't fail strict host-key checking.

## Bugs being fixed

Two compounding issues observed in the 2026-05-15 incident:

1. **`cr-bogon-egress.conf` hardcoded `by_ssh_logname = "nagios"`** but no `nagios` (or any dedicated monitoring) account exists on the FreeBSD core routers — `cr1-nl1` / `cr1-de1` only have `svag` for human SSH. `egress-cloudflare-v6` and `egress-ns2-v6` have been permanently UNKNOWN as a result.
2. **mon's icinga2 daemon had never SSH'd to `cr1.*`**, so its `~icinga2/.ssh/known_hosts` had no fingerprint — strict host-key checking rejected the connection before user auth, surfacing as *"Host key verification failed"*.

`rtr-checks.conf` previously worked via a one-off `monitoring_by_ssh_user: root` override on `rtr`; that exception is now dropped in favor of the unified `monitoring` user.

## Risk / scope

- Touches the monitoring role default user (was `root`, now `monitoring`). Anywhere that already had the icinga2 pubkey added to `root@<host>` keeps working until the next apply rolls it forward; after, the role provisions the `monitoring` user and the by_ssh check switches to it.
- Privileged check (rtr-jool-success-delta) gains a `sudo` prefix. Confirmed `jool stats` requires root; verify the new sudoers drop is rendered correctly on rtr before re-running the apply.
- `ping6` / `ip route` on cr1.* and rtr work as the unprivileged `monitoring` user without sudo.

## Test plan

- [ ] `ansible-playbook playbooks/monitoring.yml --tags apply -e monitoring_apply=true --limit cr1-nl1` — verify `monitoring` user is created, key authorized, `/usr/local/etc/doas.d/monitoring.conf` rendered.
- [ ] From mon as the icinga2 daemon: `sudo -u nagios ssh -i ~icinga2/.ssh/id_by_ssh -l monitoring cr1.nl1.servify.network 'ping6 -c1 -W1 2606:4700:4700::1111 >/dev/null'` exits 0.
- [ ] Repeat for cr1.de1 and rtr.
- [ ] Confirm `~icinga2/.ssh/known_hosts` on mon now lists all three hosts.
- [ ] `icinga2 daemon -C && systemctl reload icinga2`; egress-cloudflare-v6, egress-ns2-v6 flip UNKNOWN → OK within one check_interval (5 min) on both cr1.nl1 and cr1.de1.
- [ ] rtr-ipv4-gateway-arp, rtr-ipv4-default-route, rtr-jool-success-delta stay OK.
- [ ] Remove the old icinga2 pubkey from `root@rtr`'s authorized_keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated system-level `monitoring` SSH user for icinga2 by_ssh checks and ensure host key verification and privilege escalation for monitoring plugins are handled consistently across hosts.

New Features:
- Provision a dedicated `monitoring` system user with per-OS home, shell, and privesc configuration for all hosts using icinga2 by_ssh checks.
- Automatically populate mon's icinga2 known_hosts file for by_ssh targets via ssh-keyscan delegated to the monitoring host.

Bug Fixes:
- Fix icinga2 by_ssh failures on core routers caused by the absence of a `nagios` user and missing SSH host keys in known_hosts.

Enhancements:
- Standardize by_ssh checks to log in as the `monitoring` user instead of root or `nagios`, including updates to rtr and core router service definitions.
- Restrict privileged monitoring commands to a scoped sudoers/doas configuration allowing only Nagios plugin execution.
- Document the new monitoring user model, host key handling, and related network flows in the ansible and network-flows documentation.