### PR TITLE
feat(web): set WalletConnect projectId (#14)

### DIFF
--- a/configs/hyrule-web.env.j2
+++ b/configs/hyrule-web.env.j2
@@ -5,3 +5,9 @@ HYRULE_WEB_API_BASE_URL=http://[2a0c:b641:b50:2::20]:8402
 HYRULE_WEB_HOST=::
 HYRULE_WEB_PORT=8080
 HYRULE_WEB_DEBUG=false
+
+# Reown/WalletConnect projectId for the mobile EVM payment path (issue #14).
+# PUBLIC client id (rendered into a <meta> tag, visible in page source) — not a
+# secret, so it lives here in plaintext rather than Vault. Empty disables the
+# mobile WalletConnect path (injected-wallet + BTC/XMR still work).
+HYRULE_WEB_WALLETCONNECT_PROJECT_ID=b7c08a56db26c7771f93e42436bff40b


### PR DESCRIPTION
Activates the mobile EVM payment path for hyrule.host (issue #14): sets `HYRULE_WEB_WALLETCONNECT_PROJECT_ID` in `configs/hyrule-web.env.j2`. Public Reown client id (rendered into a page `<meta>` tag — not a secret). Applied by re-running the web deploy (renders `.env` + restarts hyrule-web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Add a configurable WalletConnect project ID environment variable to control the mobile EVM payment path.