### PR TITLE
fix(create-vms): VM DNS = rtr Unbound infra addr, not the routing gateway

### DIFF
--- a/docs/ci/provision-ci-pr.md
+++ b/docs/ci/provision-ci-pr.md
@@ -38,8 +38,11 @@ export VM_NET=<that-uuid>
 bash scripts/create-vms.sh   # or copy just the ci-pr block
 ```
 
-cloud-init assigns `2a0c:b641:b51::c1/64`, gateway + DNS `2a0c:b641:b51::1`
-(rtr Unbound/DNS64). Start the VM, wait for cloud-init, and verify
+cloud-init assigns `2a0c:b641:b51::c1/64`, default route via the customer
+gateway `2a0c:b641:b51::1`, and **DNS `2a0c:b641:b50:2::1`** — rtr's Unbound
+listens only on that infra address (reachable from the customer segment via
+rtr's INPUT path / the `customer→:53` rule), not on the gateway. Start the VM,
+wait for cloud-init, and verify
 `ssh svag@2a0c:b641:b51::c1` works over global IPv6.
 
 ## 2. Bootstrap firewall + monitoring (from the ops workstation)

--- a/scripts/create-vms.sh
+++ b/scripts/create-vms.sh
@@ -14,6 +14,11 @@ create_vm() {
   # customer-isolated vm bridge (xenbr-vm) with the rtr enX3 gateway.
   local NETWORK="${9:-$INFRA}"
   local GATEWAY="${10:-2a0c:b641:b50:2::1}"
+  # Resolver is rtr's Unbound, which listens ONLY on the infra address
+  # 2a0c:b641:b50:2::1 — NOT on per-segment gateways. Customer-segment hosts
+  # reach it via rtr's INPUT path (the customer->:53 firewall rule). So DNS must
+  # default to the infra Unbound address, independent of the routing gateway.
+  local DNS_SERVER="${11:-2a0c:b641:b50:2::1}"
 
   echo "Creating $NAME..."
 
@@ -43,7 +48,7 @@ ethernets:
       - ${IPV6}/64
     nameservers:
       addresses:
-        - ${GATEWAY}
+        - ${DNS_SERVER}
       search:
         - as215932.net
     routes:
@@ -107,6 +112,8 @@ create_vm ci "GitHub Actions self-hosted runner" 1 2147483648 21474836480 "2a0c:
 #     | python3 -c 'import sys,json; [print(n["uuid"],n["name_label"]) for n in json.load(sys.stdin)]'
 #   export VM_NET=<uuid of the xenbr-vm / "vm" network>
 # Args 7,8 (data disk/VBD) are empty; args 9,10 are NETWORK + GATEWAY.
+# Arg 11 (DNS_SERVER) defaults to the infra Unbound address — correct for the
+# customer segment too — so ci-pr does not need to pass it.
 VM_NET="${VM_NET:-}"
 if [ -n "$VM_NET" ]; then
   create_vm ci-pr "Unprivileged PR runner (PR-Agent/Semgrep/PR CI)" \


### PR DESCRIPTION
## Context
Follow-up to the ci-pr bring-up. When I parameterized `create-vms.sh` in #108, the cloud-init **nameserver** was set to `${GATEWAY}`. For ci-pr (customer segment) that became `2a0c:b641:b51::1` — but rtr's Unbound listens **only** on the infra address `2a0c:b641:b50:2::1` (`ss` confirms), so ci-pr DNS returned *connection refused* and the firewall apply failed at `apt update`.

NAT64 forwarding was fine the whole time (verified: `ping`/`curl` to `64:ff9b::1.1.1.1` work) — this was purely a resolver-address bug.

## Fix
- Add `DNS_SERVER` (arg 11, default `2a0c:b641:b50:2::1`) and use it for the nameserver; `GATEWAY` now drives only the default route.
- Customer-segment hosts reach that resolver via rtr's INPUT path (the existing `customer→:53` rule); DNS64 returns answers there.
- Infra VMs unaffected (default equals the original hardcoded value).
- The live ci-pr VM's netplan was corrected the same way; `apt`/`getent` now work.
- Doc: `docs/ci/provision-ci-pr.md` updated to state the resolver is the infra Unbound address.

## Related
- ci-pr bring-up; isolation-enforcement gap tracked separately in #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Set VM cloud-init DNS to the router’s Unbound infra address instead of the routing gateway and document the resulting network behavior for CI PR runners.

Enhancements:
- Introduce a DNS_SERVER parameter to decouple DNS configuration from the VM gateway and default it to the infra Unbound address.

Documentation:
- Clarify CI PR VM provisioning docs to describe the infra Unbound resolver address and its relationship to the customer gateway.