### PR TITLE
ci: PR-Agent + Semgrep pilot (advisory) on ci-pr

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,47 @@
+---
+name: pr-agent
+
+# Advisory AI PR review (replaces hosted Sourcery). Runs on the UNPRIVILEGED
+# `hyrule-public-pr` runner only, with read + PR/issue-comment permissions and
+# our own OpenRouter key. Never deploys, never writes code, never auto-merges.
+# Config (model/fallback/instructions): .pr_agent.toml. Design: docs/ci/pr-agent.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-agent:
+    # Public-fork policy: auto-review ONLY for same-repo (internal) PRs, and
+    # slash commands ONLY from trusted authors. This keeps OPENROUTER_API_KEY
+    # off untrusted fork PRs and stops anyone from burning the OpenRouter
+    # budget via /ask, /improve, etc.
+    if: >
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    timeout-minutes: 12
+    steps:
+      - name: PR-Agent
+        uses: The-PR-Agent/pr-agent@0bd56c0508504c718cc03d504cd4ceb6725ba3c7  # v0.35.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PR-Agent reads the OpenRouter key from openrouter__key; litellm also
+          # honours OPENROUTER_API_KEY. Set both from the org secret.
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -45,3 +45,16 @@ jobs:
           # honours OPENROUTER_API_KEY. Set both from the org secret.
           OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Force our models via dynaconf env (SECTION__KEY, double underscore —
+          # the same mechanism OPENROUTER__KEY uses, and proven to reach the
+          # action's container). .pr_agent.toml alone is NOT honoured here: it
+          # only lives on this pilot branch (not the default branch) and there is
+          # no checkout step, so PR-Agent's "repo settings" load misses it and
+          # falls back to its packaged default (gpt-5.5 → gpt-5.4-mini). These
+          # env vars override that regardless. Once .pr_agent.toml lands on main
+          # (Wave 3) it becomes the durable source; these stay as a belt-and-
+          # suspenders pin. deepseek-v4-flash/minimax-m2.7 are custom (non-listed)
+          # models, so custom_model_max_tokens is required.
+          CONFIG__MODEL: openrouter/deepseek/deepseek-v4-flash
+          CONFIG__FALLBACK_MODELS: '["openrouter/minimax/minimax-m2.7"]'
+          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,6 +30,10 @@ jobs:
   semgrep:
     name: semgrep
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    # Fail fast instead of hanging the single runner. The semgrep image (~1.3 GB)
+    # is heavy on first pull on the small ci-pr VM; it's pre-cached, but this caps
+    # a cold pull. (The job previously had no timeout, so a slow pull hung it.)
+    timeout-minutes: 20
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,60 @@
+---
+name: semgrep
+
+# Token-less Semgrep SAST. Runs on the UNPRIVILEGED `hyrule-public-pr` runner,
+# uploads SARIF to GitHub Code Scanning (free for this public repo). No
+# SEMGREP_APP_TOKEN / no Semgrep Cloud account. Reporting-only during baseline
+# (continue-on-error) — flip to a gate once findings are triaged.
+# Design: docs/ci/semgrep.md.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/semgrep.yml
+      - .semgrep.yml
+  schedule:
+    - cron: '37 3 * * *'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: semgrep
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # Run Semgrep via `docker run` (not a job-level `container:`) so the
+      # Node-based upload-sarif action runs in the normal runner environment,
+      # not inside the minimal semgrep image (which has no Node).
+      - name: Run Semgrep
+        continue-on-error: true            # reporting-only during baseline
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/src" -w /src \
+            semgrep/semgrep@sha256:bc8b15e245d7bd392bcadce7ef4db36601b375fab35bfd8070ed8ae3d7824c74 \
+            semgrep scan \
+              --config p/ci \
+              --config p/github-actions \
+              --config p/secrets \
+              --metrics off \
+              --sarif --output semgrep.sarif
+
+      # Same-repo PRs / pushes get Code Scanning upload. Fork PRs lack
+      # security-events:write — Wave 3 adds a $GITHUB_STEP_SUMMARY fallback.
+      - name: Upload SARIF
+        if: always() && hashFiles('semgrep.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@84498526a009a99c875e83ef4821a8ba52de7c22  # v3 (2.25.5 bundle)
+        with:
+          sarif_file: semgrep.sarif

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,50 @@
+# PR-Agent (advisory) configuration for AS215932/network-operations.
+#
+# Replaces the hosted Sourcery reviewer. Runs ONLY on the unprivileged
+# `hyrule-public-pr` runner with read/comment-only permissions, on our own
+# OpenRouter key. Advisory: no auto-merge, no code writes, no deploy access.
+# Full design: docs/ci/pr-agent.md.
+
+[config]
+git_provider = "github"
+# deepseek-v4-flash (primary) and minimax-m2.7 (fallback) are NOT in PR-Agent's
+# built-in model list, so they are used as *custom* models — which requires
+# custom_model_max_tokens to be set explicitly.
+model = "openrouter/deepseek/deepseek-v4-flash"
+fallback_models = ["openrouter/minimax/minimax-m2.7"]
+custom_model_max_tokens = 128000
+temperature = 0.2
+use_repo_settings_file = true
+publish_output = true
+
+[github_action_config]
+# What runs automatically on each PR (advisory only). /ask, /improve, /review
+# etc. remain available as slash commands to trusted authors.
+auto_review = true
+auto_describe = false
+auto_improve = true
+
+[pr_reviewer]
+require_security_review = true
+require_tests_review = true
+require_score_review = true
+require_estimate_effort_to_review = true
+extra_instructions = """
+This is the AS215932 network infrastructure-as-code repo. Treat as HIGH RISK:
+Ansible playbooks/roles, inventory, host_vars, ansible/generated/ configs,
+FRR/BGP and firewall (nftables/pf) templates, DNS zone files, Vault paths, and
+deploy scripts. Flag, with specifics:
+- changes that bypass render-check, idempotency, Batfish, Containerlab, or
+  dry-run gates;
+- any deploy that checks out / pulls `main` instead of an SHA-pinned ref;
+- secrets committed to files or rendered with broad permissions;
+- added `pull_request_target`;
+- broad GITHUB_TOKEN permissions or `permissions: write-all`;
+- Docker-socket exposure into job steps;
+- any pull_request job that runs on a privileged self-hosted runner label
+  (`hyrule` / `hyrule-infra`) instead of `hyrule-public-pr`.
+Do not restate the diff; surface risk, missing tests, and operational footguns.
+"""
+
+[pr_description]
+publish_description_as_comment = true


### PR DESCRIPTION
### **User description**
## Context
Wave 2 pilot of the CI/CD modernization. Adds advisory **PR-Agent** (our OpenRouter key, deepseek-v4-flash primary / minimax-m2.7 fallback) and token-less **Semgrep** (SARIF → Code Scanning), both running on the new unprivileged **ci-pr** runner (`hyrule-public-pr`).

This PR is itself the end-to-end validation: it should trigger pr-agent (a review comment) and semgrep (reporting-only) on ci-pr. Existing required checks (yamllint/ansible-lint/shellcheck/jinja/render/Sourcery) continue to run on the privileged runner.

## Notes
- PR-Agent: read/comment-only, same-repo-PR + trusted-author gated; never deploys.
- Semgrep: `continue-on-error` (reporting-only) during baseline.
- ci-pr isolation enforcement is tracked separately in #116; PR-Agent (reads text) and Semgrep (static analysis) don't execute PR code, so they're acceptable pre-enforcement. Untrusted-code migration (Wave 4) is gated on #116.
- Replaces hosted Sourcery (removed in a later step — required-check first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce advisory AI PR review and token-less Semgrep SAST on the unprivileged ci-pr runner to enhance code review and static analysis without impacting existing privileged workflows.

New Features:
- Add a Semgrep-based static analysis workflow that uploads SARIF results to GitHub Code Scanning on pull requests, main pushes, manual runs, and a nightly schedule.
- Add an advisory PR-Agent workflow to provide automated AI-based PR reviews and slash-command assistance on eligible pull requests.

Enhancements:
- Configure PR-Agent with custom OpenRouter-backed models and repository-specific high-risk review guidance for infrastructure-as-code changes.


___

### **PR Type**
Enhancement


___

### **Description**
- Add PR-Agent advisory AI review on ci-pr

- Add Semgrep SAST with SARIF upload to Code Scanning

- Configure custom OpenRouter models for PR-Agent

- Set 20-min timeout for slow Semgrep image pulls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR opened/updated"] --> B{"same-repo PR?"}
  B -->|"yes"| C["PR-Agent<br>(OpenRouter, read-only)"]
  C --> D["Review comment<br>+ /slash commands"]
  A2["PR/push/schedule"] --> E["Semgrep<br>(docker run, no token)"]
  E --> F["SARIF → GitHub Code Scanning"]
  subgraph ci-pr runner
    C
    E
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Ci/cd</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Add PR-Agent advisory review workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>New GitHub Actions workflow for advisory AI PR review<br> <li> Runs on unprivileged <code>hyrule-public-pr</code> runner only<br> <li> Enforces same-repo/public-fork access control<br> <li> Configures custom OpenRouter models (deepseek-v4-flash, minimax-m2.7)</ul>


</details>


  </td>
  <td><a href="https://github.com/AS215932/network-operations/pull/118/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>semgrep.yml</strong><dd><code>Add Semgrep SAST workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/semgrep.yml

<ul><li>New GitHub Actions workflow for token-less Semgrep scanning<br> <li> Runs on unprivileged runner with SARIF upload<br> <li> Includes PR, push, manual, and scheduled triggers<br> <li> Sets 20-min timeout to prevent hung runners on cold image pull</ul>


</details>


  </td>
  <td><a href="https://github.com/AS215932/network-operations/pull/118/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbb">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Add PR-Agent configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Configuration file for PR-Agent custom models and behavior<br> <li> Sets primary/fallback models and token limits<br> <li> Extra instructions for high-risk infrastructure code review<br> <li> Enables auto-review, auto-improve, and security review</ul>


</details>


  </td>
  <td><a href="https://github.com/AS215932/network-operations/pull/118/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

