### PR TITLE
[codex] Bound xo MCP gateway sessions

### DIFF
--- a/ansible/roles/xo_mcp/defaults/main.yml
+++ b/ansible/roles/xo_mcp/defaults/main.yml
@@ -5,6 +5,9 @@ xo_mcp_install_dir: /opt/xo-mcp
 xo_mcp_port: 8766
 xo_mcp_path: /mcp
 xo_mcp_health_path: /health
+xo_mcp_session_timeout_ms: 120000
+xo_mcp_tasks_max: 256
+xo_mcp_memory_max: 1536M
 xo_mcp_allowed_remote_ips:
   - "46.105.40.223"
   - "{{ peers.proxy.ipv6 }}"

--- a/ansible/roles/xo_mcp/templates/xo-mcp.service.j2
+++ b/ansible/roles/xo_mcp/templates/xo-mcp.service.j2
@@ -19,9 +19,16 @@ ExecStart={{ xo_mcp_install_dir }}/node_modules/.bin/supergateway \
     --port {{ xo_mcp_port }} \
     --streamableHttpPath {{ xo_mcp_path }} \
     --healthEndpoint {{ xo_mcp_health_path }} \
+    --stateful \
+    --sessionTimeout {{ xo_mcp_session_timeout_ms }} \
     --logLevel info
 Restart=always
 RestartSec=5
+# The stdio MCP server is a child process tree; stop/restart must reap the
+# whole gateway session instead of leaving npm/node children behind.
+KillMode=control-group
+TasksMax={{ xo_mcp_tasks_max }}
+MemoryMax={{ xo_mcp_memory_max }}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=xo-mcp

--- a/tests/iac/test_xo_mcp_contracts.py
+++ b/tests/iac/test_xo_mcp_contracts.py
@@ -1,0 +1,27 @@
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class XoMcpContractsTest(unittest.TestCase):
+    def test_streamable_http_gateway_is_stateful_and_bounded(self):
+        defaults = yaml.safe_load((REPO / "ansible/roles/xo_mcp/defaults/main.yml").read_text())
+        service = (REPO / "ansible/roles/xo_mcp/templates/xo-mcp.service.j2").read_text()
+
+        self.assertEqual(defaults["xo_mcp_session_timeout_ms"], 120000)
+        self.assertEqual(defaults["xo_mcp_tasks_max"], 256)
+        self.assertEqual(defaults["xo_mcp_memory_max"], "1536M")
+        self.assertIn("--stateful", service)
+        self.assertRegex(service, r"--sessionTimeout\s+{{\s*xo_mcp_session_timeout_ms\s*}}")
+        self.assertIn("KillMode=control-group", service)
+        self.assertIn("TasksMax={{ xo_mcp_tasks_max }}", service)
+        self.assertIn("MemoryMax={{ xo_mcp_memory_max }}", service)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Run the XO MCP supergateway in stateful Streamable HTTP mode with a 120s session timeout.
- Add systemd task and memory limits plus explicit control-group cleanup for `xo-mcp.service`.
- Add an IaC contract test that keeps the stateful gateway flags and guardrails in place.

## Root Cause
`xo-mcp.service` was running supergateway in stateless stdio-to-Streamable-HTTP mode. Each `/health/mcp` probe/list-tools request spawned and retained another `@xen-orchestra/mcp` child process tree. On `noc`, this grew to 1607 tasks and roughly 4.6 GiB in `xo-mcp.service`, creating host memory pressure and causing systemd/OOM to kill a `noc-agent` worker.

## Validation
- On `noc`, applied a temporary drop-in with the same stateful/session-timeout/resource-limit settings.
- Before: five `/health/mcp` calls grew `xo-mcp.service` from 7 to 107 tasks and ~50 MiB to ~460 MiB.
- After: repeated `/health/mcp` calls stayed stable at 67 tasks and ~272 MiB, with `/health/mcp` returning `status: ok`.
- `scripts/ci/iac-static.sh` passed locally; existing advisory warnings were emitted for systemd socket permissions, missing Caddy RFC2136 module, and unbound interface access in the sandbox.

## Summary by Sourcery

Configure the XO MCP supergateway to run as a bounded, stateful Streamable HTTP service with resource limits and enforce these settings via an IaC contract test.

Enhancements:
- Run the XO MCP supergateway in stateful Streamable HTTP mode with a fixed session timeout and bounded systemd cgroup resources.

Tests:
- Add an IaC contract test to assert the XO MCP gateway remains stateful with the expected session timeout and systemd resource limits.