### PR TITLE
ci: add ci-pr — unprivileged PR runner (two-runner security model)

### DIFF
--- a/ansible/generated/ci-pr/icinga_host.conf
+++ b/ansible/generated/ci-pr/icinga_host.conf
@@ -1,0 +1,19 @@
+// /etc/icinga2/conf.d/hosts/ansible/ci-pr.conf
+// Managed by ansible/roles/monitoring — do not edit by hand.
+// Source of truth: ansible/inventory/host_vars/ci-pr.yml
+
+object Host "ci-pr" {
+  address6 = "2a0c:b641:b51::c1"
+  display_name = "ci-pr"
+
+  check_command = "ping6"
+
+  vars.os = "Debian"
+  vars.role = "ci"
+  vars.ssh_port = 22
+
+  vars.prom_instance_node = "[2a0c:b641:b51::c1]:9100"
+
+  vars.disks["disk /"] = { mountpoint = "/" }
+}
+

--- a/ansible/generated/ci-pr/nftables.conf
+++ b/ansible/generated/ci-pr/nftables.conf
@@ -1,0 +1,49 @@
+#!/usr/sbin/nft -f
+# /etc/nftables.conf — managed by ansible (roles/firewall)
+# Host: ci-pr
+# Generated: do not edit by hand.
+
+flush ruleset
+
+table inet filter {
+    chain input {
+        type filter hook input priority filter; policy drop;
+
+        # Loopback always allowed.
+        iif lo accept
+
+        # Established/related — keep returning packets flowing.
+        ct state established,related accept
+        ct state invalid drop
+
+        # ICMPv6 — required for ND, RA, MTU discovery, ping.
+        meta l4proto ipv6-icmp accept
+
+        # ICMPv4 — keep ping working.
+        meta l4proto icmp accept
+
+        # SSH from VPN clients and the KPN ops prefix.
+        ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
+        ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
+        ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
+        ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
+
+        # Per-host service allowances.
+        ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape (mon, pull-only)"
+
+
+        # End of input — log+counter what would have been dropped if policy were drop.
+        limit rate 10/second counter log prefix "fw-drop "
+    }
+
+    chain forward {
+        type filter hook forward priority filter; policy drop;
+        ct state established,related accept
+        ct state invalid drop
+    }
+
+    chain output {
+        type filter hook output priority filter; policy accept;
+    }
+}

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -43,6 +43,10 @@ peers:
     mgmt_v4: "10.0.0.60"
   vault:   { ipv6: "2a0c:b641:b50:2::c0" }
   ci:      { ipv6: "2a0c:b641:b50:2::d0" }
+  # ci-pr — unprivileged PR runner, customer-isolated segment (not infra).
+  # Key matches inventory_hostname (the monitoring template does
+  # peers[inventory_hostname]); referenced via peers['ci-pr'] where needed.
+  ci-pr:   { ipv6: "2a0c:b641:b51::c1" }
   ns2:
     ipv4: "54.38.14.218"
     ipv6: "2001:41d0:304:300::7bfb"

--- a/ansible/inventory/host_vars/ci-pr.yml
+++ b/ansible/inventory/host_vars/ci-pr.yml
@@ -1,0 +1,47 @@
+---
+# ci-pr — UNPRIVILEGED self-hosted GitHub Actions runner for untrusted PR code
+# (PR-Agent, Semgrep, and — after Wave 4 — all pull_request lint/test/build jobs).
+#
+# Deliberately on the CUSTOMER-ISOLATED segment (2a0c:b641:b51::/48, rtr enX3):
+# rtr's forward chain drops enX3 -> { enX2 infra, enX0 mgmt }, so a compromised
+# PR job here cannot reach the management overlay. Treat ci-pr as DISPOSABLE.
+#
+# Hard isolation vs the privileged `ci` runner:
+#   - github_runner_vault_enabled: false  -> no Vault AppRole, no secrets.env
+#   - github_runner_ssh_key_path: ""      -> no id_ci fleet deploy key
+#   - containerlab/xcaddy disabled         -> no lab toolchain
+#   - no infra/mgmt reachability (customer isolation enforced on rtr)
+#
+# Monitoring works (mon -> ci-pr:9100 is infra->customer = permitted, pull-only).
+# Log shipping does NOT (ci-pr -> log:6000 is customer->infra = dropped by the
+# isolation), so logs_register stays false — local journald only. Turning it on
+# would require punching a ci-pr->log hole in the customer isolation; don't.
+#
+# Runbook: docs/ci/provision-ci-pr.md. Flows: docs/network-flows.md -> "### ci-pr".
+
+# --- github_runner role: UNPRIVILEGED profile ---
+github_runner_group_name: public-pr
+github_runner_labels:
+  - self-hosted
+  - linux
+  - "{{ github_runner_arch }}"
+  - hyrule-public-pr
+github_runner_vault_enabled: false        # no AppRole, no /etc/github-runner/secrets.env
+github_runner_ssh_key_path: ""            # no id_ci deploy key
+github_runner_containerlab_enabled: false # labs stay on the privileged `ci` runner
+github_runner_caddy_rfc2136_enabled: false
+github_runner_storage_enabled: false      # no separate data disk
+
+# --- Firewall: default-deny inbound + node_exporter scrape from mon only ---
+# node_exporter is pull-only; mon -> ci-pr is infra->customer, which rtr permits.
+firewall_extra_rules:
+  - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape (mon, pull-only)" }
+
+# --- Monitoring: register on mon (Icinga host + node_exporter scrape) ---
+monitoring_register: true
+monitoring_role: ci
+
+# --- Logs: OFF. Pushing to the log VM (customer->infra) is dropped by the
+# customer isolation; shipping would require weakening that boundary. The logs
+# role end_hosts itself when logs_register is false — local journald only.
+logs_register: false

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -31,6 +31,10 @@ all:
           ansible_host: 2a0c:b641:b50:2::c0
         ci:
           ansible_host: 2a0c:b641:b50:2::d0
+        # ci-pr — unprivileged PR runner on the CUSTOMER-isolated segment
+        # (2a0c:b641:b51::/48, enX3). In `linux` for firewall+monitoring only.
+        ci-pr:
+          ansible_host: 2a0c:b641:b51::c1
         ns2:
           ansible_host: 2001:41d0:304:300::7bfb
           ansible_user: debian

--- a/ansible/playbooks/ci_pr.yml
+++ b/ansible/playbooks/ci_pr.yml
@@ -1,0 +1,55 @@
+---
+# ci-pr rollout — installs the UNPRIVILEGED self-hosted GitHub Actions runner on
+# the ci-pr VM (customer-isolated segment, 2a0c:b641:b51::c1).
+#
+# Applied from the OPS WORKSTATION, NOT the privileged `ci` runner: ci-pr has no
+# id_ci, so the `ci` deploy user cannot reach it — and it must not. Vault is
+# disabled for ci-pr, so no secrets.local.sh env is required beyond the runner
+# registration token. See docs/ci/provision-ci-pr.md.
+#
+# Prerequisites:
+#   - ci-pr VM provisioned and reachable at peers.ci_pr.ipv6 (2a0c:b641:b51::c1).
+#   - Org runner registration token (1 h TTL); the runner joins the `public-pr`
+#     group via github_runner_group_name in host_vars/ci-pr.yml:
+#       export GH_RUNNER_TOKEN=$(gh api -X POST \
+#         /orgs/AS215932/actions/runners/registration-token --jq .token)
+#     Once registered, .runner / .credentials persist in the install dir.
+#
+# Apply (from the ops workstation):
+#   ansible-playbook playbooks/ci_pr.yml --tags apply \
+#     -e github_runner_apply=true \
+#     -e github_runner_registration_token="$GH_RUNNER_TOKEN" \
+#     --limit ci-pr
+
+- name: ci-pr — pre-deploy snapshot
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+  tags: [snapshot, always]
+
+- name: ci-pr — apply unprivileged self-hosted runner
+  hosts: ci-pr
+  serial: 1
+  gather_facts: true
+  become: true
+  roles:
+    - github_runner
+  tags: [ci_pr]
+
+- name: ci-pr — post-deploy snapshot
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Post-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+  tags: [snapshot, always]

--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -124,6 +124,13 @@ github_runner_packages:
   - openssh-client
   - gh
 
+# Heavy IaC gates. Enabled by default so the privileged `ci` runner keeps
+# building the Containerlab/Batfish labs and the RFC2136 Caddy. The unprivileged
+# `ci-pr` runner sets both false — it never runs labs, and dropping them keeps
+# its toolchain (and attack surface) minimal.
+github_runner_containerlab_enabled: true
+github_runner_caddy_rfc2136_enabled: true
+
 # Heavy IaC gates. containerlab is installed from its upstream .deb because it
 # is not packaged in Debian; Caddy is built with the RFC2136 DNS provider so
 # `caddy validate` can parse configs/Caddyfile.

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -280,6 +280,7 @@
   register: github_runner_containerlab_check
   changed_when: false
   failed_when: false
+  when: github_runner_containerlab_enabled | bool
   tags: [apply]
 
 - name: Download containerlab package
@@ -289,13 +290,17 @@
     owner: root
     group: root
     mode: "0644"
-  when: github_runner_containerlab_check.rc != 0
+  when:
+    - github_runner_containerlab_enabled | bool
+    - github_runner_containerlab_check.rc | default(1) != 0
   tags: [apply]
 
 - name: Install containerlab package
   apt:
     deb: "{{ github_runner_containerlab_deb_path }}"
-  when: github_runner_containerlab_check.rc != 0
+  when:
+    - github_runner_containerlab_enabled | bool
+    - github_runner_containerlab_check.rc | default(1) != 0
   tags: [apply]
 
 - name: Ensure runner is in containerlab admin group
@@ -303,6 +308,7 @@
     name: "{{ github_runner_user }}"
     groups: "{{ github_runner_containerlab_admin_group }}"
     append: true
+  when: github_runner_containerlab_enabled | bool
   tags: [apply]
 
 - name: Install xcaddy builder
@@ -311,6 +317,7 @@
     GOBIN: "{{ github_runner_xcaddy_path | dirname }}"
   args:
     creates: "{{ github_runner_xcaddy_path }}"
+  when: github_runner_caddy_rfc2136_enabled | bool
   tags: [apply]
 
 - name: Check whether Caddy has RFC2136 DNS provider
@@ -320,6 +327,7 @@
   register: github_runner_caddy_rfc2136_check
   changed_when: false
   failed_when: false
+  when: github_runner_caddy_rfc2136_enabled | bool
   tags: [apply]
 
 - name: Ensure Caddy build directories exist
@@ -333,7 +341,9 @@
     - "{{ github_runner_caddy_build_dir }}"
     - "{{ github_runner_caddy_go_cache }}"
     - "{{ github_runner_caddy_go_path }}"
-  when: github_runner_caddy_rfc2136_check.rc != 0
+  when:
+    - github_runner_caddy_rfc2136_enabled | bool
+    - github_runner_caddy_rfc2136_check.rc | default(1) != 0
   tags: [apply]
 
 - name: Build Caddy with RFC2136 DNS provider
@@ -345,7 +355,9 @@
     TMPDIR: "{{ github_runner_caddy_build_dir }}"
     GOCACHE: "{{ github_runner_caddy_go_cache }}"
     GOPATH: "{{ github_runner_caddy_go_path }}"
-  when: github_runner_caddy_rfc2136_check.rc != 0
+  when:
+    - github_runner_caddy_rfc2136_enabled | bool
+    - github_runner_caddy_rfc2136_check.rc | default(1) != 0
   tags: [apply]
 
 - name: Ensure custom Caddy binary is executable
@@ -354,7 +366,9 @@
     owner: root
     group: root
     mode: "0755"
-  when: github_runner_caddy_rfc2136_check.rc != 0
+  when:
+    - github_runner_caddy_rfc2136_enabled | bool
+    - github_runner_caddy_rfc2136_check.rc | default(1) != 0
   tags: [apply]
 
 - name: Ensure runner install directory exists

--- a/docs/ci/provision-ci-pr.md
+++ b/docs/ci/provision-ci-pr.md
@@ -1,0 +1,110 @@
+# Provisioning the `ci-pr` VM (unprivileged PR runner)
+
+`ci-pr` is the **unprivileged** self-hosted GitHub Actions runner that handles
+untrusted PR code — PR-Agent, Semgrep, and (after Wave 4) every `pull_request`
+lint/test/build job. It is deliberately **disposable** and **isolated**:
+
+- On the **customer segment** `2a0c:b641:b51::c1/64` (rtr `enX3`/`xenbr-vm`), so
+  rtr's `iifname enX3 oifname {enX2,enX0} drop` cuts it off from the infra and
+  management overlays. A compromised PR job here cannot reach production.
+- **No** Vault AppRole, **no** `/etc/github-runner/secrets.env`, **no** `id_ci`
+  deploy key, **no** Containerlab/xcaddy — see `host_vars/ci-pr.yml`.
+- Registered in the **`public-pr`** org runner group (label `hyrule-public-pr`),
+  separate from the privileged `ci` runner's `hyrule-ci` group.
+
+Contrast with the privileged `ci` runner: see `docs/ci/provision.md`.
+
+## 0. Prereqs
+
+- `~/.ssh/id_servify` (ops workstation key — also authorizes `ci-pr` SSH).
+- `gh` authenticated to the AS215932 org.
+- Decide sizing: **1 vCPU, 2 GiB RAM, 20 GiB root** (Debian 13). No data disk.
+
+## 1. Create the VM on the customer (vm) bridge
+
+The VM lands on `xenbr-vm`, not infra. Resolve that network's UUID on XOA, then
+run the (now parameterized) `scripts/create-vms.sh` helper:
+
+```bash
+# On XOA (10.0.0.10, via the dom0 jump) or wherever xo-cli is configured:
+xo-cli --list-objects type=network \
+  | python3 -c 'import sys,json; [print(n["uuid"], n["name_label"]) for n in json.load(sys.stdin)]'
+# Pick the xenbr-vm / "vm" network UUID:
+export VM_NET=<that-uuid>
+
+# create-vms.sh skips ci-pr unless VM_NET is set. It uses args 9,10 =
+# NETWORK + GATEWAY to place ci-pr on the vm bridge with the rtr enX3 gateway:
+#   create_vm ci-pr "..." 1 2147483648 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
+bash scripts/create-vms.sh   # or copy just the ci-pr block
+```
+
+cloud-init assigns `2a0c:b641:b51::c1/64`, gateway + DNS `2a0c:b641:b51::1`
+(rtr Unbound/DNS64). Start the VM, wait for cloud-init, and verify
+`ssh svag@2a0c:b641:b51::c1` works over global IPv6.
+
+## 2. Bootstrap firewall + monitoring (from the ops workstation)
+
+`ci-pr` is applied from the **workstation**, NOT the privileged `ci` runner: it
+has no `id_ci`, so the `ci` deploy user cannot (and must not) reach it. Vault is
+disabled for `ci-pr`, so no `secrets.local.sh` env is required for these.
+
+```bash
+cd ansible
+
+# Firewall: default-deny + node_exporter scrape from mon (host_vars/ci-pr.yml).
+ansible-playbook playbooks/firewall.yml --tags apply \
+  -e '{"firewall_apply":true}' --limit ci-pr
+
+# Monitoring: node_exporter + Icinga2 Host registration on mon.
+ansible-playbook playbooks/monitoring.yml --tags apply \
+  -e '{"monitoring_apply":true}' --limit ci-pr
+```
+
+Logs are intentionally **off** (`logs_register: false`): pushing to the log VM
+(`ci-pr → log:6000`) is customer→infra and is dropped by the isolation. Keep
+logs in local journald; do not punch a hole.
+
+### 2a. Add `ci-pr` to Prometheus on mon (the one manual step)
+
+The `monitoring` role does not manage `prometheus.yml`. On `mon`, add `ci-pr`
+(`[2a0c:b641:b51::c1]:9100`) to the appropriate `static_configs` job and
+`systemctl reload prometheus`. Confirm `mon → ci-pr:9100` scrapes succeed
+(infra→customer is permitted by rtr's forward policy).
+
+## 3. Register the runner in the `public-pr` group
+
+```bash
+# Org runner registration token (1 h TTL):
+export GH_RUNNER_TOKEN=$(gh api -X POST \
+  /orgs/AS215932/actions/runners/registration-token --jq .token)
+
+cd ansible
+ansible-playbook playbooks/ci_pr.yml --tags apply \
+  -e github_runner_apply=true \
+  -e github_runner_registration_token="$GH_RUNNER_TOKEN" \
+  --limit ci-pr
+```
+
+The runner joins `public-pr` (via `github_runner_group_name` in
+`host_vars/ci-pr.yml`) with labels `[self-hosted, linux, x64, hyrule-public-pr]`.
+Confirm it shows online:
+`gh api orgs/AS215932/actions/runners --jq '.runners[].name'`.
+
+## 4. Verify isolation (acceptance probe)
+
+From a throwaway workflow job on `hyrule-public-pr` (or `ssh svag@2a0c:b641:b51::c1`):
+
+```bash
+test ! -e /etc/github-runner/secrets.env && echo "OK: no secrets.env"
+test ! -e /var/lib/github-runner/.ssh/id_ci && echo "OK: no id_ci"
+pgrep -fa vault-agent || echo "OK: no vault agent"
+# Must FAIL/timeout (no infra/mgmt reachability):
+timeout 5 bash -c 'cat < /dev/null > /dev/tcp/2a0c:b641:b50:2::50/9100' \
+  && echo "FAIL: reached mon (infra)" || echo "OK: cannot reach infra mgmt"
+# Must SUCCEED (egress):
+timeout 5 bash -c 'cat < /dev/null > /dev/tcp/openrouter.ai/443' \
+  && echo "OK: egress to openrouter" || echo "FAIL: no egress"
+```
+
+Then open a draft PR to exercise PR-Agent (`deepseek-v4-flash`) and Semgrep
+(SARIF → Code Scanning). See `docs/ci/pr-agent.md` / `docs/ci/semgrep.md`.

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -28,7 +28,8 @@ Last sync: 2026-04-29 (verified live with `nft list ruleset` / `pfctl -sr`).
 | noc | Debian 13 | `2a0c:b641:b50:2::a0` | — | noc-agent (FastAPI :8000) + hyrule-mcp (stdio child) |
 | log | Debian 13 | `2a0c:b641:b50:2::b0`, `10.0.0.60` (mgmt) | — | Vector aggregator + Loki (centralized logs) |
 | vault | Debian 13 | `2a0c:b641:b50:2::c0` | — | Vault secret plane (proxied as `vault.as215932.net`) |
-| ci | Debian 13 | `2a0c:b641:b50:2::d0` | — | Self-hosted GitHub Actions runner |
+| ci | Debian 13 | `2a0c:b641:b50:2::d0` | — | Self-hosted GitHub Actions runner (privileged) |
+| ci-pr | Debian 13 | `2a0c:b641:b51::c1` (customer-isolated) | — | Unprivileged PR runner (PR-Agent/Semgrep/PR CI) |
 | ns2 | Debian 13 | (off-net) `2001:41d0:304:300::7bfb` | `54.38.14.218` | secondary nameserver (OVH GRA11) |
 | cr1-nl1 | FreeBSD 14.3 | loopback `2a0c:b641:b50::a` | — | core router (Servperso NL transit) |
 | cr1-de1 | FreeBSD 15.0 | loopback `2a0c:b641:b50::b` | — | core router (Servperso DE + Extra-Transit + IXPs) |
@@ -46,7 +47,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 | `2a0c:b641:b50:2::/64` | Infra subnet (rtr `::1`, VMs `::10`–`::70`) |
 | `2a0c:b641:b50:3::/64` | VPN clients (routed via vpn VM) |
 | `2a0c:b641:b50:ffXX::/127` | WireGuard tunnel /127s (mesh links) |
-| `2a0c:b641:b51::/48` | Customer VM allocations |
+| `2a0c:b641:b51::/48` | Customer VM allocations (also `::c1` = ci-pr, the unprivileged PR runner) |
 | `10.0.0.0/24` | Mgmt v4 (dom0 ↔ XOA XAPI) |
 | `10.0.2.0/24` | Legacy v4 DNAT targets on rtr |
 | `2a02:a442:1016::/48`, `77.166.211.126/32` | Ops-prefix (KPN home, used for SSH and AXFR allow) |
@@ -177,6 +178,22 @@ Self-hosted GitHub Actions runner. Picks up workflow jobs from
 | ops-prefix, vpn-clients | TCP | 22 | SSH (operator access for runner troubleshooting) |
 
 Outbound (cross-cutting): ci → github.com TCP/443 (poll runner queue, fetch action images), ci → api.anthropic.com TCP/443 (AI review), ci → every infra host TCP/22 (apply runs via `ansible-playbook --tags apply`), ci → mon TCP/9090 (Prometheus query during render-check), ci → log TCP/6000 (Vector agent).
+
+### ci-pr (`2a0c:b641:b51::c1`) — unprivileged PR runner, customer-isolated
+
+Unprivileged self-hosted GitHub Actions runner for **untrusted PR code**
+(PR-Agent, Semgrep, and — after Wave 4 — all `pull_request` lint/test/build
+jobs). Deliberately on the **customer-isolated** vm bridge: rtr drops
+`enX3 → {enX2 infra, enX0 mgmt}`, so a compromised PR job cannot reach the
+management overlay. No Vault, no `id_ci`, no `secrets.env`, no Containerlab —
+treated as disposable.
+
+| From | Proto | Port | Purpose |
+|------|-------|------|---------|
+| mon | TCP | 9100 | node_exporter scrape (infra→customer, pull-only) |
+| ops-prefix, vpn-clients | TCP | 22 | SSH (operator access; apply runs from the ops workstation, not the privileged runner) |
+
+Outbound (cross-cutting): ci-pr → github.com TCP/443 (runner queue, action images), ci-pr → openrouter.ai TCP/443 (PR-Agent LLM), ci-pr → PyPI/npm/ghcr/Docker Hub TCP/443 (toolchain + semgrep image), ci-pr → rtr (`2a0c:b641:b51::1`) TCP+UDP/53 (Unbound + DNS64). **No** log shipping: `ci-pr → log:6000` is customer→infra and is dropped by the isolation, so ci-pr keeps logs in local journald only.
 
 ### log (`2a0c:b641:b50:2::b0` overlay, `10.0.0.60` mgmt)
 

--- a/scripts/create-vms.sh
+++ b/scripts/create-vms.sh
@@ -10,6 +10,10 @@ create_vm() {
   local NAME=$1 DESC="$2" VCPU=$3 MEM=$4 DISK=$5 IPV6=$6
   local DATA_DISK="${7:-}"
   local DATA_VBD_POSITION="${8:-1}"
+  # Network + gateway default to infra; ci-pr overrides them to land on the
+  # customer-isolated vm bridge (xenbr-vm) with the rtr enX3 gateway.
+  local NETWORK="${9:-$INFRA}"
+  local GATEWAY="${10:-2a0c:b641:b50:2::1}"
 
   echo "Creating $NAME..."
 
@@ -39,18 +43,18 @@ ethernets:
       - ${IPV6}/64
     nameservers:
       addresses:
-        - 2a0c:b641:b50:2::1
+        - ${GATEWAY}
       search:
         - as215932.net
     routes:
       - to: ::/0
-        via: 2a0c:b641:b50:2::1"
+        via: ${GATEWAY}"
 
   VM_ID=$(xo-cli vm.create \
     name_label="$NAME" \
     name_description="$DESC" \
     template=$TEMPLATE \
-    VIFs="json:[{\"network\":\"$INFRA\"}]" \
+    VIFs="json:[{\"network\":\"$NETWORK\"}]" \
     CPUs.number=$VCPU \
     memory=$MEM \
     bootAfterCreate=false \
@@ -96,6 +100,20 @@ create_vm vpn "WireGuard VPN" 1 1073741824 10737418240 "2a0c:b641:b50:2::60"
 create_vm irc "Soju IRC bouncer" 1 1073741824 10737418240 "2a0c:b641:b50:2::80"
 create_vm vault "Vault secret plane" 1 2147483648 21474836480 "2a0c:b641:b50:2::c0"
 create_vm ci "GitHub Actions self-hosted runner" 1 2147483648 21474836480 "2a0c:b641:b50:2::d0" 53687091200 8
+
+# ci-pr — UNPRIVILEGED PR runner on the CUSTOMER-isolated vm bridge (xenbr-vm),
+# NOT infra. Resolve the vm-bridge network UUID and export VM_NET before running:
+#   xo-cli --list-objects type=network \
+#     | python3 -c 'import sys,json; [print(n["uuid"],n["name_label"]) for n in json.load(sys.stdin)]'
+#   export VM_NET=<uuid of the xenbr-vm / "vm" network>
+# Args 7,8 (data disk/VBD) are empty; args 9,10 are NETWORK + GATEWAY.
+VM_NET="${VM_NET:-}"
+if [ -n "$VM_NET" ]; then
+  create_vm ci-pr "Unprivileged PR runner (PR-Agent/Semgrep/PR CI)" \
+    1 2147483648 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
+else
+  echo "SKIP ci-pr: export VM_NET=<xenbr-vm network UUID> to create it (see docs/ci/provision-ci-pr.md)."
+fi
 
 # mon needs a second NIC on xenbr-mgmt to scrape dom0/XOA (underlay-only hosts).
 # After create_vm, add it manually:


### PR DESCRIPTION
## Context
Wave 0 of the CI/CD modernization (replace hosted Sourcery with PR-Agent on our OpenRouter key + token-less Semgrep + a two-runner security model). This adds **`ci-pr`**, the disposable **unprivileged** self-hosted runner for *untrusted PR code* — PR-Agent, Semgrep, and (after the Wave 4 migration) all `pull_request` lint/test/build jobs. The privileged `ci` runner stays for deploy/apply/Vault/labs.

`ci-pr` lives on the **customer-isolated** vm bridge (`2a0c:b641:b51::c1`, rtr `enX3`): rtr drops `enX3 → {enX2 infra, enX0 mgmt}`, so a compromised PR job can't reach production. **No** Vault, **no** `id_ci`, **no** `secrets.env`, **no** Containerlab — treated as disposable.

**Design note (logs):** monitoring works (`mon → ci-pr:9100` is infra→customer, pull-only, allowed by rtr's `policy accept`), but log shipping is intentionally **off** — `ci-pr → log:6000` is customer→infra and is *dropped* by the isolation. Enabling it would require punching a hole in the customer isolation; we don't. Local journald only.

## Action items
- [x] `github_runner` role: add `github_runner_containerlab_enabled` / `github_runner_caddy_rfc2136_enabled` toggles (default **true** → existing `ci` runner unaffected; `ci-pr` sets both false). Vault + `id_ci` were already toggle-gated.
- [x] Inventory: `ci-pr` host (in `linux` for firewall+monitoring) + `peers['ci-pr']`; `host_vars/ci-pr.yml` unprivileged profile.
- [x] `playbooks/ci_pr.yml` (applied from the ops workstation; joins the `public-pr` org runner group).
- [x] `create-vms.sh`: parameterized NETWORK + GATEWAY so `ci-pr` lands on the vm bridge (guarded on `VM_NET`).
- [x] Docs: `network-flows.md` `### ci-pr` + `docs/ci/provision-ci-pr.md` bring-up runbook.
- [x] `generated/ci-pr/`: rendered `nftables.conf` + `icinga_host.conf` (no logs config).

Apply is gated (manual, reviewed) — **this PR changes nothing live**. Bring-up follows after review (runbook included).

## Validation (local)
yamllint clean · `ansible-playbook ci_pr.yml --syntax-check` ✓ · `ansible-lint` 0 failures · `deploy-preflight.sh --repo-only` ✓ · `iac-static.sh` ✓ · firewall+monitoring render produce the committed `generated/ci-pr/` files; logs role correctly `end_host`s (no vector config). shellcheck not run locally (no docker) — `create-vms.sh` edits are minimal/consistent.

## Related
- The `public-pr` org runner group (id 4, all 6 repos) is already created.
- Heads-up follow-up: `render-all.sh` skips the `apply`-tagged render tasks, so the `render` check is effectively a no-op and `generated/` has drifted (separate issue to file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an unprivileged, customer-isolated ci-pr GitHub Actions runner and associated infrastructure.

New Features:
- Add ci-pr VM definition on the customer-isolated network for untrusted PR workflows.
- Add a dedicated ci_pr Ansible playbook and host_vars profile for the unprivileged PR runner.
- Document ci-pr provisioning steps and network flows, including its isolation and monitoring model.

Enhancements:
- Gate containerlab and Caddy RFC2136 setup in the github_runner role behind feature flags so they can be disabled for unprivileged runners.
- Parameterize VM network and gateway selection in create-vms.sh to support alternative bridges such as the customer vm network.
- Extend shared inventory and monitoring configuration to include the ci-pr host and generated firewall/monitoring artifacts.