### PR TITLE
deploy reliability: hyrule_cloud restart-on-apply + hyrule_web SSH path (#96 #85)

### DIFF
--- a/ansible/roles/hyrule_cloud/tasks/checkout.yml
+++ b/ansible/roles/hyrule_cloud/tasks/checkout.yml
@@ -13,4 +13,6 @@
     accept_hostkey: false
   become: true
   become_user: "{{ hyrule_cloud_app_user }}"
-  notify: restart hyrule-cloud
+  # No `notify: restart` here. A retry where the SHA is already checked out
+  # reports `ok` and would notify nothing, leaving the OLD process running
+  # (#96). The restart is now unconditional in health.yml on every apply.

--- a/ansible/roles/hyrule_cloud/tasks/health.yml
+++ b/ansible/roles/hyrule_cloud/tasks/health.yml
@@ -1,10 +1,20 @@
 ---
-# Flush handlers so the systemd-active assert and the HTTP probe see the
-# *post-restart* state, not the pre-restart state. Without flush_handlers,
-# Ansible runs handlers at end-of-play and these checks would race the restart.
+# Flush handlers first so any `reload systemd` (changed unit file) runs before
+# we restart. Then restart UNCONDITIONALLY: the deploy must guarantee the
+# running process is on the requested ref, but a retry where the checkout SHA
+# was already current, or a deps-only change, notifies no restart handler and
+# leaves the OLD process running (#96). This runs after vault.yml so the
+# restarted process sees the freshly-rendered env, and before the asserts so
+# they observe post-restart state.
 
-- name: Flush handlers before health check
+- name: Flush handlers (reload systemd if the unit changed) before restart
   ansible.builtin.meta: flush_handlers
+
+- name: Restart hyrule-cloud (deterministic on every apply)
+  ansible.builtin.systemd:
+    name: "{{ hyrule_cloud_service_name }}"
+    state: restarted
+    enabled: true
 
 - name: Check hyrule-cloud systemd state
   ansible.builtin.systemd:

--- a/ansible/roles/hyrule_cloud/tasks/runtime.yml
+++ b/ansible/roles/hyrule_cloud/tasks/runtime.yml
@@ -17,7 +17,9 @@
   become_user: "{{ hyrule_cloud_app_user }}"
   changed_when: false
   when: hyrule_cloud_pyproject.stat.exists
-  notify: restart hyrule-cloud
+  # No `notify: restart` — `changed_when: false` means this task never reports
+  # changed, so the handler would never fire anyway (dead notify, #96). The
+  # restart is unconditional in health.yml on every apply.
 
 - name: Install Vault render hook for hyrule-cloud environment file
   ansible.builtin.template:
@@ -34,6 +36,8 @@
     owner: root
     group: root
     mode: "0644"
+  # reload systemd if the unit file changed; the restart itself is
+  # unconditional in health.yml (after vault.yml renders the env), so it is
+  # deliberately not notified here (#96).
   notify:
     - reload systemd
-    - restart hyrule-cloud

--- a/ansible/roles/hyrule_web/defaults/main.yml
+++ b/ansible/roles/hyrule_web/defaults/main.yml
@@ -28,7 +28,13 @@ hyrule_web_repo: git@github-hyrule-web:AS215932/hyrule-web.git
 # the same flag with an older SHA.
 hyrule_web_version: main
 
-hyrule_web_deploy_key_path: "{{ hyrule_web_state_dir }}/.ssh/id_hyrule_web"
+# SSH state lives in the app user's actual $HOME/.ssh, because the git
+# checkout runs as `become_user: hyrule` and ssh reads ~/.ssh/config from there
+# — a config/key under hyrule_web_state_dir (/var/lib/hyrule-web/.ssh) is inert
+# (#85). Key name keeps the existing live hyphen (`id_hyrule-web`) so the role
+# adopts the already-registered deploy key instead of minting a duplicate.
+hyrule_web_ssh_dir: "/home/{{ hyrule_web_app_user }}/.ssh"
+hyrule_web_deploy_key_path: "{{ hyrule_web_ssh_dir }}/id_hyrule-web"
 
 hyrule_web_service_name: hyrule-web
 hyrule_web_listen_url: http://127.0.0.1:8080/

--- a/ansible/roles/hyrule_web/tasks/apply.yml
+++ b/ansible/roles/hyrule_web/tasks/apply.yml
@@ -25,8 +25,8 @@
 # Don't pass `home:` — on first install we accept the user module's default
 # (/home/<user>); on hosts where the user already exists, changing home
 # would force a usermod that fails while the service is running. The deploy
-# key + SSH config live under hyrule_web_state_dir regardless of the user's
-# home, owned by hyrule_web_app_user.
+# key + SSH config live under the user's $HOME/.ssh (hyrule_web_ssh_dir) so
+# the become_user: hyrule git checkout actually reads them (#85).
 - name: Ensure hyrule user exists
   ansible.builtin.user:
     name: "{{ hyrule_web_app_user }}"
@@ -45,7 +45,7 @@
     - { path: "{{ hyrule_web_install_dir }}", mode: "0755" }
     - { path: "{{ hyrule_web_etc_dir }}", owner: root, mode: "0750" }
     - { path: "{{ hyrule_web_state_dir }}", mode: "0750" }
-    - { path: "{{ hyrule_web_state_dir }}/.ssh", mode: "0700" }
+    - { path: "{{ hyrule_web_ssh_dir }}", mode: "0700" }
 
 - name: Bootstrap per-app deploy key and SSH config
   ansible.builtin.import_tasks: bootstrap_key.yml

--- a/ansible/roles/hyrule_web/tasks/bootstrap_key.yml
+++ b/ansible/roles/hyrule_web/tasks/bootstrap_key.yml
@@ -37,12 +37,12 @@
   ansible.builtin.known_hosts:
     name: github.com
     key: "{{ lookup('pipe', 'ssh-keyscan -t ed25519 github.com 2>/dev/null') }}"
-    path: "{{ hyrule_web_state_dir }}/.ssh/known_hosts"
+    path: "{{ hyrule_web_ssh_dir }}/known_hosts"
     state: present
 
 - name: Ensure known_hosts ownership
   ansible.builtin.file:
-    path: "{{ hyrule_web_state_dir }}/.ssh/known_hosts"
+    path: "{{ hyrule_web_ssh_dir }}/known_hosts"
     owner: "{{ hyrule_web_app_user }}"
     group: "{{ hyrule_web_app_group }}"
     mode: "0644"
@@ -50,7 +50,7 @@
 - name: Render SSH config for the github-hyrule-web alias
   ansible.builtin.template:
     src: ssh_config.j2
-    dest: "{{ hyrule_web_state_dir }}/.ssh/config"
+    dest: "{{ hyrule_web_ssh_dir }}/config"
     owner: "{{ hyrule_web_app_user }}"
     group: "{{ hyrule_web_app_group }}"
     mode: "0600"

--- a/ansible/roles/hyrule_web/templates/ssh_config.j2
+++ b/ansible/roles/hyrule_web/templates/ssh_config.j2
@@ -7,4 +7,4 @@ Host github-hyrule-web
     IdentityFile {{ hyrule_web_deploy_key_path }}
     IdentitiesOnly yes
     StrictHostKeyChecking yes
-    UserKnownHostsFile {{ hyrule_web_state_dir }}/.ssh/known_hosts
+    UserKnownHostsFile {{ hyrule_web_ssh_dir }}/known_hosts


### PR DESCRIPTION
Two independent deploy-reliability bugs in app-deploy roles.

## #96 — hyrule_cloud kept running old code after a retry
The restart was handler-driven (notified by checkout-SHA-change + unit-file copy). On a re-run where the SHA was already checked out, the checkout reports `ok` → notifies nothing → service keeps running OLD code; the `uv sync` notify was dead anyway (`changed_when: false` never reports changed).

**Fix:** one unconditional restart in `health.yml`, after `flush_handlers` (daemon-reload a changed unit first) and after `vault.yml` (so the restart picks up the freshly-rendered env), before the active/HTTP asserts. Removed the now-redundant restart notifies (kept `reload systemd`). Restart is cheap + idempotent (ExecStartPre runs `alembic upgrade head`). **Closes #96**

## #85 — hyrule_web deploy key was inert
The checkout runs as `become_user: hyrule`; ssh reads `/home/hyrule/.ssh/config`, but the role wrote its key+config under `/var/lib/hyrule-web/.ssh`, which that user never reads. The live host quietly used a separately-bootstrapped key.

**Fix (option a):** new `hyrule_web_ssh_dir = /home/{{ app_user }}/.ssh`; key/config/known_hosts all move there, keeping the live hyphenated name `id_hyrule-web` so the role **adopts** the existing registered deploy key rather than minting a duplicate. **Closes #85**

### Operator follow-ups for #85 (can't be done/verified from this pass)
- Before applying: confirm the live `/home/hyrule/.ssh/config` + git remote use the `github-hyrule-web` alias (the role normalizes the remote to it on checkout). The template overwrites `~/.ssh/config` — fine for a dedicated service user.
- Remove the now-redundant `/var/lib/hyrule-web/.ssh` deploy key from https://github.com/AS215932/hyrule-web/settings/keys.
- Add a greenfield-VM test (role has only run against the pre-existing web VM).

### Verification
YAML lint clean for both roles; restart ordering reasoned against the apply.yml import order (bootstrap → checkout → runtime → vault → health). These are apply-time host changes (not rendered artifacts), so not exercised by render-check; the design is verified by reading, full validation needs a live apply.

## Summary by Sourcery

Ensure hyrule_cloud deployments always restart the service on apply and fix hyrule_web deploy SSH configuration so the app user actually uses the intended deploy key.

Bug Fixes:
- Force a deterministic hyrule_cloud service restart during health checks so retries and dependency-only changes do not leave the old process running.
- Move hyrule_web SSH key, config, and known_hosts into the app user's home directory so git checkouts use the correct deploy key and GitHub host configuration.

Enhancements:
- Tighten hyrule_cloud handler usage by delegating systemd reloads to handlers while performing the service restart directly in the health check flow.
- Standardize hyrule_web SSH path configuration via a dedicated variable to better align with the app user's home directory layout.