### PR TITLE
[codex] Use FreeBSD node_exporter rc variables correctly

### DIFF
--- a/ansible/roles/monitoring/tasks/node_exporter.yml
+++ b/ansible/roles/monitoring/tasks/node_exporter.yml
@@ -33,10 +33,8 @@
     dest: "{{ monitoring_node_env_path }}"
     content: |
       node_exporter_enable="YES"
-      node_exporter_flags="--web.listen-address={{ monitoring_node_listen }}"
-      node_exporter_syslog_output_enable="YES"
-      node_exporter_syslog_output_priority="info"
-      node_exporter_syslog_output_facility="daemon"
+      node_exporter_listen_address="{{ monitoring_node_listen }}"
+      node_exporter_flags="-S -s info -l daemon"
     owner: root
     group: wheel
     mode: "0644"

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -58,8 +58,9 @@ class MockRenderTest(unittest.TestCase):
 
     def test_freebsd_node_exporter_task_configures_syslog_output(self):
         task_file = (REPO / "ansible/roles/monitoring/tasks/node_exporter.yml").read_text()
-        self.assertIn('node_exporter_syslog_output_enable="YES"', task_file)
-        self.assertIn('node_exporter_syslog_output_facility="daemon"', task_file)
+        self.assertIn('node_exporter_listen_address="{{ monitoring_node_listen }}"', task_file)
+        self.assertIn('node_exporter_flags="-S -s info -l daemon"', task_file)
+        self.assertNotIn('node_exporter_flags="--web.listen-address=', task_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- set FreeBSD node_exporter_listen_address for exporter binding
- reserve node_exporter_flags for daemon(8) syslog logging flags
- add contract coverage to prevent passing exporter args to daemon(8)

## Tests
- uv run pytest tests/iac/test_mock_render.py

## Summary by Sourcery

Update FreeBSD node_exporter rc configuration to use the dedicated listen address variable and reserve flags for syslog logging, and adjust tests to enforce the new contract.

Enhancements:
- Configure node_exporter_listen_address for exporter binding instead of passing listen arguments via flags.
- Reserve node_exporter_flags exclusively for daemon(8) syslog logging options on FreeBSD.

Tests:
- Update FreeBSD node_exporter configuration tests to assert correct use of listen address and logging flags and prevent regressions.