### PR TITLE
[codex] Clear legacy FreeBSD node_exporter args

### DIFF
--- a/ansible/roles/monitoring/tasks/node_exporter.yml
+++ b/ansible/roles/monitoring/tasks/node_exporter.yml
@@ -34,6 +34,7 @@
     content: |
       node_exporter_enable="YES"
       node_exporter_listen_address="{{ monitoring_node_listen }}"
+      node_exporter_args=""
       node_exporter_flags="-S -s info -l daemon"
     owner: root
     group: wheel

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -59,6 +59,7 @@ class MockRenderTest(unittest.TestCase):
     def test_freebsd_node_exporter_task_configures_syslog_output(self):
         task_file = (REPO / "ansible/roles/monitoring/tasks/node_exporter.yml").read_text()
         self.assertIn('node_exporter_listen_address="{{ monitoring_node_listen }}"', task_file)
+        self.assertIn('node_exporter_args=""', task_file)
         self.assertIn('node_exporter_flags="-S -s info -l daemon"', task_file)
         self.assertNotIn('node_exporter_flags="--web.listen-address=', task_file)
 


### PR DESCRIPTION
## Summary
- explicitly clear FreeBSD node_exporter_args in rc.conf.d
- prevents stale /etc/rc.conf exporter args from adding a duplicate listen-address
- extend the render contract test for the override

## Tests
- uv run pytest tests/iac/test_mock_render.py

## Summary by Sourcery

Ensure FreeBSD node_exporter configuration explicitly clears legacy args to avoid conflicting listen-address settings.

Bug Fixes:
- Prevent duplicate node_exporter listen-address configuration on FreeBSD by resetting node_exporter_args in rc.conf.d.

Tests:
- Extend the FreeBSD node_exporter render contract test to assert that node_exporter_args is explicitly cleared.