### PR TITLE
fix: install Redis 8 and repair noc Vault WIF refresh

### DIFF
--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -68,9 +68,9 @@
       vars:
         vault_agent_name: noc-agent
         # vault_agent_vault_addr inherits the role default
-        # (https://[{{ peers.vault.ipv6 }}]:8200 + tls_skip_verify) so noc's
-        # secrets plane survives a Caddy/proxy outage. The public
-        # vault.as215932.net Caddy route stays intact for external consumers.
+        # (http://[{{ peers.vault.ipv6 }}]:8200) so noc's secrets plane
+        # survives a Caddy/proxy outage. The public vault.as215932.net route
+        # stays intact for external consumers.
         vault_agent_role_id: "{{ lookup('env', 'VAULT_NOC_AGENT_ROLE_ID') | default('', true) }}"
         vault_agent_secret_id: "{{ lookup('env', 'VAULT_NOC_AGENT_SECRET_ID') | default('', true) }}"
         vault_agent_env_destination: /opt/noc-agent/.env

--- a/ansible/roles/noc_agent/defaults/main.yml
+++ b/ansible/roles/noc_agent/defaults/main.yml
@@ -23,6 +23,7 @@ nodejs_lts_setup_url: "https://deb.nodesource.com/setup_lts.x"
 
 # langgraph-checkpoint-redis. Keep it bound to localhost for noc-agent only.
 noc_agent_redis_repo_suite: "{{ ansible_distribution_release | lower }}"
+noc_agent_redis_repo_key_source: /usr/share/keyrings/redis-archive-key.asc
 noc_agent_redis_repo_keyring: /usr/share/keyrings/redis-archive-keyring.gpg
 noc_agent_redis_repo_key_url: https://packages.redis.io/gpg
 noc_agent_redis_repo_url: https://packages.redis.io/deb

--- a/ansible/roles/noc_agent/defaults/main.yml
+++ b/ansible/roles/noc_agent/defaults/main.yml
@@ -20,3 +20,9 @@ noc_agent_google_application_credentials: "{{ noc_agent_google_wif_config_path i
 
 # NodeSource setup script for Node.js LTS (used by `npx @xen-orchestra/mcp`).
 nodejs_lts_setup_url: "https://deb.nodesource.com/setup_lts.x"
+
+# langgraph-checkpoint-redis. Keep it bound to localhost for noc-agent only.
+noc_agent_redis_repo_suite: "{{ ansible_distribution_release | lower }}"
+noc_agent_redis_repo_keyring: /usr/share/keyrings/redis-archive-keyring.gpg
+noc_agent_redis_repo_key_url: https://packages.redis.io/gpg
+noc_agent_redis_repo_url: https://packages.redis.io/deb

--- a/ansible/roles/noc_agent/handlers/main.yml
+++ b/ansible/roles/noc_agent/handlers/main.yml
@@ -25,3 +25,9 @@
     state: restarted
     enabled: true
   ignore_errors: "{{ ansible_check_mode }}"
+- name: restart redis-server
+  systemd:
+    name: "redis-server"
+    state: restarted
+    enabled: true
+    daemon_reload: true

--- a/ansible/roles/noc_agent/tasks/main.yml
+++ b/ansible/roles/noc_agent/tasks/main.yml
@@ -11,17 +11,72 @@
       - git
       - ca-certificates
       - curl
-      - redis-server
+      - gpg
     state: present
     update_cache: true
     cache_valid_time: 3600
   tags: [apply]
 
-- name: Ensure Redis checkpoint store is enabled
-  systemd:
+- name: Install Redis apt signing key
+  shell: >-
+    curl -fsSL {{ noc_agent_redis_repo_key_url }} |
+    gpg --dearmor -o {{ noc_agent_redis_repo_keyring }}
+  args:
+    creates: "{{ noc_agent_redis_repo_keyring }}"
+  tags: [apply]
+
+- name: Ensure Redis apt signing key is readable
+  file:
+    path: "{{ noc_agent_redis_repo_keyring }}"
+    owner: root
+    group: root
+    mode: "0644"
+  tags: [apply]
+
+- name: Add Redis apt repository
+  apt_repository:
+    repo: "deb [signed-by={{ noc_agent_redis_repo_keyring }}] {{ noc_agent_redis_repo_url }} {{ noc_agent_redis_repo_suite }} main"
+    filename: redis
+    state: present
+    update_cache: true
+  tags: [apply]
+
+- name: Remove broken Redis Stack package
+  apt:
+    name: redis-stack-server
+    state: absent
+    purge: true
+    autoremove: true
+  tags: [apply]
+
+- name: Install Redis 8 server
+  apt:
     name: redis-server
+    state: present
+  tags: [apply]
+
+- name: Keep Redis 8 bound to localhost
+  lineinfile:
+    path: "/etc/redis/redis.conf"
+    regexp: '^#?\s*bind\s+'
+    line: "bind 127.0.0.1 ::1"
+  notify: restart redis-server
+  tags: [apply]
+
+- name: Keep Redis 8 protected mode enabled
+  lineinfile:
+    path: "/etc/redis/redis.conf"
+    regexp: '^#?\s*protected-mode\s+'
+    line: "protected-mode yes"
+  notify: restart redis-server
+  tags: [apply]
+
+- name: Ensure Redis 8 service is started
+  systemd:
+    name: "redis-server"
     state: started
     enabled: true
+    daemon_reload: true
   tags: [apply]
 
 - name: Check if Node.js is already installed

--- a/ansible/roles/noc_agent/tasks/main.yml
+++ b/ansible/roles/noc_agent/tasks/main.yml
@@ -17,12 +17,32 @@
     cache_valid_time: 3600
   tags: [apply]
 
+- name: Download Redis apt signing key
+  get_url:
+    url: "{{ noc_agent_redis_repo_key_url }}"
+    dest: "{{ noc_agent_redis_repo_key_source }}"
+    owner: root
+    group: root
+    mode: "0644"
+  register: noc_agent_redis_repo_key_download
+  tags: [apply]
+
+- name: Check if Redis apt signing keyring exists
+  stat:
+    path: "{{ noc_agent_redis_repo_keyring }}"
+  register: noc_agent_redis_repo_keyring_stat
+  tags: [apply]
+
 - name: Install Redis apt signing key
-  shell: >-
-    curl -fsSL {{ noc_agent_redis_repo_key_url }} |
-    gpg --dearmor -o {{ noc_agent_redis_repo_keyring }}
-  args:
-    creates: "{{ noc_agent_redis_repo_keyring }}"
+  command:
+    argv:
+      - gpg
+      - --dearmor
+      - --yes
+      - --output
+      - "{{ noc_agent_redis_repo_keyring }}"
+      - "{{ noc_agent_redis_repo_key_source }}"
+  when: noc_agent_redis_repo_key_download.changed or not noc_agent_redis_repo_keyring_stat.stat.exists
   tags: [apply]
 
 - name: Ensure Redis apt signing key is readable
@@ -60,6 +80,7 @@
     path: "/etc/redis/redis.conf"
     regexp: '^#?\s*bind\s+'
     line: "bind 127.0.0.1 ::1"
+    backup: true
   notify: restart redis-server
   tags: [apply]
 
@@ -68,6 +89,7 @@
     path: "/etc/redis/redis.conf"
     regexp: '^#?\s*protected-mode\s+'
     line: "protected-mode yes"
+    backup: true
   notify: restart redis-server
   tags: [apply]
 

--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -1,11 +1,10 @@
 ---
 vault_agent_name: noc-agent
-# Direct internal IPv6 so the secrets plane survives a Caddy/proxy outage.
-# The public hostname stays for external consumers (CI, ops workstation);
-# infra-side renewals run over the AS215932 /64, where MITM requires
-# already being inside the subnet — tls_skip_verify is acceptable.
-vault_agent_vault_addr: "https://[{{ peers.vault.ipv6 }}]:8200"
-vault_agent_vault_tls_skip_verify: true
+# Direct internal IPv6 over the plain-HTTP Vault listener. The public hostname
+# stays for external consumers (CI, ops workstation); infra-side renewals bypass
+# Caddy so a proxy outage does not break the secrets plane.
+vault_agent_vault_addr: "http://[{{ peers.vault.ipv6 }}]:8200"
+vault_agent_vault_tls_skip_verify: false
 vault_agent_config_dir: "/etc/vault-agent.d"
 vault_agent_run_dir: "/run/vault-agent"
 vault_agent_role_id: ""

--- a/docs/vault-wif.md
+++ b/docs/vault-wif.md
@@ -7,6 +7,7 @@ This is the v1 secret architecture for the NOC Agent:
 - Vault issues a short-lived OIDC identity token at `identity/oidc/token/google-wif-noc-agent`.
 - Google Workload Identity Federation exchanges that token for a short-lived Google access token.
 - `GOOGLE_APPLICATION_CREDENTIALS=/etc/noc-agent/google-wif.json` makes the standard Google client libraries use ADC without a static service-account key.
+- Infra-side Vault Agent traffic uses the internal plain-HTTP Vault listener on the vault VM's internal port 8200; the public `vault.as215932.net` route remains for external operators and CI.
 
 ## One-time rollout
 


### PR DESCRIPTION
## Summary
- switch noc-agent Redis provisioning from redis-stack-server to redis-server from the official Redis APT repo
- track the Redis repo by Debian codename so trixie hosts install Redis 8 directly
- point Vault Agent at the internal plain-HTTP Vault listener so WIF subject token refresh works again

## Why
The noc rollout had two linked infra issues:
- redis-stack-server was not viable on Debian 13/Trixie, while the official Redis repo provides Redis 8.6.x with the FT/JSON surface noc-agent needs
- vault-agent-noc-agent was configured for https://[vault]:8200 even though the internal Vault listener is plain HTTP, which broke WIF JWT refresh and surfaced as Gemini quota OAuth failures in /health/model

## Validation
- ansible-playbook --syntax-check playbooks/noc.yml
- live verification on noc: Redis 8.6.3 installed from packages.redis.io trixie
- live verification on noc: Vault Agent authenticated and re-rendered /run/noc-agent/google-subject.jwt
- live verification from mon: noc-agent model-health plugin returned OK after the Vault fix

## Summary by Sourcery

Switch noc-agent Redis provisioning to the official Redis APT repository and ensure Redis 8 is securely configured, while correcting Vault Agent to use the internal plain-HTTP Vault listener for reliable WIF token refresh.

New Features:
- Provision Redis 8 for noc-agent from the official Redis APT repository tracked by Debian release.
- Configure noc-agent Redis defaults for the external Redis repository and keyring locations.

Bug Fixes:
- Fix Vault Agent configuration for noc-agent to use the internal plain-HTTP Vault listener so WIF subject token refresh works reliably.
- Remove the incompatible redis-stack-server package from noc hosts to prevent Redis provisioning failures on newer Debian releases.

Enhancements:
- Ensure Redis 8 is bound to localhost with protected mode enabled and managed via systemd with a dedicated restart handler.
- Document the updated Vault WIF architecture, including use of the internal Vault listener for infra-side traffic.

Documentation:
- Update Vault WIF documentation to describe infra-side use of the internal plain-HTTP Vault listener.