### PR TITLE
[codex] Use FreeBSD router loopbacks in inventory

### DIFF
--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -58,7 +58,7 @@ all:
         cr1-nl1:
           ansible_host: 2a0c:b641:b50::a
         cr1-de1:
-          ansible_host: cr1-de1.servify.network
+          ansible_host: 2a0c:b641:b50::b
 
     routers:
       hosts:

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -43,6 +43,13 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
 
         self.assertEqual(defaults["ci_runner_user_shell"], "/bin/sh")
 
+    def test_freebsd_router_inventory_uses_loopback_addresses(self):
+        inventory = yaml.safe_load((REPO / "ansible/inventory/hosts.yml").read_text())
+        freebsd_hosts = inventory["all"]["children"]["freebsd"]["hosts"]
+
+        self.assertEqual(freebsd_hosts["cr1-nl1"]["ansible_host"], "2a0c:b641:b50::a")
+        self.assertEqual(freebsd_hosts["cr1-de1"]["ansible_host"], "2a0c:b641:b50::b")
+
     def test_runner_known_hosts_is_seeded_without_controller_key_path(self):
         tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
 


### PR DESCRIPTION
## Summary
- target cr1-de1 by its WireGuard loopback address in Ansible inventory
- add a contract test that both FreeBSD routers use loopback management addresses

## Tests
- uv run pytest tests/iac/test_vault_and_runner_contracts.py tests/iac/test_mock_render.py

## Summary by Sourcery

Tests:
- Add a contract test verifying FreeBSD router inventory entries use the expected loopback addresses.