### PR TITLE
[codex] Handle FreeBSD node_exporter restart transitions

### DIFF
--- a/ansible/roles/monitoring/handlers/main.yml
+++ b/ansible/roles/monitoring/handlers/main.yml
@@ -11,10 +11,17 @@
   listen: restart node_exporter
   when: ansible_os_family == "OpenBSD"
 
-- name: restart node_exporter (FreeBSD)
-  ansible.builtin.service:
-    name: "{{ monitoring_node_service }}"
-    state: restarted
+- name: stop node_exporter before FreeBSD restart
+  ansible.builtin.command: "pkill -x {{ monitoring_node_service }}"
+  register: monitoring_freebsd_node_exporter_pkill
+  changed_when: monitoring_freebsd_node_exporter_pkill.rc == 0
+  failed_when: monitoring_freebsd_node_exporter_pkill.rc not in [0, 1]
+  listen: restart node_exporter
+  when: ansible_os_family == "FreeBSD"
+
+- name: start node_exporter (FreeBSD)
+  ansible.builtin.command: "service {{ monitoring_node_service }} onestart"
+  changed_when: true
   listen: restart node_exporter
   when: ansible_os_family == "FreeBSD"
 

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -58,12 +58,16 @@ class MockRenderTest(unittest.TestCase):
 
     def test_freebsd_node_exporter_task_configures_syslog_output(self):
         task_file = (REPO / "ansible/roles/monitoring/tasks/node_exporter.yml").read_text()
+        handlers = (REPO / "ansible/roles/monitoring/handlers/main.yml").read_text()
+
         self.assertIn('node_exporter_user="nobody"', task_file)
         self.assertIn('node_exporter_group="nobody"', task_file)
         self.assertIn('node_exporter_listen_address="{{ monitoring_node_listen }}"', task_file)
         self.assertIn('node_exporter_args=""', task_file)
         self.assertIn('node_exporter_flags="-S -s info -l daemon"', task_file)
         self.assertNotIn('node_exporter_flags="--web.listen-address=', task_file)
+        self.assertIn('pkill -x {{ monitoring_node_service }}', handlers)
+        self.assertIn('service {{ monitoring_node_service }} onestart', handlers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace FreeBSD node_exporter service restarted handler with root-level pkill plus rc onestart
- handles transition from legacy root-owned exporter processes to managed nobody user
- add contract coverage for the FreeBSD restart path

## Tests
- uv run pytest tests/iac/test_mock_render.py

## Summary by Sourcery

Adjust FreeBSD node_exporter restart handling and extend test coverage for the new restart flow.

Bug Fixes:
- Ensure FreeBSD node_exporter restarts correctly when transitioning from legacy root-owned processes to the managed nobody user by explicitly stopping and starting the service.

Tests:
- Add contract-style assertions verifying the FreeBSD node_exporter restart path uses pkill and rc onestart commands.