### PR TITLE
cr-bogon-egress: compress ping6 interval to fit by_ssh 10s timeout

### DIFF
--- a/configs/mon/icinga2/services/cr-bogon-egress.conf
+++ b/configs/mon/icinga2/services/cr-bogon-egress.conf
@@ -14,7 +14,7 @@ apply Service "egress-cloudflare-v6" {
   check_interval = 5m
   retry_interval = 1m
 
-  vars.by_ssh_command = "ping6 -c 10 -W 1 -q 2606:4700:4700::1111 >/dev/null"
+  vars.by_ssh_command = "ping6 -c 10 -i 0.5 -W 1 -q 2606:4700:4700::1111 >/dev/null"
   vars.by_ssh_logname = "monitoring"
   notes = "Cloudflare v6 reachability from core router (regresses if pf.bogons6 blocks outbound NDP)."
 
@@ -26,7 +26,7 @@ apply Service "egress-ns2-v6" {
   check_interval = 5m
   retry_interval = 1m
 
-  vars.by_ssh_command = "ping6 -c 10 -W 1 -q 2001:41d0:304:300::7bfb >/dev/null"
+  vars.by_ssh_command = "ping6 -c 10 -i 0.5 -W 1 -q 2001:41d0:304:300::7bfb >/dev/null"
   vars.by_ssh_logname = "monitoring"
   notes = "ns2 (off-net secondary DNS) reachability from core router."
 


### PR DESCRIPTION
## Summary

\`ping6 -c 10 -W 1\` at the default 1s interval takes ~9–10s wall time, which collides with \`check_by_ssh\`'s default 10s plugin timeout. Result: the check trips CRITICAL with \"Plugin timed out after 10 seconds\" even when Cloudflare is fully reachable (verified live from cr1-nl1: 0% loss, 2.6ms RTT to 2606:4700:4700::1111).

Pre-existing bug, surfaced now because the by_ssh plumbing finally works end-to-end after the #69 / cr1.* user-provisioning bootstrap. The dataplane-level Icinga checks (blackbox-icmp etc.) confirm cr1-nl1 ↔ Cloudflare is fine — the alert is a false positive from the timeout, not an outage.

Add \`-i 0.5\` to space probes at 500ms; same 10 probes in ~5s, leaves comfortable margin for SSH connect + auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent false CRITICAL alerts in IPv6 egress checks by shortening ping6 intervals so checks complete within the by_ssh timeout.