### PR TITLE
[codex] Grant Hyrule MCP journal read access

### DIFF
--- a/ansible/roles/hyrule_mcp/tasks/main.yml
+++ b/ansible/roles/hyrule_mcp/tasks/main.yml
@@ -28,6 +28,12 @@
     system: true
   tags: [apply]
 
+- name: Ensure systemd journal reader group exists
+  group:
+    name: systemd-journal
+    system: true
+  tags: [apply]
+
 - name: Ensure noc-agent system user exists
   user:
     name: "{{ hyrule_mcp_app_user }}"

--- a/ansible/roles/hyrule_mcp/tasks/main.yml
+++ b/ansible/roles/hyrule_mcp/tasks/main.yml
@@ -32,6 +32,8 @@
   user:
     name: "{{ hyrule_mcp_app_user }}"
     group: "{{ hyrule_mcp_app_group }}"
+    groups: systemd-journal
+    append: true
     home: /var/lib/noc-agent
     shell: /bin/bash
     system: true

--- a/ansible/roles/noc_mcp_key/tasks/main.yml
+++ b/ansible/roles/noc_mcp_key/tasks/main.yml
@@ -18,6 +18,13 @@
     noc_mcp_target_user: "{{ ssh_users[inventory_hostname] | default(ssh_users.default) }}"
   tags: [apply]
 
+- name: Ensure systemd journal reader group exists
+  group:
+    name: systemd-journal
+    system: true
+  when: "'linux' in group_names"
+  tags: [apply]
+
 - name: Grant MCP SSH user read access to systemd journals
   user:
     name: "{{ noc_mcp_target_user }}"

--- a/ansible/roles/noc_mcp_key/tasks/main.yml
+++ b/ansible/roles/noc_mcp_key/tasks/main.yml
@@ -18,6 +18,16 @@
     noc_mcp_target_user: "{{ ssh_users[inventory_hostname] | default(ssh_users.default) }}"
   tags: [apply]
 
+- name: Grant MCP SSH user read access to systemd journals
+  user:
+    name: "{{ noc_mcp_target_user }}"
+    groups: systemd-journal
+    append: true
+  when:
+    - "'linux' in group_names"
+    - noc_mcp_target_user != "root"
+  tags: [apply]
+
 - name: Authorize id_noc_mcp for {{ noc_mcp_target_user }} (restricted to noc's address)
   authorized_key:
     user: "{{ noc_mcp_target_user }}"

--- a/configs/hyrule-mcp.service
+++ b/configs/hyrule-mcp.service
@@ -8,6 +8,7 @@ After=network.target
 Type=exec
 User=noc-agent
 Group=noc-agent
+SupplementaryGroups=systemd-journal
 WorkingDirectory=/opt/hyrule-mcp
 EnvironmentFile=/opt/noc-agent/.env
 Environment=HYRULE_MCP_TRANSPORT=http

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,6 +74,7 @@ WG endpoints are **underlay** addresses. WG link addresses are in `2a0c:b641:b50
 | api | hyrule-cloud + Postgres 17 | 2 | 4GB | 40GB | Debian 13 | infra :2::20 |
 | web | hyrule-web | 1 | 2GB | 20GB | Debian 13 | infra :2::30 |
 | proxy | TLS reverse proxy | 1 | 1GB | 10GB | Debian 13 + Caddy | infra :2::40 |
+| noc | Autonomous NOC agent + hyrule-mcp | 1 | 8GB | 20GB | Debian 13 | infra :2::a0 |
 | vault | machine secret plane | 1 | 2GB | 20GB | Debian 13 + Vault OSS | infra :2::c0 |
 | mail | Mail server | 2 | 2GB | 40GB | OpenBSD 7.8 + OpenSMTPD/Rspamd/Dovecot | infra :2::90 + dedicated failover IPv4 |
 

--- a/scripts/create-vms.sh
+++ b/scripts/create-vms.sh
@@ -94,6 +94,7 @@ create_vm proxy "TLS reverse proxy (Caddy)" 1 1073741824 10737418240 "2a0c:b641:
 create_vm mon "Monitoring (Icinga2 + Prometheus + Grafana)" 2 4294967296 42949672960 "2a0c:b641:b50:2::50"
 create_vm vpn "WireGuard VPN" 1 1073741824 10737418240 "2a0c:b641:b50:2::60"
 create_vm irc "Soju IRC bouncer" 1 1073741824 10737418240 "2a0c:b641:b50:2::80"
+create_vm noc "Autonomous NOC agent + hyrule-mcp" 1 8589934592 21474836480 "2a0c:b641:b50:2::a0"
 create_vm vault "Vault secret plane" 1 2147483648 21474836480 "2a0c:b641:b50:2::c0"
 create_vm ci "GitHub Actions self-hosted runner" 1 2147483648 21474836480 "2a0c:b641:b50:2::d0" 53687091200 8
 

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -6,6 +6,7 @@ import yaml
 
 
 REPO = Path(__file__).resolve().parents[2]
+JOURNAL_GROUP = "systemd-journal"
 
 
 class VaultAndRunnerContractsTest(unittest.TestCase):
@@ -38,12 +39,41 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
 
     def test_hyrule_mcp_users_can_read_systemd_journals(self):
         service = (REPO / "configs/hyrule-mcp.service").read_text()
-        hyrule_mcp_tasks = (REPO / "ansible/roles/hyrule_mcp/tasks/main.yml").read_text()
-        noc_mcp_key_tasks = (REPO / "ansible/roles/noc_mcp_key/tasks/main.yml").read_text()
+        hyrule_mcp_tasks = yaml.safe_load((REPO / "ansible/roles/hyrule_mcp/tasks/main.yml").read_text())
+        noc_mcp_key_tasks = yaml.safe_load((REPO / "ansible/roles/noc_mcp_key/tasks/main.yml").read_text())
 
-        self.assertIn("SupplementaryGroups=systemd-journal", service)
-        self.assertRegex(hyrule_mcp_tasks, re.compile(r"groups:\s*systemd-journal"))
-        self.assertRegex(noc_mcp_key_tasks, re.compile(r"groups:\s*systemd-journal"))
+        self.assertIn(f"SupplementaryGroups={JOURNAL_GROUP}", service)
+        self.assertEqual(
+            _task_by_name(hyrule_mcp_tasks, "Ensure systemd journal reader group exists")["group"]["name"],
+            JOURNAL_GROUP,
+        )
+        self.assertIn(
+            JOURNAL_GROUP,
+            _groups_for(_task_by_name(hyrule_mcp_tasks, "Ensure noc-agent system user exists")["user"]["groups"]),
+        )
+        self.assertEqual(
+            _task_by_name(noc_mcp_key_tasks, "Ensure systemd journal reader group exists")["group"]["name"],
+            JOURNAL_GROUP,
+        )
+        self.assertIn(
+            JOURNAL_GROUP,
+            _groups_for(
+                _task_by_name(noc_mcp_key_tasks, "Grant MCP SSH user read access to systemd journals")["user"]["groups"]
+            ),
+        )
+
+
+def _task_by_name(tasks, name):
+    for task in tasks:
+        if task.get("name") == name:
+            return task
+    raise AssertionError(f"task not found: {name}")
+
+
+def _groups_for(value):
+    if isinstance(value, list):
+        return {str(item) for item in value}
+    return {part.strip() for part in str(value).replace(",", " ").split() if part.strip()}
 
 
 if __name__ == "__main__":

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -36,6 +36,15 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn("secret_id_response_wrapping_path", hcl)
         self.assertIn("remove_secret_id_file_after_reading = true", hcl)
 
+    def test_hyrule_mcp_users_can_read_systemd_journals(self):
+        service = (REPO / "configs/hyrule-mcp.service").read_text()
+        hyrule_mcp_tasks = (REPO / "ansible/roles/hyrule_mcp/tasks/main.yml").read_text()
+        noc_mcp_key_tasks = (REPO / "ansible/roles/noc_mcp_key/tasks/main.yml").read_text()
+
+        self.assertIn("SupplementaryGroups=systemd-journal", service)
+        self.assertRegex(hyrule_mcp_tasks, re.compile(r"groups:\s*systemd-journal"))
+        self.assertRegex(noc_mcp_key_tasks, re.compile(r"groups:\s*systemd-journal"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- Add `systemd-journal` as a supplementary group for the `hyrule-mcp` service.
- Ensure the local `noc-agent` runtime user is in `systemd-journal`.
- Ensure non-root Linux MCP SSH target users are in `systemd-journal` when the MCP key is distributed.
- Added a contract test for journal-read access desired state.

## Why
`os_journalctl` was failing with insufficient permissions, so NOC reports could prove service uptime via `systemctl` but could not read journals to determine restart cause.

## Validation
- `python -m unittest tests.iac.test_vault_and_runner_contracts -v` -> 6 passed

## Summary by Sourcery

Grant Hyrule MCP-related users read access to systemd journals and enforce this via contract tests.

New Features:
- Ensure the Hyrule MCP service process runs with the systemd-journal supplementary group.
- Ensure the local noc MCP runtime user is added to the systemd-journal group on Linux hosts when the MCP key is distributed.

Tests:
- Add a contract test verifying that the Hyrule MCP service and related Ansible roles configure systemd-journal group membership for journal access.