### PR TITLE
[codex] Let ci runner key bootstrap use inventory users

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -115,9 +115,13 @@ jobs:
         run: |
           playbook="${{ inputs.playbook }}"
           apply_var="${playbook//-/_}_apply=true"
+          user_args=(-e ansible_user=ci)
+          if [ "${playbook}" = "ci-runner-key" ]; then
+            user_args=()
+          fi
           ansible-playbook "playbooks/${playbook}.yml" \
             --tags apply \
-            -e ansible_user=ci \
+            "${user_args[@]}" \
             -e "${apply_var}" \
             ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
 

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -27,6 +27,9 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn("- ci-runner-key", workflow)
         self.assertIn("CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci", workflow)
         self.assertIn('apply_var="${playbook//-/_}_apply=true"', workflow)
+        self.assertIn('user_args=(-e ansible_user=ci)', workflow)
+        self.assertIn('if [ "${playbook}" = "ci-runner-key" ]; then', workflow)
+        self.assertIn('user_args=()', workflow)
         self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
 
     def test_runner_known_hosts_is_seeded_without_controller_key_path(self):


### PR DESCRIPTION
## Summary
- keep normal production applies pinned to `ansible_user=ci`
- let `ci-runner-key` use inventory SSH users because it is the playbook that creates/authorizes the `ci` deploy user
- extend the workflow contract test for the bootstrap exception

## Why
The gated `ci-runner-key` apply reached the playbook, read `CI_KEY_PATH`, and then failed because apply.yml forced `ansible_user=ci` before the `ci` account existed on the FreeBSD routers. This keeps the bootstrap inside the audited production gate while allowing it to connect through the established inventory users.

## Validation
- `python3 -m unittest tests.iac.test_vault_and_runner_contracts`

## Summary by Sourcery

Allow the ci-runner-key bootstrap workflow to use inventory-defined SSH users while keeping other applies pinned to the ci user.

CI:
- Update the apply workflow to conditionally omit ansible_user=ci for the ci-runner-key playbook so it can bootstrap the ci user via inventory accounts.

Tests:
- Extend the workflow contract test to cover the ci-runner-key bootstrap exception and its user selection logic.