### PR TITLE
[codex] Seed runner known_hosts with router targets

### DIFF
--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -403,10 +403,30 @@
 # runner without a manual ssh-keyscan on every fresh host.
 - name: Seed runner known_hosts with the infra fleet host keys
   shell:
-    cmd: >-
-      ssh-keyscan -T 5 -6
-      {% for name, p in peers.items() if p.ipv6 is defined and p.ipv6 != '::' %}{{ p.ipv6 }} {% endfor %}
-      > {{ github_runner_ssh_dir }}/known_hosts 2>/dev/null
+    cmd: |
+      set -euo pipefail
+      tmp="$(mktemp)"
+      {% set ns = namespace(targets=[]) %}
+      {% for host in groups['all'] | default([]) %}
+      {% set target = hostvars[host].ansible_host | default(host) %}
+      {% if target not in ['0.0.0.0', '::'] %}
+      {% set _ = ns.targets.append(target) %}
+      {% endif %}
+      {% endfor %}
+      {% for p in peers.values() %}
+      {% for attr in ['ipv6', 'loopback', 'underlay'] %}
+      {% if p[attr] is defined and p[attr] not in ['0.0.0.0', '::'] %}
+      {% set _ = ns.targets.append(p[attr]) %}
+      {% endif %}
+      {% endfor %}
+      {% endfor %}
+      {% for target in ns.targets | unique %}
+      ssh-keyscan -T 5 {{ target | quote }} >> "$tmp" 2>/dev/null || true
+      {% endfor %}
+      sort -u "$tmp" > {{ github_runner_ssh_dir }}/known_hosts
+      rm -f "$tmp"
+      test -s {{ github_runner_ssh_dir }}/known_hosts
+    executable: /bin/bash
   changed_when: true
   when: github_runner_ssh_key_path | length > 0
   tags: [apply]


### PR DESCRIPTION
## Summary
- include inventory ansible_host targets when seeding the CI runner known_hosts file
- include peer loopback and underlay addresses so FreeBSD router apply jobs can pass host key verification
- keep placeholder external targets filtered out and preserve host key checking

## Verification
- scripts/ci/deploy-preflight.sh --repo-only
- python3 tests/iac/test_mock_render.py

## Context
The monitoring apply for cr1-nl1/cr1-de1 failed before touching router config because the runner known_hosts was seeded from peers.*.ipv6 only. The FreeBSD routers live under loopback/underlay fields and inventory ansible_host values.

## Summary by Sourcery

Expand seeding of CI runner known_hosts to cover all inventory hosts and router peer addresses while filtering placeholder targets.

Enhancements:
- Collect ansible_host values from all inventory hosts plus peer ipv6, loopback, and underlay addresses when generating runner known_hosts.
- Deduplicate and validate ssh-keyscan outputs into known_hosts to ensure non-empty, filtered host key data for CI runners.