### PR TITLE
[codex] Use portable shell for ci deploy user

### DIFF
--- a/ansible/roles/ci_runner_key/defaults/main.yml
+++ b/ansible/roles/ci_runner_key/defaults/main.yml
@@ -10,4 +10,4 @@ ci_runner_key_from_address: "{{ peers.ci.ipv6 }}"
 # operator's svag. Gets NOPASSWD root (sudo on Linux, doas on BSD) so
 # apply.yml's playbooks can escalate. apply.yml passes -e ansible_user=ci.
 ci_runner_user: ci
-ci_runner_user_shell: /bin/bash
+ci_runner_user_shell: /bin/sh

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -38,6 +38,11 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertNotIn("ansible_become", freebsd_vars)
         self.assertEqual(freebsd_vars["ansible_become_method"], "doas")
 
+    def test_ci_runner_deploy_user_uses_portable_shell(self):
+        defaults = yaml.safe_load((REPO / "ansible/roles/ci_runner_key/defaults/main.yml").read_text())
+
+        self.assertEqual(defaults["ci_runner_user_shell"], "/bin/sh")
+
     def test_runner_known_hosts_is_seeded_without_controller_key_path(self):
         tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
 


### PR DESCRIPTION
## Summary
- change the `ci_runner_key` deploy user shell from `/bin/bash` to `/bin/sh`
- add a contract test so the deploy user shell remains portable across Linux and BSD targets

## Why
The gated FreeBSD bootstrap successfully created and authorized the `ci` user, but SSHD rejected login because `/bin/bash` does not exist on the FreeBSD routers. `/bin/sh` is available on the target OS families and is sufficient for the non-interactive Ansible deploy user.

## Validation
- `python3 -m unittest tests.iac.test_vault_and_runner_contracts`

## Summary by Sourcery

Ensure the CI deploy user uses a portable shell and enforce this via a contract test.

Bug Fixes:
- Set the CI runner deploy user shell to /bin/sh to work across Linux and BSD targets.

Tests:
- Add a contract test verifying the CI runner deploy user shell remains /bin/sh for portability.