### PR TITLE
noc-agent-model-health: parse JSON body so the alert says *why*

### DIFF
--- a/ansible/generated/noc/icinga_host.conf
+++ b/ansible/generated/noc/icinga_host.conf
@@ -75,15 +75,11 @@ object Service "noc-agent-mail-health" {
 
 object Service "noc-agent-model-health" {
   host_name = "noc"
-  check_command = "http"
+  check_command = "noc_agent_model_health"
   check_interval = 2m
   retry_interval = 30s
   notes = "Configured AI model and fallback access for noc-agent"
-  vars.http_address = "2a0c:b641:b50:2::a0"
-  vars.http_port = 8000
-  vars.http_uri = "/health/model"
-  vars.http_ipv6 = true
-  vars.http_timeout = 15
-  vars.http_expect_body_regex = "\"status\":\"ok\""
+  vars.noc_model_host = "2a0c:b641:b50:2::a0"
+  vars.noc_model_port = 8000
 }
 

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -69,17 +69,15 @@ monitoring_extra_services:
       http_expect_body_regex: '"status":"ok"'
 
   - name: noc-agent-model-health
-    check_command: http
+    # Custom check: surfaces /health/model's JSON body in the alert.
+    # CheckCommand defined in configs/mon/icinga2/services/noc-agent-model-health.conf.
+    check_command: noc_agent_model_health
     interval: 2m
     retry: 30s
     notes: "Configured AI model and fallback access for noc-agent"
     vars:
-      http_address: "{{ peers.noc.ipv6 }}"
-      http_port: 8000
-      http_uri: "/health/model"
-      http_ipv6: true
-      http_timeout: 15
-      http_expect_body_regex: '"status":"ok"'
+      noc_model_host: "{{ peers.noc.ipv6 }}"
+      noc_model_port: 8000
 
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true

--- a/configs/mon/icinga2/scripts/check_noc_agent_model_health.sh
+++ b/configs/mon/icinga2/scripts/check_noc_agent_model_health.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# check_noc_agent_model_health.sh — Icinga2 check executed on mon.
+#
+# Curls noc-agent's /health/model and surfaces the JSON body's reason
+# fields in the plugin output line. Replaces the generic `check_http`
+# command, which only reports the HTTP status code and throws away the
+# JSON explaining *why* the model is unavailable (failing model name,
+# quota state, missing creds).
+#
+# Endpoint shape is fixed by hyrule-noc-agent/app/main.py:647-662 —
+# {status, missing[], quota_monitoring, quota, primary_model,
+# fallback_models}. jq extraction matches that contract.
+#
+# Usage: check_noc_agent_model_health.sh <ipv6> <port>
+#
+# Exit codes:
+#   0 OK            — HTTP 200, status=ok
+#   2 CRITICAL      — HTTP 503 (or unreachable)
+#   3 UNKNOWN       — non-200/503 response, or jq parse failure
+
+set -u
+
+if [ "$#" -ne 2 ]; then
+    echo "UNKNOWN - usage: $0 <ipv6> <port>"
+    exit 3
+fi
+host="$1"; port="$2"
+
+body="$(mktemp)"
+trap 'rm -f "$body"' EXIT
+
+code="$(curl -sS --max-time 10 -o "$body" -w '%{http_code}' \
+    "http://[$host]:$port/health/model" 2>/dev/null)" || {
+    echo "CRITICAL - /health/model unreachable from mon (curl exit non-zero)"
+    exit 2
+}
+
+# Parse fields; jq -r prints "null" if a key is missing, so treat that as "?".
+field() {
+    val="$(jq -r "$1 // \"?\"" "$body" 2>/dev/null)" || val="?"
+    [ "$val" = "null" ] && val="?"
+    printf '%s' "$val"
+}
+
+status=$(field '.status')
+quota=$(field '.quota_monitoring')
+primary=$(field '.primary_model')
+err=$(jq -r '.error // ""' "$body" 2>/dev/null || true)
+missing=$(jq -r '.missing | join(",") // ""' "$body" 2>/dev/null || true)
+[ "$missing" = "null" ] && missing=""
+
+detail="primary=$primary status=$status quota=$quota"
+[ -n "$missing" ] && detail="$detail missing=$missing"
+[ -n "$err" ]     && detail="$detail err=$err"
+
+case "$code" in
+    200) echo "OK - $detail"; exit 0 ;;
+    503) echo "CRITICAL - $detail"; exit 2 ;;
+    *)   echo "UNKNOWN - http=$code $detail"; exit 3 ;;
+esac

--- a/configs/mon/icinga2/scripts/check_noc_agent_model_health.sh
+++ b/configs/mon/icinga2/scripts/check_noc_agent_model_health.sh
@@ -27,11 +27,16 @@ fi
 host="$1"; port="$2"
 
 body="$(mktemp)"
-trap 'rm -f "$body"' EXIT
+err_log="$(mktemp)"
+trap 'rm -f "$body" "$err_log"' EXIT
 
+# Keep curl's stderr (TLS handshake, connection refused, timeout reason)
+# so the alert body has something actionable instead of a generic
+# "exit non-zero".
 code="$(curl -sS --max-time 10 -o "$body" -w '%{http_code}' \
-    "http://[$host]:$port/health/model" 2>/dev/null)" || {
-    echo "CRITICAL - /health/model unreachable from mon (curl exit non-zero)"
+    "http://[$host]:$port/health/model" 2>"$err_log")" || {
+    reason="$(tr '\n' ' ' < "$err_log" | sed 's/  */ /g')"
+    echo "CRITICAL - /health/model unreachable from mon: ${reason:-curl exit non-zero}"
     exit 2
 }
 
@@ -46,8 +51,10 @@ status=$(field '.status')
 quota=$(field '.quota_monitoring')
 primary=$(field '.primary_model')
 err=$(jq -r '.error // ""' "$body" 2>/dev/null || true)
-missing=$(jq -r '.missing | join(",") // ""' "$body" 2>/dev/null || true)
-[ "$missing" = "null" ] && missing=""
+# `(.missing // [])` short-circuits when .missing is null or absent, so
+# `join` always receives a list — avoids the jq error
+# `Cannot iterate over null` that `.missing | join(",")` raises.
+missing=$(jq -r '(.missing // []) | join(",")' "$body" 2>/dev/null || true)
 
 detail="primary=$primary status=$status quota=$quota"
 [ -n "$missing" ] && detail="$detail missing=$missing"

--- a/configs/mon/icinga2/services/noc-agent-model-health.conf
+++ b/configs/mon/icinga2/services/noc-agent-model-health.conf
@@ -1,0 +1,21 @@
+// /etc/icinga2/conf.d/services/noc-agent-model-health.conf
+//
+// Custom CheckCommand for noc-agent's /health/model endpoint. The
+// upstream `check_http` plugin only surfaces the HTTP status code —
+// /health/model returns JSON explaining *why* it's degraded (failing
+// model name, quota state, missing creds). This wrapper script extracts
+// those fields and puts them in the plugin output line so the alert
+// itself is actionable.
+//
+// Service object lives in host_vars/noc.yml :: monitoring_extra_services
+// (rendered into /etc/icinga2/conf.d/hosts/ansible/noc.conf by the
+// monitoring role) and references this CheckCommand by name.
+
+object CheckCommand "noc_agent_model_health" {
+  command = [ "/etc/icinga2/scripts/check_noc_agent_model_health.sh" ]
+
+  arguments = {
+    "host" = { skip_key = true; order = 1; value = "$noc_model_host$" }
+    "port" = { skip_key = true; order = 2; value = "$noc_model_port$" }
+  }
+}


### PR DESCRIPTION
## Summary

Replace the stock `check_http` for `noc-agent-model-health` with a small wrapper that GETs `/health/model`, jq-extracts the JSON body fields (status, quota_monitoring, primary_model, missing, error), and emits the reason as the plugin output line — so the alert text itself tells the operator what's broken.

## Before / after

**Before:**
```
HTTP CRITICAL: HTTP/1.1 503 Service Unavailable - 931 bytes in 0.710 second response time
```

**After (example degradation):**
```
CRITICAL - primary=claude-opus-4-7 status=degraded quota=ok missing=ANTHROPIC_API_KEY
```

## Files

- `configs/mon/icinga2/scripts/check_noc_agent_model_health.sh` — new wrapper.
- `configs/mon/icinga2/services/noc-agent-model-health.conf` — new `object CheckCommand "noc_agent_model_health"`. Mirrors the `dns_soa_ecmp` pattern.
- `ansible/inventory/host_vars/noc.yml` — service entry switches from `check_command: http` to `noc_agent_model_health`; vars become `noc_model_host` + `noc_model_port`.
- `ansible/generated/noc/icinga_host.conf` — re-rendered to match.

Endpoint contract is fixed by `hyrule-noc-agent/app/main.py:647-662`, so the jq paths are stable.

## Follow-up

The parallel `noc-agent-mail-health` alert has the same generic-503 problem; tracked in #67.

## Test plan

- [ ] `ansible-playbook playbooks/icinga2.yml --check --diff` shows the new check script + service config; no other drift.
- [ ] Apply and reload icinga2 on mon. Manually run `/etc/icinga2/scripts/check_noc_agent_model_health.sh 2a0c:b641:b50:2::a0 8000` — confirm the parsed-body output.
- [ ] Force a 503 by temporarily unsetting `ANTHROPIC_API_KEY` in `/opt/noc-agent/.env` (or pointing `MODEL_PRIMARY` at a bogus model), reload noc-agent, watch Discord — the alert body should now contain the parsed reason.
- [ ] Restore the env, confirm OK transition includes parsed fields too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a custom Icinga2 check command and script for noc-agent model health to surface detailed JSON health information directly in alerts instead of generic HTTP status codes.

Enhancements:
- Replace the generic HTTP check for noc-agent model health with a dedicated CheckCommand that parses /health/model JSON and includes key fields in alert output.
- Introduce a noc-agent model health check script executed on the monitoring host that calls the noc-agent endpoint and maps HTTP/JSON status to appropriate Nagios/Icinga return codes.

Deployment:
- Update noc host monitoring configuration to use the new noc_agent_model_health check and associated host/port variables instead of the generic HTTP check.