### PR TITLE
rtr: revert by_ssh logname flip until apt-cache failure is fixed

### DIFF
--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -60,12 +60,14 @@ monitoring_check_vars:
 monitoring_check_scripts:
   - check_jool_success_delta.sh
 
-# mon's icinga2 by_ssh pubkey, authorized for the dedicated `monitoring`
-# user (created by the monitoring role). The role default is now
-# `monitoring` — no per-host override needed. Privileged checks (jool)
-# are wrapped in sudo, gated by the sudoers-monitoring drop. Set
+# mon's icinga2 by_ssh pubkey, currently authorized for root@rtr (legacy
+# convention). The fleet-wide migration to the dedicated `monitoring`
+# user is deferred for rtr — the monitoring role's node_exporter step
+# fails on rtr with "Failed to update apt cache" (pre-existing issue,
+# tracked separately). cr1.* already use `monitoring`. Set
 # MONITORING_BY_SSH_PUBKEY in secrets.local.sh until the icinga2 role
 # lands a Vault-rendered pubkey distribution path.
+monitoring_by_ssh_user: root
 monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
 
 # --- Logs --- (ships journald to log VM via Vector)

--- a/configs/mon/icinga2/services/rtr-checks.conf
+++ b/configs/mon/icinga2/services/rtr-checks.conf
@@ -4,10 +4,12 @@
 // Catches the same failure class as #18 (NAT64 outage) earlier and from
 // a different angle than the dataplane probe (`nat64-ipv4-reachability`).
 //
-// All three use the by_ssh CheckCommand from mon → rtr, logging in as the
-// dedicated `monitoring` user (provisioned by ansible/roles/monitoring).
-// Privileged commands are wrapped in sudo — see sudoers-monitoring.j2,
-// which scopes the privesc to /usr/local/lib/nagios/plugins/*.
+// All three use the by_ssh CheckCommand from mon → rtr. rtr currently uses
+// the legacy root-based by_ssh path (root has the icinga2 pubkey authorized
+// per rtr.yml: monitoring_by_ssh_user=root); migration to the dedicated
+// `monitoring` user is deferred until rtr's apt-cache failure (blocks the
+// monitoring role's node_exporter task) is resolved. cr1.* already use the
+// `monitoring` user — see configs/mon/icinga2/services/cr-bogon-egress.conf.
 //
 // Filed by issue #20. The host.name match changed from "rtr.ovh1" to "rtr"
 // in PR for issue #21 (monitoring_register migration).
@@ -18,7 +20,6 @@ apply Service "rtr-ipv4-gateway-arp" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ping -c2 -W2 -I enX4 193.70.32.254 >/dev/null"
-  vars.by_ssh_logname = "monitoring"
   notes = "rtr's WAN default gateway is reachable on the underlay interface (catches enX4 down, ARP failure)."
 
   assign where host.name == "rtr"
@@ -30,7 +31,6 @@ apply Service "rtr-ipv4-default-route" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ip -4 route show default | grep -q '193.70.32.254'"
-  vars.by_ssh_logname = "monitoring"
   notes = "rtr has the expected v4 default route via OVH gateway 193.70.32.254 (catches FRR or systemd-networkd misconfig)."
 
   assign where host.name == "rtr"
@@ -42,11 +42,10 @@ apply Service "rtr-jool-success-delta" {
   retry_interval = 1m
 
   // Wrapper script tracks the JSTAT_SUCCESS counter over time. Deployed
-  // via the monitoring role at /usr/local/lib/nagios/plugins/. Requires
-  // root to read jool netlink stats; sudo is granted by the
-  // sudoers-monitoring drop, scoped to this plugin dir only.
-  vars.by_ssh_command = "sudo /usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
-  vars.by_ssh_logname = "monitoring"
+  // via the monitoring role at /usr/local/lib/nagios/plugins/. rtr's
+  // by_ssh user is still root, so no sudo wrap needed yet — that lands
+  // alongside the rtr migration once apt-cache works.
+  vars.by_ssh_command = "/usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
   notes = "JSTAT_SUCCESS counter should advance between checks — flat counter signals NAT64 pipeline broken (jool down, pool4/pool6 mismatch, VRF leak missing)."
 
   assign where host.name == "rtr"


### PR DESCRIPTION
## Summary

Follow-up to #69. The monitoring role apply on rtr (run [25943681326](https://github.com/AS215932/network-operations/actions/runs/25943681326)) failed at the prerequisite \`Install node_exporter (Debian)\` step:

\`\`\`
fatal: [rtr]: FAILED! => {"changed": false, "msg": "Failed to update apt cache after 5 retries: "}
\`\`\`

This is a pre-existing networking issue on rtr (likely related to the \`project_rtr_networkd_bgp.md\` memory entry — networkd reload glitches under FRR), not caused by #69. But it means the dedicated \`monitoring\` user can't be provisioned on rtr until the apt issue is fixed.

If we ship #69's icinga2 service-config flip on \`mon\` with rtr in the new state, mon will start trying to SSH into rtr as \`monitoring\` — which doesn't exist there yet — and all three rtr by_ssh checks (gateway-arp, default-route, jool-success-delta) flip CRITICAL.

This PR keeps the rtr-side service config on the legacy root-based path. \`cr1.nl1\` / \`cr1.de1\` still migrate to \`monitoring\` (their applies succeeded). rtr migrates separately once the apt-cache failure is resolved.

## Files

- \`configs/mon/icinga2/services/rtr-checks.conf\`: drop \`by_ssh_logname = "monitoring"\` from all three apply blocks; drop the \`sudo\` wrap on the jool check (root doesn't need it).
- \`ansible/inventory/host_vars/rtr.yml\`: restore \`monitoring_by_ssh_user: root\` so the next monitoring role apply still targets root's authorized_keys.

## Test plan

- [ ] \`ansible-playbook playbooks/icinga2.yml --check --diff\` shows rtr-checks.conf with no \`by_ssh_logname\` lines, no \`sudo\` prefix on jool.
- [ ] After icinga2 reload: rtr-{ipv4-gateway-arp, ipv4-default-route, jool-success-delta} stay OK.
- [ ] cr1.nl1 / cr1.de1 \`egress-cloudflare-v6\` and \`egress-ns2-v6\` flip UNKNOWN → OK.

## Follow-up

File a separate issue tracking the rtr apt-cache failure and the eventual migration to the \`monitoring\` user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Revert rtr monitoring SSH user migration to keep checks running under the legacy root-based by_ssh setup until apt-cache issues on rtr are resolved.

Enhancements:
- Update rtr Icinga2 by_ssh service definitions to stop targeting the dedicated monitoring user and run the Jool check directly as root without sudo.
- Document the temporary deferral of rtr's migration to the monitoring user in both the rtr service checks and host vars.

Chores:
- Restore rtr host_vars to explicitly configure monitoring_by_ssh_user as root so future monitoring role runs continue to use root's authorized_keys.