### PR TITLE
[codex] Seed runner known_hosts without controller key

### DIFF
--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -89,9 +89,11 @@ github_runner_vault_reload_command: /bin/true
 
 # SSH identity for the runner. apply.yml jobs SSH to the infra fleet (pre/post
 # Icinga snapshots, --tags apply runs); the runner user needs its own key.
-# The private half is copied from the controller path CI_KEY_PATH; the public
-# half is distributed fleet-wide by playbooks/ci-runner-key.yml. known_hosts
-# is seeded so ansible.cfg's host_key_checking=True still holds for the runner.
+# The private half is copied from the controller path CI_KEY_PATH when set; the
+# public half is distributed fleet-wide by playbooks/ci-runner-key.yml.
+# known_hosts is always seeded so ansible.cfg's host_key_checking=True still
+# holds for the runner during normal apply.yml runs where the key already
+# exists on disk.
 github_runner_ssh_key_path: "{{ lookup('env', 'CI_KEY_PATH') | default('', true) }}"
 github_runner_ssh_dir: "{{ github_runner_home }}/.ssh"
 github_runner_ssh_key_dest: "{{ github_runner_ssh_dir }}/id_ci"

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -428,7 +428,6 @@
       test -s {{ github_runner_ssh_dir }}/known_hosts
     executable: /bin/bash
   changed_when: true
-  when: github_runner_ssh_key_path | length > 0
   tags: [apply]
 
 - name: Fix runner known_hosts ownership
@@ -437,7 +436,6 @@
     owner: "{{ github_runner_user }}"
     group: "{{ github_runner_group }}"
     mode: "0644"
-  when: github_runner_ssh_key_path | length > 0
   tags: [apply]
 
 - name: Check whether runner is already installed

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -21,6 +21,17 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
             if "runs-on:" in text:
                 self.assertIn("hyrule-infra", text, workflow)
 
+    def test_runner_known_hosts_is_seeded_without_controller_key_path(self):
+        tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
+
+        seed_task = _task_by_name(tasks, "Seed runner known_hosts with the infra fleet host keys")
+        self.assertIsNotNone(seed_task)
+        self.assertNotIn("when", seed_task)
+
+        ownership_task = _task_by_name(tasks, "Fix runner known_hosts ownership")
+        self.assertIsNotNone(ownership_task)
+        self.assertNotIn("when", ownership_task)
+
     def test_hyrule_cloud_policy_is_dedicated(self):
         policy = (REPO / "configs/vault/policies/hyrule-cloud.hcl").read_text()
         self.assertIn('path "kv/data/hyrule-cloud"', policy)


### PR DESCRIPTION
## Summary
- seed the runner known_hosts file even when CI_KEY_PATH is not present on the controller
- keep CI_KEY_PATH scoped to optional keypair installation only
- add an IaC contract test so known_hosts seeding remains active during normal apply.yml runs

## Why
The live ci apply for PR #101 succeeded, but the runner known_hosts file did not include the FreeBSD router host keys because the seeding task was gated on CI_KEY_PATH. In production apply.yml runs, the runner key already exists on disk and CI_KEY_PATH is not exported, so known_hosts must be regenerated independently.

## Validation
- `python3 -m unittest tests.iac.test_vault_and_runner_contracts`

Note: `python3 -m pytest ...` and `uv run pytest ...` could not run locally because pytest is not installed in this checkout.

## Summary by Sourcery

Ensure runner known_hosts is always seeded independently of controller SSH key configuration.

Bug Fixes:
- Prevent runner known_hosts seeding from being skipped when CI_KEY_PATH is unset on the controller.

Enhancements:
- Add IaC contract test to guarantee runner known_hosts seeding and ownership tasks are not gated by CI_KEY_PATH.
- Clarify defaults documentation for runner SSH key handling and known_hosts seeding behavior.

Tests:
- Add contract test verifying runner known_hosts seeding and ownership tasks have no conditional when clause based on CI_KEY_PATH.