### PR TITLE
monitoring: FreeBSD by_ssh shell, mail-health body, runner crash-loop (#80 #67 #92)

### DIFF
--- a/ansible/generated/noc/icinga_host.conf
+++ b/ansible/generated/noc/icinga_host.conf
@@ -61,16 +61,12 @@ object Service "noc-agent-config-health" {
 
 object Service "noc-agent-mail-health" {
   host_name = "noc"
-  check_command = "http"
+  check_command = "noc_agent_mail_health"
   check_interval = 2m
   retry_interval = 30s
   notes = "NOC mailbox IMAP login/select used by mail polling"
-  vars.http_address = "2a0c:b641:b50:2::a0"
-  vars.http_port = 8000
-  vars.http_uri = "/health/mail"
-  vars.http_ipv6 = true
-  vars.http_timeout = 15
-  vars.http_expect_body_regex = "\"status\":\"ok\""
+  vars.noc_mail_host = "2a0c:b641:b50:2::a0"
+  vars.noc_mail_port = 8000
 }
 
 object Service "noc-agent-model-health" {

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -56,17 +56,16 @@ monitoring_extra_services:
       http_expect_body_regex: '"status":"ok"'
 
   - name: noc-agent-mail-health
-    check_command: http
+    # Custom check: surfaces /health/mail's JSON body (IMAP reason / error) in
+    # the alert instead of just the HTTP code.
+    # CheckCommand defined in configs/mon/icinga2/services/noc-agent-mail-health.conf.
+    check_command: noc_agent_mail_health
     interval: 2m
     retry: 30s
     notes: "NOC mailbox IMAP login/select used by mail polling"
     vars:
-      http_address: "{{ peers.noc.ipv6 }}"
-      http_port: 8000
-      http_uri: "/health/mail"
-      http_ipv6: true
-      http_timeout: 15
-      http_expect_body_regex: '"status":"ok"'
+      noc_mail_host: "{{ peers.noc.ipv6 }}"
+      noc_mail_port: 8000
 
   - name: noc-agent-model-health
     # Custom check: surfaces /health/model's JSON body in the alert.

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -23,6 +23,11 @@ monitoring_mon_host: mon
 # Override per-host via host_vars if a different bind is needed.
 monitoring_node_listen: ":9100"
 
+# Expose node_systemd_service_restart_total (one extra series per systemd unit)
+# so crash/restart loops are visible to Prometheus/Icinga (#92). On by default;
+# set false in host_vars on a high-cardinality node to cap scrape cost.
+monitoring_node_restart_metrics: true
+
 # Disks to monitor. Each key is the Icinga service name suffix; mountpoint is
 # read by the prom_disk apply rule on mon. Default = root only.
 monitoring_disks:

--- a/ansible/roles/monitoring/tasks/node_exporter.yml
+++ b/ansible/roles/monitoring/tasks/node_exporter.yml
@@ -16,9 +16,13 @@
     # --collector.systemd.enable-restarts-metrics exposes
     # node_systemd_service_restart_total{name="<unit>"} so a crash/restart loop
     # is visible to Prometheus/Icinga. Without it a flapping unit that bounces
-    # back to active=1 between samples is invisible (issue #92). Enabled
-    # fleet-wide on Linux — the blind spot is not specific to github-runner.
-    line: 'ARGS="--web.listen-address={{ monitoring_node_listen }} --collector.systemd --collector.systemd.enable-restarts-metrics"'
+    # back to active=1 between samples is invisible (issue #92). On by default
+    # fleet-wide (the blind spot is not github-runner-specific); it adds one
+    # series per systemd unit, so set monitoring_node_restart_metrics: false in
+    # host_vars on any high-cardinality node where that scrape cost matters.
+    line: >-
+      ARGS="--web.listen-address={{ monitoring_node_listen }} --collector.systemd{{
+      ' --collector.systemd.enable-restarts-metrics' if monitoring_node_restart_metrics | bool else '' }}"
     owner: root
     group: root
     mode: "0644"

--- a/ansible/roles/monitoring/tasks/node_exporter.yml
+++ b/ansible/roles/monitoring/tasks/node_exporter.yml
@@ -13,7 +13,12 @@
     path: "{{ monitoring_node_env_path }}"
     create: true
     regexp: '^ARGS='
-    line: 'ARGS="--web.listen-address={{ monitoring_node_listen }} --collector.systemd"'
+    # --collector.systemd.enable-restarts-metrics exposes
+    # node_systemd_service_restart_total{name="<unit>"} so a crash/restart loop
+    # is visible to Prometheus/Icinga. Without it a flapping unit that bounces
+    # back to active=1 between samples is invisible (issue #92). Enabled
+    # fleet-wide on Linux — the blind spot is not specific to github-runner.
+    line: 'ARGS="--web.listen-address={{ monitoring_node_listen }} --collector.systemd --collector.systemd.enable-restarts-metrics"'
     owner: root
     group: root
     mode: "0644"

--- a/ansible/roles/monitoring/vars/FreeBSD.yml
+++ b/ansible/roles/monitoring/vars/FreeBSD.yml
@@ -4,7 +4,12 @@ monitoring_node_service: node_exporter
 monitoring_node_env_path: /etc/rc.conf.d/node_exporter
 
 # Dedicated by_ssh remote user (FreeBSD variant). doas, not sudo.
-monitoring_user_shell: /usr/sbin/nologin
+# Must be a real shell: icinga2's by_ssh runs `ssh monitoring@host <cmd>`, and
+# FreeBSD's /usr/sbin/nologin rejects command execution outright ("This account
+# is currently not available."), so every by_ssh check fails. /bin/sh is the
+# minimal shell that lets the dedicated, key-only, doas-scoped user run plugins.
+# (cr1.{nl1,de1} were bootstrapped to /bin/sh by hand 2026-05-15 — issue #80.)
+monitoring_user_shell: /bin/sh
 monitoring_user_home: /var/db/monitoring
 monitoring_user_privesc_template: doas-monitoring.conf.j2
 monitoring_user_privesc_dest: /usr/local/etc/doas.d/monitoring.conf

--- a/configs/mon/icinga2/scripts/check_noc_agent_mail_health.sh
+++ b/configs/mon/icinga2/scripts/check_noc_agent_mail_health.sh
@@ -28,6 +28,12 @@ if [ "$#" -ne 2 ]; then
 fi
 host="$1"; port="$2"
 
+# Fail diagnosably if the plugin's own deps are missing, rather than emitting a
+# confusing parse/curl error.
+for dep in curl jq; do
+    command -v "$dep" >/dev/null 2>&1 || { echo "UNKNOWN - required tool '$dep' not found on mon"; exit 3; }
+done
+
 body="$(mktemp)"
 err_log="$(mktemp)"
 trap 'rm -f "$body" "$err_log"' EXIT
@@ -51,10 +57,12 @@ field() {
 status=$(field '.status')
 mbox=$(field '.mailbox')
 count=$(field '.message_count')
-err=$(jq -r '.error // ""' "$body" 2>/dev/null || true)
+# Go through field() too, so a malformed body fails the same way for every key
+# ("?"). On the happy path .error is absent → "?" → omitted from the detail.
+err=$(field '.error')
 
 detail="status=$status mailbox=$mbox count=$count"
-[ -n "$err" ] && detail="$detail err=$err"
+[ -n "$err" ] && [ "$err" != "?" ] && detail="$detail err=$err"
 
 case "$code" in
     200) echo "OK - $detail"; exit 0 ;;

--- a/configs/mon/icinga2/scripts/check_noc_agent_mail_health.sh
+++ b/configs/mon/icinga2/scripts/check_noc_agent_mail_health.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# check_noc_agent_mail_health.sh — Icinga2 check executed on mon.
+#
+# Curls noc-agent's /health/mail and surfaces the JSON body's reason fields
+# in the plugin output line. Replaces the generic `check_http` command, which
+# only reports the HTTP status code and throws away the JSON explaining *why*
+# the mailbox poll is unhealthy (IMAP login failure, TLS error, missing creds,
+# select failure).
+#
+# Endpoint shape is fixed by hyrule-noc-agent/app/main.py:797-807 +
+# app/mail.py:240-264:
+#   200 OK        -> {status:"ok", host, user, mailbox, message_count}
+#   503 degraded  -> {status:"degraded", error:"<safe reason>"}
+# jq extraction matches that contract.
+#
+# Usage: check_noc_agent_mail_health.sh <ipv6> <port>
+#
+# Exit codes:
+#   0 OK            — HTTP 200, status=ok
+#   2 CRITICAL      — HTTP 503 (or unreachable)
+#   3 UNKNOWN       — non-200/503 response, or jq parse failure
+
+set -u
+
+if [ "$#" -ne 2 ]; then
+    echo "UNKNOWN - usage: $0 <ipv6> <port>"
+    exit 3
+fi
+host="$1"; port="$2"
+
+body="$(mktemp)"
+err_log="$(mktemp)"
+trap 'rm -f "$body" "$err_log"' EXIT
+
+# Keep curl's stderr (TLS handshake, connection refused, timeout reason) so the
+# alert body has something actionable instead of a generic "exit non-zero".
+code="$(curl -sS --max-time 15 -o "$body" -w '%{http_code}' \
+    "http://[$host]:$port/health/mail" 2>"$err_log")" || {
+    reason="$(tr '\n' ' ' < "$err_log" | sed 's/  */ /g')"
+    echo "CRITICAL - /health/mail unreachable from mon: ${reason:-curl exit non-zero}"
+    exit 2
+}
+
+# Parse fields; jq -r prints "null" if a key is missing, so treat that as "?".
+field() {
+    val="$(jq -r "$1 // \"?\"" "$body" 2>/dev/null)" || val="?"
+    [ "$val" = "null" ] && val="?"
+    printf '%s' "$val"
+}
+
+status=$(field '.status')
+mbox=$(field '.mailbox')
+count=$(field '.message_count')
+err=$(jq -r '.error // ""' "$body" 2>/dev/null || true)
+
+detail="status=$status mailbox=$mbox count=$count"
+[ -n "$err" ] && detail="$detail err=$err"
+
+case "$code" in
+    200) echo "OK - $detail"; exit 0 ;;
+    503) echo "CRITICAL - $detail"; exit 2 ;;
+    *)   echo "UNKNOWN - http=$code $detail"; exit 3 ;;
+esac

--- a/configs/mon/icinga2/services/github-runner.conf
+++ b/configs/mon/icinga2/services/github-runner.conf
@@ -36,3 +36,46 @@ apply Service "github-runner" {
   // ci is the only runner today; key on a host var when a second one lands.
   assign where host.name == "ci"
 }
+
+// Crash/restart-loop detection. The active-state check above samples every 2m
+// and a flapping unit bounces back through active=1 between samples, so an
+// orphan crash-loop (NRestarts 245+, SessionConflict on every start) stayed
+// invisible to Icinga and was only found by hand (issue #92). This keys on the
+// restart *rate* instead, exposed by node_exporter's
+// --collector.systemd.enable-restarts-metrics (enabled in the monitoring role).
+object CheckCommand "prom_systemd_restart_rate" {
+  command = [ PluginDir + "/check_prom_query" ]
+
+  arguments = {
+    "-u" = "$prom_url$"
+    "-q" = {{
+      var inst = macro("$prom_instance$")
+      var unit = macro("$systemd_unit$")
+      var win  = macro("$restart_window$")
+      return "increase(node_systemd_service_restart_total{instance=\"" + inst + "\",name=\"" + unit + "\"}[" + win + "])"
+    }}
+    "-w" = "$restart_warn$"
+    "-c" = "$restart_crit$"
+    "-o" = "gt"
+    "-n" = "restarts"
+    "-f" = "%d"
+  }
+
+  vars.prom_url = "http://localhost:9090"
+  vars.restart_window = "10m"
+  vars.restart_warn = "3"
+  vars.restart_crit = "5"
+}
+
+apply Service "github-runner-restart-loop" {
+  check_command = "prom_systemd_restart_rate"
+  check_interval = 2m
+  retry_interval = 1m
+
+  notes = "GitHub Actions runner restart rate over 10m (catches crash loops the active-state check misses)"
+
+  vars.prom_instance = host.vars.prom_instance_node
+  vars.systemd_unit = "github-runner.service"
+
+  assign where host.name == "ci"
+}

--- a/configs/mon/icinga2/services/noc-agent-mail-health.conf
+++ b/configs/mon/icinga2/services/noc-agent-mail-health.conf
@@ -1,0 +1,22 @@
+// /etc/icinga2/conf.d/services/noc-agent-mail-health.conf
+//
+// Custom CheckCommand for noc-agent's /health/mail endpoint. The upstream
+// `check_http` plugin only surfaces the HTTP status code — /health/mail
+// returns JSON explaining *why* the mailbox poll is degraded (IMAP login
+// failure, TLS error, missing creds, select failure). This wrapper script
+// extracts those fields and puts them in the plugin output line so the alert
+// itself is actionable.
+//
+// Mirrors the noc-agent-model-health pattern. Service object lives in
+// host_vars/noc.yml :: monitoring_extra_services (rendered into
+// /etc/icinga2/conf.d/hosts/ansible/noc.conf by the monitoring role) and
+// references this CheckCommand by name.
+
+object CheckCommand "noc_agent_mail_health" {
+  command = [ "/etc/icinga2/scripts/check_noc_agent_mail_health.sh" ]
+
+  arguments = {
+    "host" = { skip_key = true; order = 1; value = "$noc_mail_host$" }
+    "port" = { skip_key = true; order = 2; value = "$noc_mail_port$" }
+  }
+}


### PR DESCRIPTION
Three self-contained monitoring fixes. (#81 and #56 from the same cluster are tracked as comments on their issues — they touch apply-time trust/hypervisor state that can't be verified without a live apply.)

## #80 — FreeBSD by_ssh user shell
`monitoring_user_shell` was `/usr/sbin/nologin` in `vars/FreeBSD.yml`. icinga2's by_ssh runs `ssh monitoring@host <cmd>`; FreeBSD's nologin rejects command execution, so every by_ssh check on cr1.{nl1,de1} fails. The hosts were bootstrapped to `/bin/sh` by hand 2026-05-15 — this makes the repo match. **Closes #80**

## #67 — mail-health alert surfaces the JSON body
`noc-agent-mail-health` used stock `check_http` (HTTP code only). Mirrored the model-health fix: a custom `check_noc_agent_mail_health.sh` that extracts `status`/`mailbox`/`message_count`/`error` from `/health/mail` (contract: `app/main.py:797-807` + `app/mail.py:240-264`) into the plugin output. New CheckCommand + host_vars switch + re-rendered `generated/noc/icinga_host.conf`. **Closes #67**

## #92 — github-runner crash-loop detection
The runner check only alerted on `node_systemd_unit_state{state="active"} < 1`; during the orphan crash-loop the unit flapped back through active=1 between 2m samples and stayed invisible. Enabled `--collector.systemd.enable-restarts-metrics` (Linux, fleet-wide — the blind spot isn't runner-specific) and added a `github-runner-restart-loop` Service on `increase(node_systemd_service_restart_total[10m]) > {3 warn, 5 crit}`. **Closes #92**

## Verification
- `check_noc_agent_mail_health.sh`: `sh -n` clean; jq parsing verified against both `status:ok` and `status:degraded` payloads (degraded yields `err=IMAP login failed: …`).
- `generated/noc/icinga_host.conf` re-rendered via `ansible-playbook playbooks/monitoring.yml --tags validate --connection=local --limit noc` — diff is exactly the check_command/vars swap.
- `check_prom_query -o gt` semantics confirmed against the crash-loop thresholds.

Note: depends on the render-check fix in #121 for CI's `render` job to actually exercise these renders.

## Summary by Sourcery

Update monitoring to correctly handle FreeBSD by_ssh checks, surface noc mail health details in alerts, and detect GitHub runner crash loops via systemd restart metrics.

New Features:
- Expose noc-agent mail health details via a dedicated Icinga2 CheckCommand and helper script that parse the /health/mail JSON response.
- Add a GitHub runner restart-loop Icinga2 service using Prometheus systemd restart metrics to detect crash loops missed by active-state checks.

Bug Fixes:
- Set the FreeBSD monitoring by_ssh user shell to a real shell so remote checks can execute successfully.
- Replace the generic HTTP-based noc mail health check so alerts now include the underlying IMAP/TLS error context instead of only HTTP status codes.

Enhancements:
- Enable node_exporter systemd restart metrics fleet-wide on Linux to support restart-based alerting beyond the GitHub runner use case.