### PR TITLE
github-runner secrets.env: surface MONITORING_BY_SSH_PUBKEY (follow-up to #69)

### DIFF
--- a/ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2
@@ -12,4 +12,5 @@ DISCORD_WEBHOOK_URL={{ .Data.data.discord_webhook_url }}
 ICINGA_API_USER={{ .Data.data.icinga_api_user }}
 ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
 ICINGA_NOC_AGENT_API_PASSWORD={{ or .Data.data.icinga_noc_agent_api_password "" }}
+MONITORING_BY_SSH_PUBKEY={{ or .Data.data.monitoring_by_ssh_pubkey "" }}
 {{- end }}{% endraw %}


### PR DESCRIPTION
## Summary

Without this, the monitoring role's by_ssh user provisioning from #69 silently no-ops on CI runs. \`host_vars/{cr1*,rtr}.yml\` resolves \`monitoring_by_ssh_pubkey\` from \`lookup('env', 'MONITORING_BY_SSH_PUBKEY')\`; the CI runner sources \`/etc/github-runner/secrets.env\` (Vault-Agent-rendered) and that file is missing the var.

Add the corresponding line to \`github-runner.env.ctmpl.j2\`. Wrapped in \`or … ""\` so the ctmpl keeps rendering until the Vault key exists.

## Prerequisite (operator action — tracked in #76)

Once this is merged the ctmpl is wired, but \`monitoring_by_ssh_pubkey\` still needs to land in Vault at \`kv/data/ci-runner\`. The operator runs (locally, with the existing svag Vault creds):

\`\`\`
vault kv patch kv/ci-runner \\
  monitoring_by_ssh_pubkey="$(cat ~/.ssh/id_servify_monitoring.pub)"
\`\`\`

(Or whichever pubkey is currently set in \`secrets.local.sh\`'s \`MONITORING_BY_SSH_PUBKEY\`.)

## Test plan

After Vault patch + this PR merge:

- [ ] \`gh workflow run apply.yml -F playbook=ci -F limit=ci -F dry_run=false\` — re-renders \`/etc/github-runner/secrets.env\`.
- [ ] Verify the new var is present: \`grep ^MONITORING_BY_SSH_PUBKEY= /etc/github-runner/secrets.env\` (on ci).
- [ ] \`gh workflow run apply.yml -F playbook=monitoring -F limit=cr1-nl1,cr1-de1 -F dry_run=false\` — should NOW provision the \`monitoring\` user (not skip).
- [ ] cr1.{nl1,de1} \`egress-cloudflare-v6\` and \`egress-ns2-v6\` flip UNKNOWN → OK within one check_interval (5m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the MONITORING_BY_SSH_PUBKEY environment variable is rendered into the GitHub runner secrets file so monitoring-by-SSH provisioning no longer no-ops in CI.