### PR TITLE
cr-bogon-egress: reduce ping6 to -c 5 (FreeBSD subsecond is root-only)

### DIFF
--- a/configs/mon/icinga2/services/cr-bogon-egress.conf
+++ b/configs/mon/icinga2/services/cr-bogon-egress.conf
@@ -4,17 +4,21 @@
 // it fails from the core router itself, before the dataplane-level Icinga
 // checks (which only see ~50% loss via ECMP and look like flap).
 //
-// Coarse but reliable: 10 ping6 probes to a known v6 anchor. If *every*
+// Coarse but reliable: 5 ping6 probes to a known v6 anchor. If *every*
 // probe fails ping6 exits non-zero and by_ssh maps that to CRITICAL.
 // Doesn't catch <100% loss on a single path — that's what the ECMP-aware
 // check from issue #27 is for.
+//
+// FreeBSD ping6 only allows the non-root `monitoring` user to use the
+// default 1s interval, so 5 probes ≈ 4s plus SSH connect/auth keeps the
+// check inside the 10s default `check_by_ssh` plugin timeout.
 
 apply Service "egress-cloudflare-v6" {
   check_command = "by_ssh"
   check_interval = 5m
   retry_interval = 1m
 
-  vars.by_ssh_command = "ping6 -c 10 -i 0.5 -W 1 -q 2606:4700:4700::1111 >/dev/null"
+  vars.by_ssh_command = "ping6 -c 5 -W 1 -q 2606:4700:4700::1111 >/dev/null"
   vars.by_ssh_logname = "monitoring"
   notes = "Cloudflare v6 reachability from core router (regresses if pf.bogons6 blocks outbound NDP)."
 
@@ -26,7 +30,7 @@ apply Service "egress-ns2-v6" {
   check_interval = 5m
   retry_interval = 1m
 
-  vars.by_ssh_command = "ping6 -c 10 -i 0.5 -W 1 -q 2001:41d0:304:300::7bfb >/dev/null"
+  vars.by_ssh_command = "ping6 -c 5 -W 1 -q 2001:41d0:304:300::7bfb >/dev/null"
   vars.by_ssh_logname = "monitoring"
   notes = "ns2 (off-net secondary DNS) reachability from core router."
 


### PR DESCRIPTION
PR #78's `-i 0.5` requires root on FreeBSD: `ping6: Operation not permitted: only root may use interval < 1s`. The unprivileged `monitoring` by_ssh user hits this. Switch to `-c 5` at default 1s interval — ~4s probe time + SSH overhead stays comfortably inside `check_by_ssh`'s 10s plugin timeout. 5 probes is still enough signal for the bogon-NDP-blocks-all-egress regression this check exists to catch (it's all-or-nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust IPv6 egress monitoring checks to use a shorter, rootless-compatible ping sequence within SSH timeout constraints.

Bug Fixes:
- Fix IPv6 egress monitoring failures on FreeBSD by avoiding ping6 subsecond intervals that require root privileges.

Enhancements:
- Reduce ping6 probe count and rely on default 1s interval to keep SSH-based checks within the plugin timeout and reflect intended regression detection behavior.