### PR TITLE
[codex] Gate ci runner key bootstrap applies

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -25,6 +25,7 @@ on:
           - noc
           - vault
           - ci
+          - ci-runner-key
           - knot
           - extmon
           - rtr_routing
@@ -65,6 +66,9 @@ jobs:
       # known_hosts-seeded by the github_runner role); overrides ansible.cfg's
       # workstation default of ~/.ssh/id_servify.
       ANSIBLE_PRIVATE_KEY_FILE: /var/lib/github-runner/.ssh/id_ci
+      # ci-runner-key.yml reads CI_KEY_PATH and distributes its public half to
+      # target hosts. In apply.yml runs the key already exists on the runner.
+      CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci
     steps:
       - uses: actions/checkout@v4
 
@@ -109,10 +113,12 @@ jobs:
         if: ${{ !inputs.dry_run }}
         working-directory: ansible
         run: |
-          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+          playbook="${{ inputs.playbook }}"
+          apply_var="${playbook//-/_}_apply=true"
+          ansible-playbook "playbooks/${playbook}.yml" \
             --tags apply \
             -e ansible_user=ci \
-            -e "${{ inputs.playbook }}_apply=true" \
+            -e "${apply_var}" \
             ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
 
       - name: Post-deploy Icinga snapshot

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -21,6 +21,14 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
             if "runs-on:" in text:
                 self.assertIn("hyrule-infra", text, workflow)
 
+    def test_apply_workflow_can_gate_ci_runner_key_bootstrap(self):
+        workflow = (REPO / ".github/workflows/apply.yml").read_text()
+
+        self.assertIn("- ci-runner-key", workflow)
+        self.assertIn("CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci", workflow)
+        self.assertIn('apply_var="${playbook//-/_}_apply=true"', workflow)
+        self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
+
     def test_runner_known_hosts_is_seeded_without_controller_key_path(self):
         tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
 


### PR DESCRIPTION
## Summary
- expose `ci-runner-key` as a production-gated `apply.yml` playbook option
- export `CI_KEY_PATH` in apply runs so the bootstrap playbook can distribute the runner public key
- normalize hyphenated playbook names before building the apply extra-var
- add a static contract test for this workflow path

## Why
The FreeBSD router monitoring apply needs the `ci` deploy user authorized before the self-hosted runner can SSH to the routers. The existing bootstrap role performs that setup, but it was not reachable through the audited production deployment workflow.

## Validation
- `python3 -m unittest tests.iac.test_vault_and_runner_contracts`

## Summary by Sourcery

Gate the CI runner SSH key bootstrap through the audited apply workflow and ensure its contract is enforced by tests.

New Features:
- Expose a ci-runner-key playbook as a selectable option in the apply workflow to control runner key distribution.

Enhancements:
- Export CI_KEY_PATH in apply runs and normalize hyphenated playbook names when building apply extra-vars in the workflow script.

Tests:
- Add a vault/runner contract test to assert the apply workflow correctly wires the ci-runner-key path and extra-var behavior.