### PR TITLE
hyrule_cloud: install C build toolchain for Block E native-crypto deps

### DIFF
--- a/ansible/roles/hyrule_cloud/defaults/main.yml
+++ b/ansible/roles/hyrule_cloud/defaults/main.yml
@@ -77,3 +77,14 @@ hyrule_cloud_packages:
   # already has it because PostgreSQL is installed locally; listing it
   # here makes the role portable to a fresh host.
   - libpq-dev
+  # Block E (Wave 4): the native-crypto deps have no wheels for the api's
+  # Python and build C extensions from source on `uv sync` — bip-utils pulls
+  # ed25519-blake2b (needs gcc + Python.h) and coincurve builds a bundled
+  # libsecp256k1 (needs the autotools/libffi/pkg-config chain).
+  - build-essential
+  - python3-dev
+  - libffi-dev
+  - pkg-config
+  - autoconf
+  - automake
+  - libtool


### PR DESCRIPTION
## Context
The Block E (Wave 4) intent engine adds `bip-utils` + `coincurve`. Neither ships a wheel for the `api` host's Python, so `uv sync` builds them from source:
- `bip-utils` → `ed25519-blake2b`: needs `gcc` + `Python.h`
- `coincurve`: builds a bundled `libsecp256k1` (autotools + libffi + pkg-config)

`api` had no compiler, so the first Wave 4-5 deploy failed at `uv sync` with `x86_64-linux-gnu-gcc: No such file or directory`.

## Change
Add `build-essential python3-dev libffi-dev pkg-config autoconf automake libtool` to the role's base packages — same on-host-build pattern as the existing `libpq-dev`.

## Verified
Re-running the deploy after this installed the toolchain; `uv sync` compiled both extensions; `api` now runs **alembic 007** with Block E/F/H live (`/v1/stats/network` up, wallet-recovery challenge works), Icinga green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add core compiler and development libraries (build-essential, python3-dev, libffi-dev, pkg-config, autoconf, automake, libtool) to the hyrule_cloud role base packages to support native extension builds.