### PR TITLE
noc playbook: drop explicit vault_addr override (follow-up to #68)

### DIFF
--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -67,7 +67,10 @@
     - role: vault_agent
       vars:
         vault_agent_name: noc-agent
-        vault_agent_vault_addr: "https://vault.as215932.net"
+        # vault_agent_vault_addr inherits the role default
+        # (https://[{{ peers.vault.ipv6 }}]:8200 + tls_skip_verify) so noc's
+        # secrets plane survives a Caddy/proxy outage. The public
+        # vault.as215932.net Caddy route stays intact for external consumers.
         vault_agent_role_id: "{{ lookup('env', 'VAULT_NOC_AGENT_ROLE_ID') | default('', true) }}"
         vault_agent_secret_id: "{{ lookup('env', 'VAULT_NOC_AGENT_SECRET_ID') | default('', true) }}"
         vault_agent_env_destination: /opt/noc-agent/.env


### PR DESCRIPTION
## Summary

Follow-up to #68. The role default for \`vault_agent_vault_addr\` is now \`https://[{{ peers.vault.ipv6 }}]:8200\` (with \`tls_skip_verify=true\`), but \`playbooks/noc.yml:70\` explicitly overrode it with the old public hostname — silently negating the fix on the only host that currently runs vault-agent.

Drop the override so noc inherits the role default.

## Test plan

- [ ] \`gh workflow run apply.yml -F playbook=noc -F limit=noc -F dry_run=true\` shows the new \`vault-agent.hcl\` (\`address = "https://[2a0c:b641:b50:2::c0]:8200"\`, \`tls_skip_verify = true\`).
- [ ] Real apply on noc: vault-agent reconnects to the internal endpoint, \`journalctl -u vault-agent -f\` confirms no Caddy hops, \`/opt/noc-agent/.env\` keeps rendering.
- [ ] Stop Caddy on proxy for one renewal cycle; \`/health/model\` stays 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Clarify configuration comments in the noc playbook explaining the use of the vault_agent role’s default internal Vault address and its resilience during proxy outages.