### PR TITLE
[codex] Fix noc Redis suite fact fallback

### DIFF
--- a/ansible/roles/noc_agent/defaults/main.yml
+++ b/ansible/roles/noc_agent/defaults/main.yml
@@ -22,7 +22,7 @@ noc_agent_google_application_credentials: "{{ noc_agent_google_wif_config_path i
 nodejs_lts_setup_url: "https://deb.nodesource.com/setup_lts.x"
 
 # langgraph-checkpoint-redis. Keep it bound to localhost for noc-agent only.
-noc_agent_redis_repo_suite: "{{ ansible_facts['distribution_release'] | lower }}"
+noc_agent_redis_repo_suite: "{{ (ansible_facts.distribution_release | default(ansible_distribution_release) | default('bookworm')) | lower }}"
 noc_agent_redis_repo_key_source: /usr/share/keyrings/redis-archive-key.asc
 noc_agent_redis_repo_keyring: /usr/share/keyrings/redis-archive-keyring.gpg
 noc_agent_redis_repo_key_url: https://packages.redis.io/gpg


### PR DESCRIPTION
## Summary
- make the noc-agent Redis apt suite default tolerate Ansible fact layouts where ansible_facts.distribution_release is absent
- fall back to ansible_distribution_release, then bookworm, matching existing apt repo role patterns

## Verification
- scripts/ci/deploy-preflight.sh --repo-only
- python3 tests/iac/test_mock_render.py

## Context
The approved noc production apply got past deploy preflight and failed in the apply step while resolving noc_agent_redis_repo_suite from ansible_facts['distribution_release'].

## Summary by Sourcery

Make noc-agent Redis APT suite selection resilient to missing ansible_facts.distribution_release by falling back to ansible_distribution_release and then defaulting to bookworm.