### PR TITLE
monitoring playbook: include FreeBSD in hosts pattern (follow-up to #69)

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -9,7 +9,11 @@
 #   ansible-playbook playbooks/monitoring.yml --tags apply -e '{"monitoring_apply":true}'
 
 - name: Monitoring — apply
-  hosts: linux:openbsd
+  # Include FreeBSD so the cr1.* core routers pick up the monitoring role
+  # (node_exporter via pkg, dedicated `monitoring` by_ssh user from #69).
+  # `linux:openbsd` alone silently no-ops on cr1.* (hosts: pattern doesn't
+  # match → "skipping: no hosts matched"), which masked the missing user.
+  hosts: linux:openbsd:freebsd
   serial: 1
   gather_facts: false
   become: true


### PR DESCRIPTION
## Summary

\`playbooks/monitoring.yml\` had \`hosts: linux:openbsd\` — the cr1.* FreeBSD core routers were silently excluded. The applies in runs [25943592645](https://github.com/AS215932/network-operations/actions/runs/25943592645) (cr1-nl1) and [25943850506](https://github.com/AS215932/network-operations/actions/runs/25943850506) (cr1-de1) recorded \"success\" but the Apply step printed:

\`\`\`
skipping: no hosts matched
\`\`\`

So the \`monitoring\` user / known_hosts entries from #69 never landed on cr1.*. Result: \`egress-cloudflare-v6\` and \`egress-ns2-v6\` stayed UNKNOWN with the original *"Host key verification failed"* — the bug #69 was meant to fix.

Extend the pattern to \`linux:openbsd:freebsd\`. The FreeBSD os-vars (\`monitoring/vars/FreeBSD.yml\`) and \`doas-monitoring.conf.j2\` privesc template are already in place, so the role applies cleanly.

## Test plan

- [ ] After merge: \`gh workflow run apply.yml -F playbook=monitoring -F limit=cr1-nl1 -F dry_run=false\`. Apply step should NOT print \"skipping: no hosts matched\"; \`monitoring\` user gets created on cr1.nl1.
- [ ] Repeat for cr1.de1.
- [ ] \`egress-cloudflare-v6\` and \`egress-ns2-v6\` flip UNKNOWN → OK on both within one check_interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Include FreeBSD hosts in the monitoring playbook target pattern so cr1.* routers receive the monitoring user and configuration instead of being silently skipped.