### PR TITLE
fix: read Redis repo suite from gathered facts

### DIFF
--- a/ansible/roles/noc_agent/defaults/main.yml
+++ b/ansible/roles/noc_agent/defaults/main.yml
@@ -22,7 +22,7 @@ noc_agent_google_application_credentials: "{{ noc_agent_google_wif_config_path i
 nodejs_lts_setup_url: "https://deb.nodesource.com/setup_lts.x"
 
 # langgraph-checkpoint-redis. Keep it bound to localhost for noc-agent only.
-noc_agent_redis_repo_suite: "{{ ansible_distribution_release | lower }}"
+noc_agent_redis_repo_suite: "{{ ansible_facts['distribution_release'] | lower }}"
 noc_agent_redis_repo_key_source: /usr/share/keyrings/redis-archive-key.asc
 noc_agent_redis_repo_keyring: /usr/share/keyrings/redis-archive-keyring.gpg
 noc_agent_redis_repo_key_url: https://packages.redis.io/gpg


### PR DESCRIPTION
## Summary
- read the Redis APT suite from `ansible_facts["distribution_release"]` instead of `ansible_distribution_release`

## Why
The merged noc deployment failed in the apply workflow because the runner path did not expose `ansible_distribution_release` during task argument resolution. A gathered-facts check on noc confirmed that the stable fact key in this environment is `ansible_facts["distribution_release"]`.

## Validation
- ansible-playbook --syntax-check playbooks/noc.yml
- one-off gathered-facts play on noc confirmed `ansible_facts["distribution_release"] == "trixie"`

## Summary by Sourcery

Bug Fixes:
- Fix Redis APT repository suite selection in the noc agent role by using ansible_facts['distribution_release'] so it works in environments where ansible_distribution_release is unavailable.