### PR TITLE
[codex] Allow ci-runner-key steady-state applies

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -48,6 +48,11 @@ on:
         type: string
         required: false
         default: ""
+      bootstrap_ci_runner_key:
+        description: Connect as inventory users for first-time ci-runner-key bootstrap
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
@@ -116,7 +121,7 @@ jobs:
           playbook="${{ inputs.playbook }}"
           apply_var="${playbook//-/_}_apply=true"
           user_args=(-e ansible_user=ci)
-          if [ "${playbook}" = "ci-runner-key" ]; then
+          if [ "${playbook}" = "ci-runner-key" ] && [ "${{ inputs.bootstrap_ci_runner_key }}" = "true" ]; then
             user_args=()
           fi
           ansible-playbook "playbooks/${playbook}.yml" \

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -25,10 +25,15 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         workflow = (REPO / ".github/workflows/apply.yml").read_text()
 
         self.assertIn("- ci-runner-key", workflow)
+        self.assertIn("bootstrap_ci_runner_key:", workflow)
+        self.assertIn("Connect as inventory users for first-time ci-runner-key bootstrap", workflow)
         self.assertIn("CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci", workflow)
         self.assertIn('apply_var="${playbook//-/_}_apply=true"', workflow)
         self.assertIn('user_args=(-e ansible_user=ci)', workflow)
-        self.assertIn('if [ "${playbook}" = "ci-runner-key" ]; then', workflow)
+        self.assertIn(
+            'if [ "${playbook}" = "ci-runner-key" ] && [ "${{ inputs.bootstrap_ci_runner_key }}" = "true" ]; then',
+            workflow,
+        )
         self.assertIn('user_args=()', workflow)
         self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
 


### PR DESCRIPTION
## Summary
- add an explicit bootstrap_ci_runner_key workflow input for first-time bootstrap
- keep routine ci-runner-key applies on the dedicated ci deploy user
- update workflow contract coverage

## Tests
- uv run pytest tests/iac/test_vault_and_runner_contracts.py

## Summary by Sourcery

Gate first-time ci-runner-key bootstrapping behind an explicit workflow input while keeping steady-state applies on the ci deploy user.

New Features:
- Add a bootstrap_ci_runner_key boolean input to the apply workflow to control initial ci-runner-key bootstrapping.

Tests:
- Extend apply workflow contract tests to cover the new ci-runner-key bootstrap gating behavior.