### PR TITLE
[codex] Run FreeBSD node_exporter as nobody

### DIFF
--- a/ansible/roles/monitoring/tasks/node_exporter.yml
+++ b/ansible/roles/monitoring/tasks/node_exporter.yml
@@ -33,6 +33,8 @@
     dest: "{{ monitoring_node_env_path }}"
     content: |
       node_exporter_enable="YES"
+      node_exporter_user="nobody"
+      node_exporter_group="nobody"
       node_exporter_listen_address="{{ monitoring_node_listen }}"
       node_exporter_args=""
       node_exporter_flags="-S -s info -l daemon"

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -58,6 +58,8 @@ class MockRenderTest(unittest.TestCase):
 
     def test_freebsd_node_exporter_task_configures_syslog_output(self):
         task_file = (REPO / "ansible/roles/monitoring/tasks/node_exporter.yml").read_text()
+        self.assertIn('node_exporter_user="nobody"', task_file)
+        self.assertIn('node_exporter_group="nobody"', task_file)
         self.assertIn('node_exporter_listen_address="{{ monitoring_node_listen }}"', task_file)
         self.assertIn('node_exporter_args=""', task_file)
         self.assertIn('node_exporter_flags="-S -s info -l daemon"', task_file)


### PR DESCRIPTION
## Summary
- pin FreeBSD node_exporter_user and node_exporter_group to nobody
- prevents stale /etc/rc.conf values from making one router run exporter as root
- extend render contract coverage

## Tests
- uv run pytest tests/iac/test_mock_render.py

## Summary by Sourcery

Pin FreeBSD node_exporter to run as the nobody user/group and update tests to cover the new render contract.

Bug Fixes:
- Ensure FreeBSD node_exporter does not inherit stale /etc/rc.conf values that could cause it to run as root.

Tests:
- Extend mock render tests to assert node_exporter user and group are set to nobody in the FreeBSD task configuration.