### PR TITLE
[codex] Allow FreeBSD playbooks to opt into become

### DIFF
--- a/ansible/inventory/group_vars/freebsd.yml
+++ b/ansible/inventory/group_vars/freebsd.yml
@@ -1,6 +1,7 @@
 ---
 ansible_user: svag
-ansible_become: false
+# Default is no escalation; playbooks opt in with become: true at play or task level.
+# Localhost-delegated render tasks override with explicit become: false.
 ansible_become_method: doas
 ansible_python_interpreter: /usr/local/bin/python3
 ansible_os_family: FreeBSD

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -32,6 +32,12 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn('user_args=()', workflow)
         self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
 
+    def test_freebsd_playbooks_can_opt_into_become(self):
+        freebsd_vars = yaml.safe_load((REPO / "ansible/inventory/group_vars/freebsd.yml").read_text())
+
+        self.assertNotIn("ansible_become", freebsd_vars)
+        self.assertEqual(freebsd_vars["ansible_become_method"], "doas")
+
     def test_runner_known_hosts_is_seeded_without_controller_key_path(self):
         tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
 


### PR DESCRIPTION
## Summary
- remove the FreeBSD inventory override that forced `ansible_become: false`
- keep `doas` as the FreeBSD become method
- add a contract test proving FreeBSD playbooks can opt into become

## Why
The gated `ci-runner-key` apply now connects as the inventory user, but FreeBSD group vars forced privilege escalation off, so the user-management task ran unprivileged and `pw` failed. Monitoring applies also need playbook-level `become: true` to work on FreeBSD routers.

## Validation
- `python3 -m unittest tests.iac.test_vault_and_runner_contracts`

## Summary by Sourcery

Allow FreeBSD Ansible hosts to opt into privilege escalation while keeping doas as the become method and adding a contract test to enforce this behavior.

Bug Fixes:
- Ensure FreeBSD Ansible playbooks can perform privileged operations by no longer forcing become to be disabled at the inventory level.

Enhancements:
- Document the FreeBSD inventory defaults around privilege escalation to clarify playbook-level control.

Tests:
- Add a contract test verifying that FreeBSD group vars no longer set ansible_become and that ansible_become_method remains doas.