### PR TITLE
github_runner: reap orphaned listener (KillMode=mixed) + drop staging fstab dup

### DIFF
--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -159,10 +159,15 @@
   changed_when: true
   tags: [apply]
 
+# absent, not unmounted: `unmounted` leaves the staging mountpoint in /etc/fstab,
+# so the same partition is listed twice (staging path + runner home) and a reboot
+# races to mount /dev/xvdiN at both — the duplicate that broke the runner host.
+# `absent` unmounts AND removes the fstab line; the permanent runner-home mount is
+# (re)written by the task further down.
 - name: Unmount runner data disk staging path after migration copy
   mount:
     path: "{{ github_runner_data_disk_stage_mount }}"
-    state: unmounted
+    state: absent
   when:
     - github_runner_storage_enabled | bool
     - github_runner_storage_migration_needed | default(false)

--- a/ansible/roles/github_runner/templates/github-runner.service.j2
+++ b/ansible/roles/github_runner/templates/github-runner.service.j2
@@ -15,7 +15,16 @@ ExecStart={{ github_runner_install_dir }}/run.sh
 # generated unit — so the runner comes back regardless of exit code.
 Restart=always
 RestartSec=5s
-KillMode=process
+# mixed (NOT GitHub's default `process`): SIGTERM to run.sh, then SIGKILL to the
+# whole control group at TimeoutStopSec. With `process`, a restart mid-job (disk
+# migration, vault-agent env re-render, manual restart) orphaned Runner.Listener:
+# it kept holding the GitHub session — so the next start hit SessionConflictException
+# and crash-looped (NRestarts 245+) — and ran jobs inside the torn-down PrivateTmp
+# namespace, where `mktemp /tmp/...` failed ("No such file or directory"). `mixed`
+# reaps the listener together with the unit, so the session releases and /tmp is
+# never stale. Trade-off: a runner self-update during an in-flight job kills that
+# job (it re-queues) — rare and cheap next to the orphan loop.
+KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=5min
 Environment=HOME={{ github_runner_home }}

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -31,6 +31,20 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertNotIn("configs/hyrule-cloud.env.j2", role_text)
         self.assertNotRegex(role_text, re.compile(r"lookup\(['\"]env['\"],\s*['\"]XO_TOKEN['\"]"))
 
+    def test_runner_unit_reaps_orphans_on_restart(self):
+        # KillMode=process orphaned Runner.Listener on a mid-job restart: it held
+        # the GitHub session (next start → SessionConflict crash-loop) and ran in a
+        # torn-down PrivateTmp /tmp (mktemp failures). mixed reaps the whole cgroup.
+        unit = (REPO / "ansible/roles/github_runner/templates/github-runner.service.j2").read_text()
+        self.assertIn("KillMode=mixed", unit)
+        self.assertNotIn("KillMode=process", unit)
+
+    def test_runner_staging_unmount_removes_fstab_entry(self):
+        # state: unmounted left the staging mountpoint in /etc/fstab, duplicating
+        # the runner-home device entry and racing two mounts of /dev/xvdiN on boot.
+        tasks = (REPO / "ansible/roles/github_runner/tasks/main.yml").read_text()
+        self.assertNotRegex(tasks, re.compile(r"state:\s*unmounted"))
+
     def test_vault_agent_supports_response_wrapped_secret_id(self):
         hcl = (REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2").read_text()
         self.assertIn("secret_id_response_wrapping_path", hcl)


### PR DESCRIPTION
## Context

Follow-ups from the ci-runner orphan-loop incident (the CI `mktemp /tmp/...: No such file or directory` failures + SessionConflict crash-loop that took the runner down until a reboot).

Root cause was two latent bugs in the `github_runner` role:

1. The systemd unit set `KillMode=process` together with `PrivateTmp=true`. On a restart **mid-job** (the trigger was the new data-disk migration; vault-agent env re-render or a manual restart would do it too), `process` left `Runner.Listener` orphaned. The orphan kept holding the GitHub session — so the next service start hit `SessionConflictException` and crash-looped (`NRestarts` 245+) — and ran jobs inside the now torn-down `PrivateTmp` `/tmp`, where `mktemp` failed.
2. The staging-disk migration step unmounted with `state: unmounted`, which leaves the staging mountpoint in `/etc/fstab`. The same partition (`/dev/xvdiN`) ended up listed twice (staging path + runner home), so a reboot raced to mount it at both paths — the duplicate that had to be hand-removed before the incident reboot.

## What changed

- `templates/github-runner.service.j2`: `KillMode=process` → `KillMode=mixed` (SIGTERM to `run.sh`, SIGKILL to the whole control group at `TimeoutStopSec`). Reaps the listener with the unit so the session releases and `/tmp` is never stale. Trade-off documented inline: a runner self-update during an in-flight job now kills that job (it re-queues) — rare and far cheaper than the orphan loop.
- `tasks/main.yml`: staging unmount `state: unmounted` → `state: absent` (unmounts **and** drops the fstab line).
- `tests/iac/test_vault_and_runner_contracts.py`: two regression asserts pin `KillMode=mixed` and no `state: unmounted` in the role.

## Applying

This is latent-safe — the live runner is healthy after the incident reboot (single clean listener, `node_systemd_unit_state{...,state="active"}=1`). The new unit takes effect on the next `playbooks/ci.yml --tags apply` (template change → `reload systemd` + `restart github-runner` handlers). **Apply in a quiet window with no CI job in flight**, since the apply restarts the runner.

## Related

- Memory: `project_ci_runner_orphan_loop`
- Files: `ansible/roles/github_runner/{templates/github-runner.service.j2,tasks/main.yml}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust GitHub runner systemd configuration and disk unmount behavior to prevent orphaned processes and fstab duplication issues.

Bug Fixes:
- Ensure the GitHub runner service reaps orphaned listener processes on restart by switching the unit KillMode to mixed.
- Prevent duplicate fstab entries for the runner data disk by changing the staging unmount task to remove the mount entry entirely.

Tests:
- Add regression tests to pin the runner unit KillMode and verify that no unmounted state is used for the staging mount in the Ansible role.