### PR TITLE
noc_mcp_key: let the diagnostic MCP read root-owned configs via reader groups (#49)

### DIFF
--- a/ansible/inventory/host_vars/mon.yml
+++ b/ansible/inventory/host_vars/mon.yml
@@ -19,6 +19,13 @@ firewall_extra_rules:
   # Blackbox is localhost-only (Prometheus runs on the same box). Loopback is
   # already accepted by the base firewall rules.
 
+# Let the read-only diagnostic MCP (SSHes in as svag) traverse/read
+# /etc/icinga2/conf.d (0750 root:nagios) to correlate alerts with check
+# definitions. View-only group membership; the config structure isn't secret.
+# See issue #49 + roles/noc_mcp_key.
+noc_mcp_reader_groups:
+  - nagios
+
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true
 logs_role: mon

--- a/ansible/roles/noc_mcp_key/defaults/main.yml
+++ b/ansible/roles/noc_mcp_key/defaults/main.yml
@@ -4,3 +4,12 @@ noc_mcp_key_pub_path: "{{ noc_mcp_key_path }}.pub"
 
 # Restricts the key so it only works when the connection comes from noc's overlay address.
 noc_mcp_key_from_address: "{{ peers.noc.ipv6 }}"
+
+# Extra reader groups to add the MCP SSH user to, per host, so the read-only
+# diagnostic MCP can introspect sensitive-but-not-secret root-owned config dirs
+# (e.g. /etc/icinga2/conf.d is 0750 root:nagios — the *structure* isn't a
+# secret, only specific password values are). Set in host_vars/<host>.yml.
+# Only applied for non-root MCP users (root needs nothing). Groups must already
+# exist on the host. Keep this view-only — do NOT add groups that confer write
+# or secret access. See issue #49.
+noc_mcp_reader_groups: []

--- a/ansible/roles/noc_mcp_key/tasks/main.yml
+++ b/ansible/roles/noc_mcp_key/tasks/main.yml
@@ -35,6 +35,19 @@
     - noc_mcp_target_user != "root"
   tags: [apply]
 
+# Per-host reader groups (e.g. nagios on mon for /etc/icinga2/conf.d) so the
+# read-only diagnostic MCP can introspect root-owned config dirs without a
+# blanket loosen. View-only; see issue #49 and noc_mcp_reader_groups in defaults.
+- name: Grant MCP SSH user membership in per-host config reader groups
+  user:
+    name: "{{ noc_mcp_target_user }}"
+    groups: "{{ noc_mcp_reader_groups }}"
+    append: true
+  when:
+    - noc_mcp_target_user != "root"
+    - noc_mcp_reader_groups | length > 0
+  tags: [apply]
+
 - name: Authorize id_noc_mcp for {{ noc_mcp_target_user }} (restricted to noc's address)
   authorized_key:
     user: "{{ noc_mcp_target_user }}"


### PR DESCRIPTION
## Audit (live, read-only via MCP)
The MCP SSHes in as `ssh_users[host]` — `root` on rtr/xoa, `svag` elsewhere. On `mon` the MCP user is `svag` (`groups=svag,sudo`), and `/etc/icinga2/conf.d` is `0750 root:nagios`, so `svag` can't even traverse it:
```
$ ssh_run_command host=mon 'ls -ld /etc/icinga2/conf.d'
ls: cannot access '/etc/icinga2/conf.d': Permission denied
```
(On rtr the MCP user is root → already reads everything; the gap is the non-root `svag` hosts.)

## Fix
`noc_mcp_key` already adds the non-root MCP user to `systemd-journal`. Generalize that: a per-host `noc_mcp_reader_groups` (default `[]`) appended to the MCP user's groups (view-only, non-root-only, groups must pre-exist). Set `[nagios]` on `mon` so the read-only diagnostic MCP can introspect Icinga check/host definitions. The config *structure* isn't secret — password values live in separately-restricted files.

## Remaining (per-host decisions, left as action points on the issue)
- **noc `/etc/vault-agent.d`** (`0750 root:root`): no shared group → don't add svag to `root`. Either loosen the `.hcl` to `0644` (the agent template structure isn't secret; rendered secrets are separate `0600` files) or a scoped `sudo` read. Needs a call on whether the `.hcl` is considered sensitive.
- **cr1.* `/etc/frr`**: frr.conf carries BGP community strings — keep restricted; if MCP needs it, a scoped `sudo cat` rule rather than group read.

## Verification
Confirmed the denial live (above). The fix is apply-time group membership (mirrors the proven systemd-journal grant), so not exercised by render-check; full validation is `apply noc_mcp_key --limit mon` then re-run the `ls` via MCP (should succeed once svag is in nagios).

Refs #49

## Summary by Sourcery

Allow the diagnostic MCP SSH user to be added to per-host reader groups so it can read specified root-owned configuration directories without relaxing their permissions.

Enhancements:
- Introduce configurable noc_mcp_reader_groups to extend the MCP SSH user’s supplemental groups on non-root hosts for view-only access to selected configs.

Chores:
- Configure the mon host to add the MCP SSH user to the nagios group for read-only access to Icinga configuration.