### PR TITLE
ansible(hyrule_cloud): add role + playbooks + Caddyfile capture (Wave 0 substrate)

### DIFF
--- a/ansible/playbooks/cloud.yml
+++ b/ansible/playbooks/cloud.yml
@@ -1,0 +1,53 @@
+---
+# hyrule-cloud — apply the hyrule_cloud role on the api VM.
+#
+# Validate (no live changes; runs from controller):
+#   ansible-playbook playbooks/cloud.yml --tags validate \
+#     --connection=local --limit api --skip-tags=snapshot
+#
+# Apply (live deploy):
+#   ansible-playbook playbooks/cloud.yml --tags apply \
+#     -e hyrule_cloud_apply=true \
+#     -e hyrule_cloud_version=<sha-or-ref> \
+#     --limit api
+#
+# The deploy.yml workflow in AS215932/hyrule-cloud invokes the apply variant
+# with hyrule_cloud_version=${{ github.sha }} so production deploys are pinned
+# to the exact commit that passed CI.
+#
+# Wave 2 prerequisite: the toy `accounts` and `crypto_intents` tables created
+# via hand-applied db_patch{1,2,3}.py scripts must be dropped before Wave 2's
+# migration 003/004 run. Use the one-shot playbooks/cloud_toy_cleanup.yml
+# (idempotent, refuses to drop non-empty tables) before the Wave 2 deploy.
+
+- name: hyrule-cloud — apply
+  hosts: api
+  serial: 1
+  gather_facts: false
+  become: true
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      ansible.builtin.include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
+  roles:
+    - role: hyrule_cloud
+      tags: [hyrule_cloud]
+  post_tasks:
+    # Flush handlers so the post-snapshot reflects the new service state.
+    - name: Flush handlers before post-deploy snapshot
+      ansible.builtin.meta: flush_handlers
+      tags: [apply, always]
+    - name: Post-deploy Icinga snapshot
+      ansible.builtin.include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
+  tags: [hyrule_cloud]

--- a/ansible/playbooks/cloud_toy_cleanup.yml
+++ b/ansible/playbooks/cloud_toy_cleanup.yml
@@ -1,0 +1,108 @@
+---
+# One-shot cleanup of the hand-applied toy `accounts` and `crypto_intents`
+# tables on api's hyrule DB. These were created via db_patch{1,2,3}.py before
+# the alembic chain caught up (alembic_version still says 001 because the
+# patches never registered a revision). The Wave 2 deploy's migration 003
+# (auth_and_ownership) and 004 (intent_engine) will try to `create_table` for
+# both and fail loudly if they still exist.
+#
+# Run BEFORE the first Wave 2 apply:
+#   ansible-playbook playbooks/cloud_toy_cleanup.yml \
+#     -e cloud_toy_cleanup_apply=true --limit api
+#
+# This playbook is read-only by default. Pass cloud_toy_cleanup_apply=true to
+# actually run the DROPs. It refuses to drop a non-empty table — if any row
+# appeared since the 2026-05-18 audit, the drop fails and the operator
+# investigates before re-trying.
+
+- name: hyrule-cloud — toy table cleanup (one-shot, pre-Wave-2)
+  hosts: api
+  gather_facts: false
+  become: true
+
+  vars:
+    cloud_toy_cleanup_apply: false
+
+  tasks:
+    - name: Snapshot alembic_version on api hyrule DB
+      ansible.builtin.command:
+        cmd: sudo -u postgres psql hyrule -tAc "SELECT version_num FROM alembic_version;"
+      register: alembic_version_result
+      changed_when: false
+
+    - name: Snapshot row counts for accounts + crypto_intents
+      ansible.builtin.command:
+        cmd: >-
+          sudo -u postgres psql hyrule -tAc
+          "SELECT COALESCE((SELECT count(*) FROM accounts),0)
+           || ' ' || COALESCE((SELECT count(*) FROM crypto_intents),0);"
+      register: toy_row_counts
+      changed_when: false
+      failed_when: false
+
+    - name: Report current state
+      ansible.builtin.debug:
+        msg: |
+          alembic_version  = {{ alembic_version_result.stdout | trim }}
+          accounts rows    = {{ toy_row_counts.stdout.split(' ')[0] | default('?') }}
+          crypto_intents   = {{ toy_row_counts.stdout.split(' ')[1] | default('?') }}
+          cleanup_apply    = {{ cloud_toy_cleanup_apply }}
+
+    - name: Refuse to proceed if alembic_version != "001"
+      ansible.builtin.assert:
+        that:
+          - (alembic_version_result.stdout | trim) == "001"
+        fail_msg: >-
+          alembic_version is "{{ alembic_version_result.stdout | trim }}",
+          not "001". Either migrations have already advanced (cleanup not
+          needed) or DB is in an unexpected state. Investigate before forcing.
+
+    - name: Refuse to drop non-empty tables
+      ansible.builtin.assert:
+        that:
+          - (toy_row_counts.stdout.split(' ')[0] | int) == 0
+          - (toy_row_counts.stdout.split(' ')[1] | int) == 0
+        fail_msg: >-
+          Refusing to drop non-empty toy tables. Counts are
+          "{{ toy_row_counts.stdout | trim }}". Inspect rows before retrying.
+
+    - name: Drop toy crypto_intents table + status enum
+      ansible.builtin.command:
+        cmd: >-
+          sudo -u postgres psql hyrule -v ON_ERROR_STOP=1 -c
+          "DROP TABLE IF EXISTS crypto_intents;
+           DROP TYPE IF EXISTS crypto_intent_status;"
+      when: cloud_toy_cleanup_apply | bool
+      register: drop_intents
+      changed_when: drop_intents.rc == 0
+
+    - name: Drop toy accounts table
+      ansible.builtin.command:
+        cmd: >-
+          sudo -u postgres psql hyrule -v ON_ERROR_STOP=1 -c
+          "DROP TABLE IF EXISTS accounts;"
+      when: cloud_toy_cleanup_apply | bool
+      register: drop_accounts
+      changed_when: drop_accounts.rc == 0
+
+    - name: Verify drop
+      ansible.builtin.command:
+        cmd: >-
+          sudo -u postgres psql hyrule -tAc
+          "SELECT to_regclass('accounts'),
+                  to_regclass('crypto_intents'),
+                  (SELECT to_regtype('crypto_intent_status'));"
+      register: post_drop_state
+      changed_when: false
+      when: cloud_toy_cleanup_apply | bool
+
+    - name: Assert toy tables are gone
+      ansible.builtin.assert:
+        that:
+          - "'accounts' not in post_drop_state.stdout"
+          - "'crypto_intents' not in post_drop_state.stdout"
+          - "'crypto_intent_status' not in post_drop_state.stdout"
+        fail_msg: >-
+          Post-drop check still sees one of the toy artifacts:
+          {{ post_drop_state.stdout }}
+      when: cloud_toy_cleanup_apply | bool

--- a/ansible/playbooks/cloud_toy_cleanup.yml
+++ b/ansible/playbooks/cloud_toy_cleanup.yml
@@ -30,22 +30,46 @@
       register: alembic_version_result
       changed_when: false
 
+    # Use to_regclass so the query stays valid even if a table is missing
+    # (e.g. an earlier partial cleanup). Tagged output (`accounts=N
+    # intents=M`) is matched with a regex before parsing so a missing /
+    # malformed line trips a clean assertion, not a template error.
     - name: Snapshot row counts for accounts + crypto_intents
       ansible.builtin.command:
         cmd: >-
           sudo -u postgres psql hyrule -tAc
-          "SELECT COALESCE((SELECT count(*) FROM accounts),0)
-           || ' ' || COALESCE((SELECT count(*) FROM crypto_intents),0);"
+          "SELECT 'accounts=' ||
+              CASE WHEN to_regclass('accounts') IS NULL
+                   THEN '0' ELSE (SELECT count(*)::text FROM accounts) END
+           || ' intents=' ||
+              CASE WHEN to_regclass('crypto_intents') IS NULL
+                   THEN '0' ELSE (SELECT count(*)::text FROM crypto_intents) END;"
       register: toy_row_counts
       changed_when: false
       failed_when: false
+
+    - name: Assert the row-count query succeeded
+      ansible.builtin.assert:
+        that:
+          - toy_row_counts.rc == 0
+          - toy_row_counts.stdout is regex('^accounts=\d+ intents=\d+$')
+        fail_msg: >-
+          Could not parse row counts from psql. rc={{ toy_row_counts.rc }};
+          stdout={{ toy_row_counts.stdout | default('(empty)') | trim }};
+          stderr={{ toy_row_counts.stderr | default('') | trim }}.
+          Inspect the DB connection / postgres role before re-running.
+
+    - name: Parse row counts
+      ansible.builtin.set_fact:
+        toy_accounts_rows: "{{ (toy_row_counts.stdout | regex_search('accounts=(\\d+)', '\\1'))[0] | int }}"
+        toy_intents_rows: "{{ (toy_row_counts.stdout | regex_search('intents=(\\d+)', '\\1'))[0] | int }}"
 
     - name: Report current state
       ansible.builtin.debug:
         msg: |
           alembic_version  = {{ alembic_version_result.stdout | trim }}
-          accounts rows    = {{ toy_row_counts.stdout.split(' ')[0] | default('?') }}
-          crypto_intents   = {{ toy_row_counts.stdout.split(' ')[1] | default('?') }}
+          accounts rows    = {{ toy_accounts_rows }}
+          crypto_intents   = {{ toy_intents_rows }}
           cleanup_apply    = {{ cloud_toy_cleanup_apply }}
 
     - name: Refuse to proceed if alembic_version != "001"
@@ -60,11 +84,11 @@
     - name: Refuse to drop non-empty tables
       ansible.builtin.assert:
         that:
-          - (toy_row_counts.stdout.split(' ')[0] | int) == 0
-          - (toy_row_counts.stdout.split(' ')[1] | int) == 0
+          - toy_accounts_rows == 0
+          - toy_intents_rows == 0
         fail_msg: >-
-          Refusing to drop non-empty toy tables. Counts are
-          "{{ toy_row_counts.stdout | trim }}". Inspect rows before retrying.
+          Refusing to drop non-empty toy tables. accounts={{ toy_accounts_rows }},
+          crypto_intents={{ toy_intents_rows }}. Inspect rows before retrying.
 
     - name: Drop toy crypto_intents table + status enum
       ansible.builtin.command:

--- a/ansible/roles/hyrule_cloud/defaults/main.yml
+++ b/ansible/roles/hyrule_cloud/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+# hyrule-cloud — FastAPI API deployed on the api VM at :8402, fronted by
+# Caddy on proxy (cloud.hyrule.host / api.hyrule.host). Code lives in
+# AS215932/hyrule-cloud on GitHub.
+#
+# Apply: ansible-playbook playbooks/cloud.yml --tags apply \
+#          -e hyrule_cloud_apply=true -e hyrule_cloud_version=<sha>
+# Validate (no-op): ansible-playbook playbooks/cloud.yml --tags validate \
+#          --connection=local --limit api --skip-tags=snapshot
+
+hyrule_cloud_apply: false
+
+# User/group must match the systemd unit (configs/hyrule-cloud.service):
+# both are literally `hyrule` (not `hyrule-cloud`). Service runs
+# ProtectSystem=strict + ReadWritePaths=/opt/hyrule-cloud, so the install
+# dir must be writable by this user.
+hyrule_cloud_app_user: hyrule
+hyrule_cloud_app_group: hyrule
+
+hyrule_cloud_install_dir: /opt/hyrule-cloud
+hyrule_cloud_etc_dir: /etc/hyrule-cloud
+hyrule_cloud_state_dir: /var/lib/hyrule-cloud
+
+# The role uses the per-app deploy-key SSH alias (see ssh_config.j2) instead
+# of github.com directly, so the key in IdentityFile is unambiguous.
+hyrule_cloud_repo: git@github-hyrule-cloud:AS215932/hyrule-cloud.git
+# Override per-deploy via -e hyrule_cloud_version=<sha>. The deploy.yml
+# workflow passes ${{ github.sha }} so production deploys are SHA-pinned;
+# rollback is the same flag with an older SHA.
+hyrule_cloud_version: main
+
+hyrule_cloud_deploy_key_path: "{{ hyrule_cloud_state_dir }}/.ssh/id_hyrule_cloud"
+
+hyrule_cloud_service_name: hyrule-cloud
+# /health is the lightweight readiness probe (no DB hit). Bound to :: in
+# the unit; loopback works.
+hyrule_cloud_listen_url: http://[::1]:8402/health
+
+# Base apt packages on the target. uv is installed separately via the
+# upstream script (same idiom as hyrule_web / hyrule_mcp).
+hyrule_cloud_packages:
+  - python3
+  - python3-venv
+  - git
+  - ca-certificates
+  - curl
+  # libpq-dev is needed by asyncpg/psycopg builds on Debian. The api VM
+  # already has it because PostgreSQL is installed locally; listing it
+  # here makes the role portable to a fresh host.
+  - libpq-dev

--- a/ansible/roles/hyrule_cloud/handlers/main.yml
+++ b/ansible/roles/hyrule_cloud/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart hyrule-cloud
+  ansible.builtin.systemd:
+    name: "{{ hyrule_cloud_service_name }}"
+    state: restarted
+    enabled: true

--- a/ansible/roles/hyrule_cloud/meta/main.yml
+++ b/ansible/roles/hyrule_cloud/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: hyrule_cloud
+  description: >-
+    Deploy hyrule-cloud (FastAPI) on the api VM. SHA-pinned checkout from
+    AS215932/hyrule-cloud, uv-managed venv, env file rendered from Vault
+    secrets, systemd unit ownership, post-deploy health probe.
+  author: AS215932 ops
+  license: proprietary
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Debian
+      versions:
+        - "13"
+dependencies: []

--- a/ansible/roles/hyrule_cloud/tasks/apply.yml
+++ b/ansible/roles/hyrule_cloud/tasks/apply.yml
@@ -1,0 +1,70 @@
+---
+# Prereqs: base packages, uv, user/group, directories. Pattern matches
+# ansible/roles/hyrule_web/tasks/apply.yml so a future operator can read either
+# role and recognise the shape.
+
+- name: Ensure base packages are installed
+  ansible.builtin.apt:
+    name: "{{ hyrule_cloud_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install uv (Python package manager)
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+  args:
+    creates: /usr/local/bin/uv
+
+- name: Ensure hyrule group exists
+  ansible.builtin.group:
+    name: "{{ hyrule_cloud_app_group }}"
+    system: true
+
+# Don't pass `home:` — on first install we accept the user module's default
+# (/home/<user>); on hosts where the user already exists, changing home
+# would force a usermod that fails while the service is running. The deploy
+# key + SSH config live under hyrule_cloud_state_dir regardless of the
+# user's home, owned by hyrule_cloud_app_user.
+- name: Ensure hyrule user exists
+  ansible.builtin.user:
+    name: "{{ hyrule_cloud_app_user }}"
+    group: "{{ hyrule_cloud_app_group }}"
+    shell: /bin/bash
+    system: true
+
+- name: Ensure runtime directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(hyrule_cloud_app_user) }}"
+    group: "{{ item.group | default(hyrule_cloud_app_group) }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ hyrule_cloud_install_dir }}", mode: "0755" }
+    - { path: "{{ hyrule_cloud_etc_dir }}", owner: root, mode: "0750" }
+    - { path: "{{ hyrule_cloud_state_dir }}", mode: "0750" }
+    - { path: "{{ hyrule_cloud_state_dir }}/.ssh", mode: "0700" }
+
+# The pre-existing /opt/hyrule-cloud checkout was made by root historically
+# (alembic_version=001 came from there), so git sees a dubious-ownership
+# warning when run as the hyrule user. Allow it once; idempotent.
+- name: Mark /opt/hyrule-cloud as a safe.directory for the hyrule user
+  ansible.builtin.command:
+    cmd: git config --global --add safe.directory {{ hyrule_cloud_install_dir }}
+  become: true
+  become_user: "{{ hyrule_cloud_app_user }}"
+  changed_when: false
+
+- name: Bootstrap per-app deploy key and SSH config
+  ansible.builtin.import_tasks: bootstrap_key.yml
+
+- name: Checkout hyrule-cloud at the requested ref
+  ansible.builtin.import_tasks: checkout.yml
+
+- name: Sync runtime (uv, env, systemd unit, toy-table cleanup)
+  ansible.builtin.import_tasks: runtime.yml
+
+- name: Post-deploy health check
+  ansible.builtin.import_tasks: health.yml

--- a/ansible/roles/hyrule_cloud/tasks/bootstrap_key.yml
+++ b/ansible/roles/hyrule_cloud/tasks/bootstrap_key.yml
@@ -1,0 +1,57 @@
+---
+# Generate the per-app deploy key on the target VM (idempotent — the
+# openssh_keypair module is a no-op if the key exists). On creation, print
+# the pubkey and the URL where the operator must register it. The subsequent
+# git clone fails loud if the key isn't registered yet — but the debug from
+# this task is one task above it in the playbook log, so the operator sees
+# what to do.
+
+- name: Generate hyrule-cloud deploy SSH keypair (idempotent)
+  community.crypto.openssh_keypair:
+    path: "{{ hyrule_cloud_deploy_key_path }}"
+    type: ed25519
+    owner: "{{ hyrule_cloud_app_user }}"
+    group: "{{ hyrule_cloud_app_group }}"
+    mode: "0600"
+    comment: "hyrule@api deploy:hyrule-cloud"
+  register: hyrule_cloud_keypair
+
+- name: Slurp deploy public key
+  ansible.builtin.slurp:
+    src: "{{ hyrule_cloud_deploy_key_path }}.pub"
+  register: hyrule_cloud_pubkey
+
+# Surface the registration instruction every run on first-create (changed),
+# and on demand by always being available in the play log even on no-op runs.
+- name: Show deploy public key registration instructions (on key create)
+  ansible.builtin.debug:
+    msg: |
+      hyrule-cloud deploy key (read-only) — add to:
+        https://github.com/AS215932/hyrule-cloud/settings/keys
+      Pubkey:
+        {{ hyrule_cloud_pubkey.content | b64decode | trim }}
+  when: hyrule_cloud_keypair.changed
+
+# StrictHostKeyChecking yes + UserKnownHostsFile — never accept_hostkey at
+# runtime. Seed the host key explicitly so git clone doesn't prompt.
+- name: Seed github.com host key into known_hosts
+  ansible.builtin.known_hosts:
+    name: github.com
+    key: "{{ lookup('pipe', 'ssh-keyscan -t ed25519 github.com 2>/dev/null') }}"
+    path: "{{ hyrule_cloud_state_dir }}/.ssh/known_hosts"
+    state: present
+
+- name: Ensure known_hosts ownership
+  ansible.builtin.file:
+    path: "{{ hyrule_cloud_state_dir }}/.ssh/known_hosts"
+    owner: "{{ hyrule_cloud_app_user }}"
+    group: "{{ hyrule_cloud_app_group }}"
+    mode: "0644"
+
+- name: Render SSH config for the github-hyrule-cloud alias
+  ansible.builtin.template:
+    src: ssh_config.j2
+    dest: "{{ hyrule_cloud_state_dir }}/.ssh/config"
+    owner: "{{ hyrule_cloud_app_user }}"
+    group: "{{ hyrule_cloud_app_group }}"
+    mode: "0600"

--- a/ansible/roles/hyrule_cloud/tasks/checkout.yml
+++ b/ansible/roles/hyrule_cloud/tasks/checkout.yml
@@ -1,0 +1,16 @@
+---
+# Clone (first run) or fetch + checkout (subsequent) at the requested ref.
+# version: accepts a branch, tag, or SHA — the deploy.yml workflow passes
+# ${{ github.sha }} so production deploys are pinned to a specific commit.
+
+- name: Checkout hyrule-cloud at the requested ref
+  ansible.builtin.git:
+    repo: "{{ hyrule_cloud_repo }}"
+    dest: "{{ hyrule_cloud_install_dir }}"
+    version: "{{ hyrule_cloud_version }}"
+    update: true
+    force: true
+    accept_hostkey: false
+  become: true
+  become_user: "{{ hyrule_cloud_app_user }}"
+  notify: restart hyrule-cloud

--- a/ansible/roles/hyrule_cloud/tasks/health.yml
+++ b/ansible/roles/hyrule_cloud/tasks/health.yml
@@ -1,0 +1,31 @@
+---
+# Flush handlers so the systemd-active assert and the HTTP probe see the
+# *post-restart* state, not the pre-restart state. Without flush_handlers,
+# Ansible runs handlers at end-of-play and these checks would race the restart.
+
+- name: Flush handlers before health check
+  ansible.builtin.meta: flush_handlers
+
+- name: Check hyrule-cloud systemd state
+  ansible.builtin.systemd:
+    name: "{{ hyrule_cloud_service_name }}"
+  register: hyrule_cloud_service
+
+- name: Assert hyrule-cloud service is active
+  ansible.builtin.assert:
+    that:
+      - hyrule_cloud_service.status.ActiveState == "active"
+    fail_msg: >-
+      hyrule-cloud.service is {{ hyrule_cloud_service.status.ActiveState }};
+      expected "active". Check journalctl -u hyrule-cloud on the target.
+
+- name: HTTP health check (local loopback)
+  ansible.builtin.uri:
+    url: "{{ hyrule_cloud_listen_url }}"
+    status_code: 200
+    return_content: false
+    timeout: 5
+  register: hyrule_cloud_http
+  retries: 10
+  delay: 3
+  until: hyrule_cloud_http.status == 200

--- a/ansible/roles/hyrule_cloud/tasks/main.yml
+++ b/ansible/roles/hyrule_cloud/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# Validate always runs (cheap assertions; safe with --connection=local).
+# Apply is gated on hyrule_cloud_apply=true so default playbook invocations
+# never mutate the live api service.
+- name: Validate hyrule_cloud inputs and reusable configs
+  ansible.builtin.import_tasks: validate.yml
+  tags: [validate, always]
+
+- name: Apply hyrule_cloud role
+  ansible.builtin.import_tasks: apply.yml
+  when: hyrule_cloud_apply | bool
+  tags: [apply]

--- a/ansible/roles/hyrule_cloud/tasks/runtime.yml
+++ b/ansible/roles/hyrule_cloud/tasks/runtime.yml
@@ -1,0 +1,40 @@
+---
+# --no-dev: skip pytest/ruff/mypy on the production venv. Those run in CI.
+# changed_when: false because we want git/template/unit tasks to drive the
+# restart notification — uv's "Audited"/"Resolved" stdout is noisy and would
+# fire spurious restarts.
+
+- name: Check for hyrule-cloud pyproject.toml (gated on a successful clone)
+  ansible.builtin.stat:
+    path: "{{ hyrule_cloud_install_dir }}/pyproject.toml"
+  register: hyrule_cloud_pyproject
+
+- name: Sync hyrule-cloud production dependencies via uv
+  ansible.builtin.command:
+    cmd: /usr/local/bin/uv sync --frozen --no-dev
+    chdir: "{{ hyrule_cloud_install_dir }}"
+  become: true
+  become_user: "{{ hyrule_cloud_app_user }}"
+  changed_when: false
+  when: hyrule_cloud_pyproject.stat.exists
+  notify: restart hyrule-cloud
+
+- name: Render hyrule-cloud environment file
+  ansible.builtin.template:
+    src: "{{ playbook_dir }}/../../configs/hyrule-cloud.env.j2"
+    dest: "{{ hyrule_cloud_install_dir }}/.env"
+    owner: "{{ hyrule_cloud_app_user }}"
+    group: "{{ hyrule_cloud_app_group }}"
+    mode: "0640"
+  notify: restart hyrule-cloud
+
+- name: Install /etc/systemd/system/hyrule-cloud.service
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../configs/hyrule-cloud.service"
+    dest: /etc/systemd/system/hyrule-cloud.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart hyrule-cloud

--- a/ansible/roles/hyrule_cloud/tasks/validate.yml
+++ b/ansible/roles/hyrule_cloud/tasks/validate.yml
@@ -1,0 +1,39 @@
+---
+# Assertions that run on every invocation. Cheap, controller-local where
+# possible, and they make `--tags validate` a real safety net rather than
+# a no-op rubber stamp.
+
+- name: Assert hyrule_cloud_version is set to a non-empty ref
+  ansible.builtin.assert:
+    that:
+      - hyrule_cloud_version is defined
+      - hyrule_cloud_version | length > 0
+    fail_msg: >-
+      hyrule_cloud_version must be set to a branch, tag, or commit SHA.
+      The deploy workflow normally passes the triggering commit SHA;
+      for local runs pass -e hyrule_cloud_version=main (or a SHA for rollback).
+
+- name: Stat reusable configs on the controller (hyrule-cloud.service)
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../../configs/hyrule-cloud.service"
+  register: hyrule_cloud_service_file
+  delegate_to: localhost
+  become: false
+  changed_when: false
+
+- name: Stat reusable configs on the controller (hyrule-cloud.env.j2)
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../../configs/hyrule-cloud.env.j2"
+  register: hyrule_cloud_env_template
+  delegate_to: localhost
+  become: false
+  changed_when: false
+
+- name: Assert reusable configs are present
+  ansible.builtin.assert:
+    that:
+      - hyrule_cloud_service_file.stat.exists
+      - hyrule_cloud_env_template.stat.exists
+    fail_msg: >-
+      configs/hyrule-cloud.{service,env.j2} must exist in the hyrule-infra
+      repo; the role refuses to apply without them.

--- a/ansible/roles/hyrule_cloud/templates/ssh_config.j2
+++ b/ansible/roles/hyrule_cloud/templates/ssh_config.j2
@@ -1,0 +1,10 @@
+# Managed by ansible/roles/hyrule_cloud. Per-app deploy-key alias for cloning
+# AS215932/hyrule-cloud. Strict host-key checking against the seeded known_hosts.
+
+Host github-hyrule-cloud
+    HostName github.com
+    User git
+    IdentityFile {{ hyrule_cloud_deploy_key_path }}
+    IdentitiesOnly yes
+    StrictHostKeyChecking yes
+    UserKnownHostsFile {{ hyrule_cloud_state_dir }}/.ssh/known_hosts

--- a/configs/Caddyfile
+++ b/configs/Caddyfile
@@ -1,0 +1,270 @@
+# /etc/caddy/Caddyfile — Hyrule Cloud TLS reverse proxy
+# Deploy to: proxy VM (2a0c:b641:b50:2::40)
+# Requires: caddy built with github.com/caddy-dns/rfc2136
+#   xcaddy build --with github.com/caddy-dns/rfc2136
+#
+# All backends are IPv6-only on AS215932 public space.
+#
+# Variables to fill:
+#   admin@servify.network      — Let's Encrypt contact email
+#   vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=     — Base64 TSIG secret
+
+{
+    email admin@servify.network
+}
+
+# API — cloud.hyrule.host (canonical) and api.hyrule.host (compatibility)
+cloud.hyrule.host, api.hyrule.host {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    reverse_proxy [2a0c:b641:b50:2::20]:8402 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/api.log
+    }
+}
+
+# Web frontend — hyrule.host (+ www redirect to apex).
+# Both subjects share one site block so the TLS/proxy/header config isn't
+# duplicated. Caddy issues per-subject certs (not a SAN). Matches the
+# as215932.net block below.
+hyrule.host, www.hyrule.host {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    @www host www.hyrule.host
+    redir @www https://hyrule.host{uri} permanent
+
+    reverse_proxy [2a0c:b641:b50:2::30]:8080 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/web.log
+    }
+}
+
+# Grafana — grafana.servify.network
+grafana.servify.network {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    reverse_proxy [2a0c:b641:b50:2::50]:3000 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/grafana.log
+    }
+}
+
+# Icinga Web — mon.servify.network
+mon.servify.network {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    reverse_proxy [2a0c:b641:b50:2::50]:80 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/mon.log
+    }
+}
+
+# AS215932 info site — apex + www share one site block so the TLS config,
+# reverse proxy, headers, and redirect logic aren't duplicated. Caddy still
+# issues one cert per subject (Caddyfile site blocks don't produce SAN certs);
+# propagation_delay above masks Openprovider's slow secondary AXFR.
+# Static HTML served by nginx on the web VM (port 8081).
+as215932.net, www.as215932.net {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    @www host www.as215932.net
+    redir @www https://as215932.net{uri} permanent
+
+    reverse_proxy [2a0c:b641:b50:2::30]:8081 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        # No JS anywhere on the site; lock it down so Tor Safest mode is happy.
+        Content-Security-Policy "default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+        Referrer-Policy "no-referrer"
+        X-Content-Type-Options "nosniff"
+    }
+
+    log {
+        output file /var/log/caddy/as215932.log
+    }
+}
+
+# Xen Orchestra — xo.servify.network
+xo.servify.network {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    reverse_proxy [2a0c:b641:b50:2::70]:80 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/xo.log
+    }
+}
+
+# Vault — machine secret plane for AS215932 workloads.
+vault.as215932.net {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key vLFkcfnJZux1BQuoaavvrwNS97vyhomvN6NEle92qG8=
+        }
+        propagation_delay 60s
+    }
+
+    reverse_proxy [2a0c:b641:b50:2::c0]:8200 {
+        transport http {
+            dial_timeout 3s
+            response_header_timeout 8s
+            read_timeout 30s
+            write_timeout 30s
+            keepalive 30s
+            keepalive_idle_conns 10
+        }
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    }
+
+    log {
+        output file /var/log/caddy/vault.log
+    }
+}
+
+# Wildcard for customer VM subdomains (future — HTTPS proxy to VMs)
+# *.deploy.hyrule.host {
+#     tls {
+#         dns rfc2136 { ... }
+#     }
+#     # Route to customer VMs based on subdomain lookup
+# }


### PR DESCRIPTION
## Summary
- Add `ansible/roles/hyrule_cloud/` mirroring `hyrule_web` (defaults, handlers, meta, tasks/{main,validate,apply,bootstrap_key,checkout,runtime,health}, templates/ssh_config.j2).
- Add `ansible/playbooks/cloud.yml` with pre/post Icinga snapshot wrapping per [feedback_icinga_pre_post_deploy.md].
- Add `ansible/playbooks/cloud_toy_cleanup.yml` — one-shot, idempotent, refuses to drop non-empty toy `accounts`/`crypto_intents` tables (created by hand-applied `db_patch{1,2,3}.py` scripts that never registered an alembic revision).
- Capture `configs/Caddyfile` verbatim from the live proxy VM — first time under version control.

## Why
Wave 0 of the multi-wave production rollout plan for hyrule-cloud Blocks A0–H. The hyrule-cloud service on `api` has been hand-deployed since inception; this PR is the substrate that lets `AS215932/hyrule-cloud#4`'s deploy workflow do SHA-pinned, role-driven, snapshot-bracketed deploys.

Audit findings driving this PR (DB on api, captured 2026-05-18):
- `alembic_version = 001`; `vms`, `accounts`, `domains`, `vpn_tunnels`, `crypto_intents` all 0 rows.
- Toy `accounts` + `crypto_intents` tables already exist with schemas that don't match the working-tree 003/004 migrations — toy-cleanup playbook handles this safely before Wave 2.
- Caddy uses site-block catch-all routing, so new `/v1/*` paths on api proxy automatically; no proxy changes needed for Waves 1–6.
- systemd unit's `EnvironmentFile=/opt/hyrule-cloud/.env` (NOT `/etc/hyrule-cloud/`) — role aligns to this convention.

## Test plan
- [x] `ansible-playbook playbooks/cloud.yml --tags validate --connection=local --skip-tags=snapshot --limit api` → 4 tasks ok, 0 failed (locally verified).
- [x] `ansible-playbook playbooks/cloud_toy_cleanup.yml --syntax-check --limit api` → clean.
- [ ] First live apply happens during Wave 1 (security hotfix), gated by `hyrule_cloud_apply=true` from the deploy workflow.
- [ ] No live changes from merging this PR — the role only runs when the deploy workflow invokes the playbook with `apply` tag + `hyrule_cloud_apply=true`.

Companion PR: AS215932/hyrule-cloud#4 (CI + deploy workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an Ansible role and playbooks to manage hyrule-cloud deployments on the api VM with SHA-pinned rollouts and health-checked systemd service management.

New Features:
- Add hyrule_cloud Ansible role with defaults, tasks, handlers, and SSH config template to deploy the hyrule-cloud FastAPI service on the api host.
- Add cloud.yml playbook to run hyrule_cloud role with pre/post Icinga firewall snapshots and support for validate vs apply modes.
- Add one-shot, idempotent cloud_toy_cleanup.yml playbook to safely drop legacy toy accounts and crypto_intents tables before Wave 2 migrations.
- Capture the production Caddyfile configuration into version control for the hyrule-cloud routing setup.

Enhancements:
- Ensure hyrule-cloud deploys use a per-app SSH deploy key, seeded GitHub host keys, and SHA-pinned git checkouts managed via uv.
- Add runtime validation and health-check tasks to assert required configs exist, dependencies are synced, the systemd unit is active, and the HTTP health endpoint responds.