### PR TITLE
firewall: enforce customer isolation and default deny

### DIFF
--- a/ansible/generated/api/nftables.conf
+++ b/ansible/generated/api/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,21 +22,27 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
-        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8402 counter accept comment "hyrule-cloud API from proxy"
+        ip6 saddr { 2a0c:b641:b50:2::40, 2a0c:b641:b50:2::30, 2a0c:b641:b50:2::50 } tcp dport 8402 counter accept comment "hyrule-cloud API from proxy/web/mon"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9187 counter accept comment "postgres_exporter scrape"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/ci-pr/nftables.conf
+++ b/ansible/generated/ci-pr/nftables.conf
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.

--- a/ansible/generated/ci/nftables.conf
+++ b/ansible/generated/ci/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -34,7 +40,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/dns/nftables.conf
+++ b/ansible/generated/dns/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -43,7 +49,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/extmon/nftables.conf
+++ b/ansible/generated/extmon/nftables.conf
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.

--- a/ansible/generated/irc/nftables.conf
+++ b/ansible/generated/irc/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -38,7 +44,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/log/nftables.conf
+++ b/ansible/generated/log/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -46,13 +52,15 @@ table inet filter {
         ip6 saddr 2001:41d0:304:300::7bfb tcp dport 6000 counter accept comment "Vector ingest from off-net ns2"
         ip saddr 10.0.0.0/24 tcp dport 6000 counter accept comment "Vector ingest from dom0 over mgmt v4"
         ip6 saddr 2a0c:b641:b50:2::90 tcp dport 6514 counter accept comment "syslog (TCP) from OpenBSD mail"
+        ip6 saddr 2a0c:b641:b50::a tcp dport 6514 counter accept comment "syslog (TCP) from cr1-nl1"
+        ip6 saddr 2a0c:b641:b50::b tcp dport 6514 counter accept comment "syslog (TCP) from cr1-de1"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 3100 counter accept comment "Loki HTTP API from Grafana on mon"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 8686 counter accept comment "Vector internal metrics scrape from mon"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/mon/nftables.conf
+++ b/ansible/generated/mon/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,20 +22,28 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
         ip6 saddr 2a0c:b641:b50:2::40 tcp dport 3000 counter accept comment "Grafana from proxy"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter self-scrape"
+        ip6 saddr 2a0c:b641:b50:2::a0 tcp dport 9090 counter accept comment "Prometheus API from noc-agent"
+        ip6 saddr 2a0c:b641:b50:2::a0 tcp dport 5665 counter accept comment "Icinga2 API from noc-agent"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/noc/nftables.conf
+++ b/ansible/generated/noc/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -35,7 +41,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/ns2/nftables.conf
+++ b/ansible/generated/ns2/nftables.conf
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.

--- a/ansible/generated/proxy/nftables.conf
+++ b/ansible/generated/proxy/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -38,7 +44,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -46,10 +46,11 @@ table ip filter {
     chain forward {
         type filter hook forward priority filter; policy accept;
 
-        # Customer VM isolation: drop forwarding from the customer VM bridge
-        # to the infra and management bridges. Documented in CLAUDE.md but
-        # missing from the previous live config — added here.
-        iifname enX3 oifname { enX2, enX0 } drop
+        # Customer VM isolation: packets from the customer bridge must not
+        # reach infrastructure/mgmt ranges.  Match destination prefixes first
+        # so enforcement does not depend solely on VRF slave oifname exposure.
+        iifname enX3 ip daddr { 10.0.0.0/24, 10.0.2.0/24 } counter drop comment "customer→infra/mgmt v4 isolation"
+        iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
 
         # Allow established/related
         ct state established,related accept
@@ -65,7 +66,7 @@ table ip filter {
 # --- IPv6 host filter — new in this rollout ---
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -80,11 +81,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -97,21 +104,27 @@ table inet filter {
         ip6 saddr 2a0c:b640:10::213 udp dport 1338 counter accept comment "WG to cr1-de1"
 
         # --- raw escape hatch ---
-        # OSPF6 (proto 89) on WireGuard interfaces — iBGP/OSPF mesh transit.
-        iifname { wg0, wg1 } meta l4proto ospf accept comment "OSPF6 on wg mesh"
+        # OSPF6 (proto 89) on WireGuard/overlay interfaces — iBGP/OSPF mesh transit.
+        # Linux VRF input can expose OSPF packets as arriving on the VRF master
+        # (`overlay`) rather than the WG slave, so allow both forms.
+        iifname { overlay, wg0, wg1 } meta l4proto ospf accept comment "OSPF6 on overlay/wg mesh"
         # iBGP also accepted on wg ifaces with no source restriction (already covered above
         # via loopback src match, but this is a defense-in-depth allow for the wg link).
 
 
         # End of input — log what would have been dropped.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {
         type filter hook forward priority filter; policy accept;
 
-        # Customer VM isolation for IPv6 — mirror of the v4 rule above.
-        iifname enX3 oifname { enX2, enX0 } drop
+        # Customer VM isolation for IPv6.  The source/destination-prefix rule is
+        # VRF-safe (does not rely on oifname); the bridge rule catches spoofed
+        # customer packets seen with the physical vm-bridge ingress device.
+        ip6 saddr 2a0c:b641:b51::/48 ip6 daddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b50::/64, 2a0c:b641:b50:ff00::/56 } counter drop comment "customer→infra/router v6 isolation"
+        iifname enX3 ip6 daddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b50::/64, 2a0c:b641:b50:ff00::/56 } counter drop comment "customer→infra/router v6 bridge isolation"
+        iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
     }
 
     chain output {

--- a/ansible/generated/vault/nftables.conf
+++ b/ansible/generated/vault/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,23 +22,29 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
         ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8200 counter accept comment "Vault API from Caddy proxy"
-        ip6 saddr 2a0c:b641:b50:2::a0 tcp dport 8200 counter accept comment "Vault API from noc Vault Agent fallback/direct access"
+        ip6 saddr { 2a0c:b641:b50:2::a0, 2a0c:b641:b50:2::50, 2a0c:b641:b50:2::20, 2a0c:b641:b50:2::30, 2a0c:b641:b50:2::d0 } tcp dport 8200 counter accept comment "Vault API from internal agents/checks"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 8200 counter accept comment "Vault API from VPN operators"
         ip6 saddr 2a02:a442:1016::/48 tcp dport 8200 counter accept comment "Vault API from ops prefix"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/vpn/nftables.conf
+++ b/ansible/generated/vpn/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,11 +22,17 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
@@ -36,7 +42,7 @@ table inet filter {
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/web/nftables.conf
+++ b/ansible/generated/web/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,21 +22,27 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
-        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8080 counter accept comment "hyrule-web upstream from proxy"
-        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8081 counter accept comment "as215932.net upstream from proxy"
+        ip6 saddr { 2a0c:b641:b50:2::40, 2a0c:b641:b50:2::50 } tcp dport 8080 counter accept comment "hyrule-web upstream from proxy/mon"
+        ip6 saddr { 2a0c:b641:b50:2::40, 2a0c:b641:b50:2::50 } tcp dport 8081 counter accept comment "as215932.net upstream from proxy/mon"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/generated/xoa/nftables.conf
+++ b/ansible/generated/xoa/nftables.conf
@@ -7,7 +7,7 @@ flush ruleset
 
 table inet filter {
     chain input {
-        type filter hook input priority filter; policy accept;
+        type filter hook input priority filter; policy drop;
 
         # Loopback always allowed.
         iif lo accept
@@ -22,22 +22,28 @@ table inet filter {
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
         ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
         ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
         ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
-        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 443 counter accept comment "XO UI from proxy"
+        ip6 saddr 2a0c:b641:b50:2::40 tcp dport { 80, 443 } counter accept comment "XO UI from proxy"
         ip saddr 10.0.0.0/24 tcp dport 80 counter accept comment "XAPI from dom0 (mgmt v4)"
         ip saddr 10.0.0.0/24 tcp dport 443 counter accept comment "XAPI HTTPS from dom0 (mgmt v4)"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
 
 
         # End of input — log+counter what would have been dropped if policy were drop.
-        limit rate 10/second counter log prefix "fw-would-drop " accept
+        limit rate 10/second counter log prefix "fw-drop "
     }
 
     chain forward {

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -9,8 +9,22 @@ infra_subnet: "2a0c:b641:b50:2::/64"
 vpn_clients_subnet: "2a0c:b641:b50:3::/64"
 customer_subnet: "2a0c:b641:b51::/48"
 wg_link_prefix: "2a0c:b641:b50:ff00::/56"  # all wg /127s sit under this
+router_loopback_subnet: "2a0c:b641:b50::/64"
 mgmt_v4: "10.0.0.0/24"
 legacy_infra_v4: "10.0.2.0/24"
+
+# rtr customer isolation: packets forwarded from customer allocations must not
+# reach infrastructure, management, router loopback, or router mesh ranges.  The
+# rtr nftables template enforces these by destination prefix (not only oifname),
+# because VRF forwarding can expose the VRF master/slave devices differently in
+# netfilter.
+customer_isolation_block_v6:
+  - "{{ infra_subnet }}"
+  - "{{ router_loopback_subnet }}"
+  - "{{ wg_link_prefix }}"
+customer_isolation_block_v4:
+  - "{{ mgmt_v4 }}"
+  - "{{ legacy_infra_v4 }}"
 
 # --- Ops workstation (KPN home) ---
 # Live in cr1-* pf SSH allows and configs/knot.conf.j2 AXFR sources.
@@ -94,6 +108,7 @@ ssh_allow_sources_v6:
   - "{{ vpn_clients_subnet }}"
   - "{{ peers.ci.ipv6 }}/128"
   - "{{ peers.noc.ipv6 }}/128"
+  - "{{ peers.mon.ipv6 }}/128"
 ssh_allow_sources_v4:
   - "{{ ops_prefix_v4 }}"
 

--- a/ansible/inventory/group_vars/infra_vms.yml
+++ b/ansible/inventory/group_vars/infra_vms.yml
@@ -1,5 +1,6 @@
 ---
-# Default posture for the seven Debian VMs behind rtr.
-firewall_input_policy: accept    # logging-only on first run; flip to drop in a follow-up PR
-firewall_log_only: true
+# Default posture for Debian/OpenBSD infrastructure VMs behind rtr.
+# Log-only observation is complete; Linux service hosts enforce default-deny.
+firewall_input_policy: drop
+firewall_log_only: false
 firewall_allow_node_exporter_from_mon: true

--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -2,8 +2,8 @@
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
 firewall_extra_rules:
-  # API upstream from Caddy (proxy).
-  - { proto: tcp, dport: 8402, src: "{{ peers.proxy.ipv6 }}", comment: "hyrule-cloud API from proxy" }
+  # API upstreams and backend health checks.
+  - { proto: tcp, dport: 8402, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.web.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-cloud API from proxy/web/mon" }
 
   # Monitoring scrapes.
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }

--- a/ansible/inventory/host_vars/mon.yml
+++ b/ansible/inventory/host_vars/mon.yml
@@ -12,8 +12,12 @@ firewall_extra_rules:
   # Self-scrape (mon scrapes its own node_exporter).
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter self-scrape" }
 
-  # Prometheus / blackbox / Icinga2 are localhost-only (Grafana/Prometheus run
-  # on the same box). No external allow rules; loopback already accepted.
+  # NOC automation queries Prometheus and Icinga's REST API directly.
+  - { proto: tcp, dport: 9090, src: "{{ peers.noc.ipv6 }}", comment: "Prometheus API from noc-agent" }
+  - { proto: tcp, dport: 5665, src: "{{ peers.noc.ipv6 }}", comment: "Icinga2 API from noc-agent" }
+
+  # Blackbox is localhost-only (Prometheus runs on the same box). Loopback is
+  # already accepted by the base firewall rules.
 
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -15,10 +15,10 @@ rtr_proxy_v4: "10.0.2.40"
 rtr_vpn_v4:   "10.0.2.60"
 
 # --- Input chain posture ---
-# First-run: accept + log so we can see what would be dropped.
-# Follow-up PR flips this to drop after counters confirm.
-firewall_input_policy: accept
-firewall_log_only: true
+# Enforced default-deny. Customer forwarding isolation is enforced separately in
+# the rtr nftables forward chains.
+firewall_input_policy: drop
+firewall_log_only: false
 
 firewall_extra_rules:
   # DNS recursion — overlay VMs and customer VMs use rtr's Unbound resolver.
@@ -37,8 +37,10 @@ firewall_extra_rules:
 
 # OSPF6 runs on wg0/wg1 between router loopbacks and is multicast. Allow per-iface.
 firewall_extra_raw_nft: |
-  # OSPF6 (proto 89) on WireGuard interfaces — iBGP/OSPF mesh transit.
-  iifname { wg0, wg1 } meta l4proto ospf accept comment "OSPF6 on wg mesh"
+  # OSPF6 (proto 89) on WireGuard/overlay interfaces — iBGP/OSPF mesh transit.
+  # Linux VRF input can expose OSPF packets as arriving on the VRF master
+  # (`overlay`) rather than the WG slave, so allow both forms.
+  iifname { overlay, wg0, wg1 } meta l4proto ospf accept comment "OSPF6 on overlay/wg mesh"
   # iBGP also accepted on wg ifaces with no source restriction (already covered above
   # via loopback src match, but this is a defense-in-depth allow for the wg link).
 

--- a/ansible/inventory/host_vars/vault.yml
+++ b/ansible/inventory/host_vars/vault.yml
@@ -3,7 +3,7 @@
 
 firewall_extra_rules:
   - { proto: tcp, dport: 8200, src: "{{ peers.proxy.ipv6 }}", comment: "Vault API from Caddy proxy" }
-  - { proto: tcp, dport: 8200, src: "{{ peers.noc.ipv6 }}", comment: "Vault API from noc Vault Agent fallback/direct access" }
+  - { proto: tcp, dport: 8200, src: ["{{ peers.noc.ipv6 }}", "{{ peers.mon.ipv6 }}", "{{ peers.api.ipv6 }}", "{{ peers.web.ipv6 }}", "{{ peers.ci.ipv6 }}"], comment: "Vault API from internal agents/checks" }
   - { proto: tcp, dport: 8200, src: "{{ vpn_clients_subnet }}", comment: "Vault API from VPN operators" }
   - { proto: tcp, dport: 8200, src: "{{ ops_prefix_v6 }}", comment: "Vault API from ops prefix" }
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }

--- a/ansible/inventory/host_vars/web.yml
+++ b/ansible/inventory/host_vars/web.yml
@@ -2,8 +2,8 @@
 # web — hyrule-web (uvicorn :8080 hyrule.host) + nginx (:8081 as215932.net).
 
 firewall_extra_rules:
-  - { proto: tcp, dport: 8080, src: "{{ peers.proxy.ipv6 }}", comment: "hyrule-web upstream from proxy" }
-  - { proto: tcp, dport: 8081, src: "{{ peers.proxy.ipv6 }}", comment: "as215932.net upstream from proxy" }
+  - { proto: tcp, dport: 8080, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-web upstream from proxy/mon" }
+  - { proto: tcp, dport: 8081, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "as215932.net upstream from proxy/mon" }
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}",   comment: "node_exporter scrape" }
 
 # --- Logs --- (ships journald to log VM via Vector)

--- a/ansible/inventory/host_vars/xoa.yml
+++ b/ansible/inventory/host_vars/xoa.yml
@@ -8,7 +8,7 @@ networkd_primary_unit: "10-enX1"
 
 firewall_extra_rules:
   # Xen Orchestra UI — proxied by Caddy.
-  - { proto: tcp, dport: 443, src: "{{ peers.proxy.ipv6 }}", comment: "XO UI from proxy" }
+  - { proto: tcp, dport: [80, 443], src: "{{ peers.proxy.ipv6 }}", comment: "XO UI from proxy" }
 
   # XAPI talks back over the mgmt /24. dom0 contacts XO via 10.0.0.10.
   - { proto: tcp, dport: 80,  src: "10.0.0.0/24", family: ip, comment: "XAPI from dom0 (mgmt v4)" }

--- a/ansible/roles/firewall/tasks/install.yml
+++ b/ansible/roles/firewall/tasks/install.yml
@@ -2,6 +2,14 @@
 # Ensure prerequisites for the apply pipeline are present.
 # nftables provides the `nft` binary; `at` is used for the rollback watchdog.
 
+- name: Check firewall prerequisites (Debian)
+  command: sh -c 'command -v nft >/dev/null 2>&1 && command -v at >/dev/null 2>&1'
+  register: _firewall_debian_prereqs
+  changed_when: false
+  failed_when: false
+  when: ansible_os_family == "Debian"
+  tags: [apply]
+
 - name: Install firewall prerequisites (Debian)
   apt:
     name:
@@ -10,5 +18,7 @@
     state: present
     update_cache: true
     cache_valid_time: 3600
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - _firewall_debian_prereqs.rc != 0
   tags: [apply]

--- a/ansible/roles/firewall/tasks/nftables.yml
+++ b/ansible/roles/firewall/tasks/nftables.yml
@@ -13,13 +13,13 @@
     src: "{{ 'nftables-rtr.conf.j2' if inventory_hostname == 'rtr' else 'nftables.conf.j2' }}"
     dest: "{{ firewall_conf_path }}.new"
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Syntax check rendered nftables config
   command: "{{ firewall_validate_cmd }} {{ firewall_conf_path }}.new"
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Backup currently-loaded ruleset before swap
@@ -30,7 +30,7 @@
       cp {{ firewall_conf_path }} {{ firewall_backup_path }}
     fi
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Schedule rollback watchdog (3 min) — cancels on success
@@ -39,7 +39,7 @@
       | at now + 3 minutes 2>&1 | awk '/job/ {print $2}'
   register: _firewall_at_job
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Move new config into place
@@ -48,7 +48,7 @@
     dest: "{{ firewall_conf_path }}"
     remote_src: true
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   notify: reload nftables
   tags: [apply]
 

--- a/ansible/roles/firewall/tasks/pf.yml
+++ b/ansible/roles/firewall/tasks/pf.yml
@@ -22,7 +22,7 @@
     src: pf.bogons6.j2
     dest: /etc/pf.bogons6
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   notify: reload pf bogons6
   tags: [apply]
 
@@ -31,7 +31,7 @@
     src: pf.bogons4.j2
     dest: /etc/pf.bogons4
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   notify: reload pf bogons4
   tags: [apply]
 
@@ -49,13 +49,13 @@
     src: "{{ firewall_pf_template | default('pf.conf.j2') }}"
     dest: "{{ firewall_conf_path }}.new"
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Syntax check rendered pf config
   command: "{{ firewall_validate_cmd }} {{ firewall_conf_path }}.new"
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Backup currently-loaded ruleset before swap
@@ -65,7 +65,7 @@
       cp {{ firewall_conf_path }} {{ firewall_backup_path }}
     fi
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Schedule rollback watchdog (3 min) — cancels on success
@@ -74,7 +74,7 @@
       | at now + 3 minutes 2>&1 | awk 'tolower($1) == "job" {print $2}'
   register: _firewall_at_job
   changed_when: false
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   tags: [apply]
 
 - name: Move new config into place
@@ -83,7 +83,7 @@
     dest: "{{ firewall_conf_path }}"
     remote_src: true
     mode: "0644"
-  when: firewall_apply
+  when: firewall_apply | default(false) | bool
   notify: reload pf
   tags: [apply]
 

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -46,10 +46,11 @@ table ip filter {
     chain forward {
         type filter hook forward priority filter; policy accept;
 
-        # Customer VM isolation: drop forwarding from the customer VM bridge
-        # to the infra and management bridges. Documented in CLAUDE.md but
-        # missing from the previous live config — added here.
-        iifname enX3 oifname { enX2, enX0 } drop
+        # Customer VM isolation: packets from the customer bridge must not
+        # reach infrastructure/mgmt ranges.  Match destination prefixes first
+        # so enforcement does not depend solely on VRF slave oifname exposure.
+        iifname enX3 ip daddr { {{ customer_isolation_block_v4 | join(', ') }} } counter drop comment "customer→infra/mgmt v4 isolation"
+        iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
 
         # Allow established/related
         ct state established,related accept
@@ -88,8 +89,12 @@ table inet filter {
     chain forward {
         type filter hook forward priority filter; policy accept;
 
-        # Customer VM isolation for IPv6 — mirror of the v4 rule above.
-        iifname enX3 oifname { enX2, enX0 } drop
+        # Customer VM isolation for IPv6.  The source/destination-prefix rule is
+        # VRF-safe (does not rely on oifname); the bridge rule catches spoofed
+        # customer packets seen with the physical vm-bridge ingress device.
+        ip6 saddr {{ customer_subnet }} ip6 daddr { {{ customer_isolation_block_v6 | join(', ') }} } counter drop comment "customer→infra/router v6 isolation"
+        iifname enX3 ip6 daddr { {{ customer_isolation_block_v6 | join(', ') }} } counter drop comment "customer→infra/router v6 bridge isolation"
+        iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
     }
 
     chain output {

--- a/ansible/roles/firewall/templates/partials/_input_base.j2
+++ b/ansible/roles/firewall/templates/partials/_input_base.j2
@@ -13,7 +13,12 @@
         # ICMPv4 — keep ping working.
         meta l4proto icmp accept
 
-        # SSH from VPN clients and the KPN ops prefix.
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
 {% for src in ssh_allow_sources_v6 %}
         ip6 saddr {{ src }} tcp dport 22 counter accept comment "ssh from {{ src }}"
 {% endfor %}

--- a/docs/ci/provision-ci-pr.md
+++ b/docs/ci/provision-ci-pr.md
@@ -5,8 +5,10 @@ untrusted PR code — PR-Agent, Semgrep, and (after Wave 4) every `pull_request`
 lint/test/build job. It is deliberately **disposable** and **isolated**:
 
 - On the **customer segment** `2a0c:b641:b51::c1/64` (rtr `enX3`/`xenbr-vm`), so
-  rtr's `iifname enX3 oifname {enX2,enX0} drop` cuts it off from the infra and
-  management overlays. A compromised PR job here cannot reach production.
+  rtr drops customer-sourced forwarded packets to the infra/router prefixes and
+  drops `enX3` forwarding to the infra/mgmt bridges. The primary rule matches
+  destination prefixes, not only `oifname`, so it remains effective under the
+  overlay VRF. A compromised PR job here cannot reach production.
 - **No** Vault AppRole, **no** `/etc/github-runner/secrets.env`, **no** `id_ci`
   deploy key, **no** Containerlab/xcaddy — see `host_vars/ci-pr.yml`.
 - Registered in the **`public-pr`** org runner group (label `hyrule-public-pr`),

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -87,7 +87,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| proxy | TCP | 8402 | hyrule-cloud API upstream |
+| proxy, web, mon | TCP | 8402 | hyrule-cloud API upstream and backend health checks |
 | mon | TCP | 9100 | node_exporter |
 | mon | TCP | 9187 | postgres_exporter |
 | ops-prefix, vpn-clients | TCP | 22 | SSH |
@@ -96,8 +96,8 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| proxy | TCP | 8080 | hyrule.host landing page |
-| proxy | TCP | 8081 | as215932.net info site |
+| proxy, mon | TCP | 8080 | hyrule.host landing page and backend health check |
+| proxy, mon | TCP | 8081 | as215932.net info site and backend health check |
 | mon | TCP | 9100 | node_exporter |
 | ops-prefix, vpn-clients | TCP | 22 | SSH |
 
@@ -115,7 +115,8 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 |------|-------|------|---------|
 | proxy | TCP | 3000 | Grafana via Caddy |
 | self | TCP | 9100 | node_exporter (Prometheus self-scrape) |
-| localhost only | TCP | 5665, 9090, 9115 | Icinga2 API / Prometheus / blackbox |
+| noc | TCP | 5665, 9090 | Icinga2 API / Prometheus query API for noc-agent |
+| localhost only | TCP | 9115 | blackbox exporter |
 | ops-prefix, vpn-clients | TCP | 22 | SSH |
 
 ### vpn (`2a0c:b641:b50:2::60`)
@@ -130,7 +131,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| proxy | TCP | 443 | XO web UI |
+| proxy | TCP | 80, 443 | XO web UI (Caddy upstream currently targets :80; :443 kept for appliance UI compatibility) |
 | dom0 (mgmt v4 `10.0.0.0/24`) | TCP | 80, 443 | XAPI back-channel |
 | mon | TCP | 9100 | node_exporter |
 | ops-prefix, vpn-clients | TCP | 22 | SSH |
@@ -184,9 +185,13 @@ Outbound (cross-cutting): ci → github.com TCP/443 (poll runner queue, fetch ac
 Unprivileged self-hosted GitHub Actions runner for **untrusted PR code**
 (PR-Agent, Semgrep, and — after Wave 4 — all `pull_request` lint/test/build
 jobs). Deliberately on the **customer-isolated** vm bridge: rtr drops
-`enX3 → {enX2 infra, enX0 mgmt}`, so a compromised PR job cannot reach the
-management overlay. No Vault, no `id_ci`, no `secrets.env`, no Containerlab —
-treated as disposable.
+forwarded packets from `2a0c:b641:b51::/48` to infra/router ranges
+(`2a0c:b641:b50:2::/64`, `2a0c:b641:b50::/64`, WG `/56`) and drops `enX3`
+forwarding to mgmt/legacy infra v4 (`10.0.0.0/24`, `10.0.2.0/24`). This is
+matched by destination prefix, not only `oifname`, so it remains effective when
+VRF forwarding exposes the `overlay` master/slave devices differently in
+netfilter. No Vault, no `id_ci`, no `secrets.env`, no Containerlab — treated as
+disposable.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
@@ -295,13 +300,13 @@ exceptions are:
 | Public → mail | in | 80 tcp | ACME HTTP-01 for mail.as215932.net |
 | ops-prefix, vpn-clients, noc → mail | in | 993 tcp | Private mailbox access and noc-agent polling |
 | ops-prefix, vpn-clients → mail | in | 4190 tcp | Private Sieve access |
-| ops-prefix, vpn-clients → all | in | 22 tcp | SSH |
+| ops-prefix, vpn-clients, ci, noc, mon → all | in | 22 tcp | SSH (ops access, CI apply runs, MCP access, Icinga SSH checks) |
 | all infra → log | out | 6000 tcp | Vector agent → aggregator (Loki ingest path) |
 | mail → log | out | 6514 tcp | OpenBSD syslogd `@@` forward (TCP only, no UDP) |
 | ns2 → log | out | 6000 tcp | Off-net Vector agent → aggregator over public IPv6 |
 | dom0 → log | out | 6000 tcp | Hypervisor Vector agent → aggregator over mgmt v4 |
 | mon → log | out | 3100, 8686 tcp | Grafana query + Vector metrics scrape |
-| noc, mon, api, web → vault | out | 8200 tcp | vault-agent → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
+| noc, mon, api, web, ci → vault | out | 8200 tcp | vault-agent / health checks → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
 | mon → routers | out | 22 tcp (by_ssh) | icinga2 by_ssh checks, logged in as the dedicated `monitoring` system user. Privileged plugins (jool stats) are wrapped in `sudo`/`doas`, scoped to `/usr/local/lib/nagios/plugins/*` by the role-rendered drop. |
 
 ---

--- a/docs/rtr-vrf.md
+++ b/docs/rtr-vrf.md
@@ -19,6 +19,27 @@ the right VRF from boot, no runtime migration. The overlay netdev is
 `05-overlay.netdev` (kind=vrf, table=200); each member interface
 declares `VRF=overlay` in its `[Network]` block.
 
+## Firewall matching in the overlay VRF
+
+Customer VM isolation is enforced in rtr's nftables forward path. Do not rely
+only on `iifname enX3 oifname enX2`: both `enX2` (infra) and `enX3` (customer)
+are enslaved to the same `overlay` VRF, and netfilter/device exposure can differ
+between VRF master and slave devices. The managed rules therefore include
+VRF-safe destination-prefix drops. The same caveat applies to host-input
+routing protocols: OSPFv3 packets may appear with `IN=overlay`, so rtr's input
+filter allows proto 89 on both the VRF master (`overlay`) and WG slaves
+(`wg0`/`wg1`).
+
+- IPv6 forwarded from `2a0c:b641:b51::/48` to infra/router ranges
+  (`2a0c:b641:b50:2::/64`, `2a0c:b641:b50::/64`, `2a0c:b641:b50:ff00::/56`)
+  is dropped before any broad forward accepts.
+- IPv4 forwarded from the customer bridge (`enX3`) to mgmt/legacy infra
+  (`10.0.0.0/24`, `10.0.2.0/24`) is dropped before the public DNAT allows.
+
+`ci-pr` (`2a0c:b641:b51::c1`) is the acceptance canary: `ci-pr → mon:9100`
+must time out, while DNS to rtr on the customer gateway and public HTTPS egress
+must still work.
+
 ## IPv4 DNAT VRF leak
 
 The infra subnet `10.0.2.0/24` lives on `enX2` (overlay VRF). External

--- a/tests/iac/mock_inventory.yml
+++ b/tests/iac/mock_inventory.yml
@@ -2,8 +2,18 @@
 as215932_prefix: "2a0c:b641:b50::/44"
 infra_subnet: "2a0c:b641:b50:2::/64"
 vpn_clients_subnet: "2a0c:b641:b50:3::/64"
+wg_link_prefix: "2a0c:b641:b50:ff00::/56"
+router_loopback_subnet: "2a0c:b641:b50::/64"
 customer_subnet: "2a0c:b641:b51::/48"
 mgmt_v4: "10.0.0.0/24"
+legacy_infra_v4: "10.0.2.0/24"
+customer_isolation_block_v6:
+  - "{{ infra_subnet }}"
+  - "{{ router_loopback_subnet }}"
+  - "{{ wg_link_prefix }}"
+customer_isolation_block_v4:
+  - "{{ mgmt_v4 }}"
+  - "{{ legacy_infra_v4 }}"
 
 peers:
   rtr:

--- a/tests/iac/mock_inventory.yml
+++ b/tests/iac/mock_inventory.yml
@@ -2,18 +2,8 @@
 as215932_prefix: "2a0c:b641:b50::/44"
 infra_subnet: "2a0c:b641:b50:2::/64"
 vpn_clients_subnet: "2a0c:b641:b50:3::/64"
-wg_link_prefix: "2a0c:b641:b50:ff00::/56"
-router_loopback_subnet: "2a0c:b641:b50::/64"
 customer_subnet: "2a0c:b641:b51::/48"
 mgmt_v4: "10.0.0.0/24"
-legacy_infra_v4: "10.0.2.0/24"
-customer_isolation_block_v6:
-  - "{{ infra_subnet }}"
-  - "{{ router_loopback_subnet }}"
-  - "{{ wg_link_prefix }}"
-customer_isolation_block_v4:
-  - "{{ mgmt_v4 }}"
-  - "{{ legacy_infra_v4 }}"
 
 peers:
   rtr:

--- a/tests/iac/test_firewall_contracts.py
+++ b/tests/iac/test_firewall_contracts.py
@@ -1,22 +1,68 @@
 from pathlib import Path
+import unicodedata
+
+import yaml
+from jinja2 import Environment, StrictUndefined
 
 
 REPO = Path(__file__).resolve().parents[2]
 
 
+def _normalize(text: str) -> str:
+    return " ".join(unicodedata.normalize("NFKC", text).split())
+
+
+def _ruleset_has_line_with_parts(ruleset: str, parts: list[str]) -> bool:
+    normalized_parts = [_normalize(part) for part in parts]
+    for line in ruleset.splitlines():
+        normalized_line = _normalize(line)
+        if all(part in normalized_line for part in normalized_parts):
+            return True
+    return False
+
+
+def _all_group_vars() -> dict:
+    return yaml.safe_load((REPO / "ansible/inventory/group_vars/all.yml").read_text())
+
+
+def _render_inventory_value(value: str, context: dict) -> str:
+    return Environment(undefined=StrictUndefined).from_string(value).render(context)
+
+
+def _resolved_isolation_prefixes(family: str) -> list[str]:
+    all_vars = _all_group_vars()
+    return [
+        _render_inventory_value(prefix, all_vars)
+        for prefix in all_vars[f"customer_isolation_block_{family}"]
+    ]
+
+
 def test_rtr_customer_isolation_is_destination_prefix_enforced():
     """Customer→infra isolation must not depend only on VRF oifname matching."""
     ruleset = (REPO / "ansible/generated/rtr/nftables.conf").read_text()
+    v6_prefixes = _resolved_isolation_prefixes("v6")
+    v4_prefixes = _resolved_isolation_prefixes("v4")
 
-    assert (
-        "ip6 saddr 2a0c:b641:b51::/48 "
-        "ip6 daddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b50::/64, 2a0c:b641:b50:ff00::/56 } "
-        "counter drop comment \"customer→infra/router v6 isolation\""
-    ) in ruleset
-    assert (
-        "iifname enX3 ip daddr { 10.0.0.0/24, 10.0.2.0/24 } "
-        "counter drop comment \"customer→infra/mgmt v4 isolation\""
-    ) in ruleset
+    assert _ruleset_has_line_with_parts(
+        ruleset,
+        [
+            "ip6 saddr 2a0c:b641:b51::/48",
+            "ip6 daddr",
+            *v6_prefixes,
+            "counter drop",
+            'comment "customer→infra/router v6 isolation"',
+        ],
+    )
+    assert _ruleset_has_line_with_parts(
+        ruleset,
+        [
+            "iifname enX3",
+            "ip daddr",
+            *v4_prefixes,
+            "counter drop",
+            'comment "customer→infra/mgmt v4 isolation"',
+        ],
+    )
 
 
 def test_rtr_customer_isolation_runs_before_established_accept():

--- a/tests/iac/test_firewall_contracts.py
+++ b/tests/iac/test_firewall_contracts.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_rtr_customer_isolation_is_destination_prefix_enforced():
+    """Customer→infra isolation must not depend only on VRF oifname matching."""
+    ruleset = (REPO / "ansible/generated/rtr/nftables.conf").read_text()
+
+    assert (
+        "ip6 saddr 2a0c:b641:b51::/48 "
+        "ip6 daddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b50::/64, 2a0c:b641:b50:ff00::/56 } "
+        "counter drop comment \"customer→infra/router v6 isolation\""
+    ) in ruleset
+    assert (
+        "iifname enX3 ip daddr { 10.0.0.0/24, 10.0.2.0/24 } "
+        "counter drop comment \"customer→infra/mgmt v4 isolation\""
+    ) in ruleset
+
+
+def test_rtr_customer_isolation_runs_before_established_accept():
+    ruleset = (REPO / "ansible/generated/rtr/nftables.conf").read_text()
+
+    v4_drop = ruleset.index("customer→infra/mgmt v4 isolation")
+    v4_established = ruleset.index("ct state established,related accept", v4_drop)
+    assert v4_drop < v4_established
+
+    v6_drop = ruleset.index("customer→infra/router v6 isolation")
+    output_chain = ruleset.index("chain output", v6_drop)
+    assert v6_drop < output_chain


### PR DESCRIPTION
## Summary

- enforce rtr customer→infra/router isolation with VRF-safe destination-prefix drops, not only `oifname`
- flip Linux firewall posture from log-only to default-deny and codify observed legitimate flows
- add DHCP broadcast quiet-drop, OSPF-on-overlay allowance, and Ansible apply idempotency fixes
- update docs and generated firewall artifacts; add regression tests for rtr customer isolation

Fixes #116

## Live rollout / validation

Applied live during remediation with the firewall playbook watchdogs.

- `ci-pr -> mon:9100`: timeout / blocked
- ci-pr DNS and HTTPS egress: OK
- rtr customer-isolation counter incremented during probes
- all Linux nft input chains verified as `policy drop`
- rtr BGP sessions recovered/established in overlay VRF
- `nat64-vrf-leak` and `jool`: active
- PF on `mail`, `cr1-nl1`, `cr1-de1`: enabled/enforcing

## Tests

- `pytest -q tests/iac`
- `ansible-playbook playbooks/firewall.yml --tags validate --connection=local --skip-tags=snapshot --limit 'rtr,dns,api,web,proxy,mon,vpn,xoa,irc,noc,log,vault,ci,ci-pr,ns2'`

## Summary by Sourcery

Enforce stricter firewall posture and customer isolation on rtr and infra VMs while updating related docs, inventory, and tests to codify the new security model.

New Features:
- Add VRF-safe customer-to-infra/router isolation rules on rtr using destination-prefix drops for IPv4 and IPv6.
- Extend Vault, API, web, SSH, Prometheus, and Icinga firewall allows to cover internal agents, health checks, and monitoring flows.
- Introduce explicit DHCP broadcast drops on infra hosts to reduce noisy logging.

Bug Fixes:
- Ensure rtr customer isolation remains effective under VRF by matching on destination prefixes rather than relying solely on interface names.
- Fix OSPFv3 input filtering on rtr to allow traffic arriving via the overlay VRF master as well as WireGuard interfaces.
- Make firewall apply tasks for nftables and pf idempotent and safe when firewall_apply is unset or false.
- Skip unnecessary package installation for firewall prerequisites on Debian when nft and at are already present.

Enhancements:
- Flip Linux infrastructure and rtr firewall input policy from log-only to enforced default-deny with explicit allow rules.
- Refine SSH access controls to include CI, noc, monitoring, and automation sources while documenting their purposes.
- Clarify and expand documentation around VRF firewall matching, customer isolation, and CI PR runner isolation semantics.

Documentation:
- Update network flow diagrams and CI provisioning docs to reflect new monitoring, health check, and Vault access patterns.
- Document VRF-aware firewall matching and customer isolation behavior in the rtr VRF documentation.

Tests:
- Add regression tests asserting that rtr customer isolation is implemented via destination-prefix rules and ordered before broad accepts.
- Update mock inventory data for IaC tests to include customer isolation block variables and router-related prefixes.