### PR TITLE
rtr: don't masquerade rtr's own outbound v4 — fixes SYN_RECV hang (#23)

### DIFF
--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -36,9 +36,15 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
-        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
-        oifname $WAN_IF masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
+        # packets already sourced from $WAN_IP: that covers rtr's own outbound
+        # v4 (whose source the kernel selects as $WAN_IP) and Jool's NAT64
+        # output (pool4 self-SNATs to $WAN_IP). Masquerading rtr's own
+        # locally-originated TCP left the conntrack entry stuck in SYN_RECV so
+        # the local socket never saw the SYN-ACK — rtr's own `curl -4` timed
+        # out despite working NAT64 (#23). NAT64 needs no masq here (Jool
+        # already set the public source); infra/customer ranges are v6-only.
+        oifname $WAN_IF ip saddr != $WAN_IP masquerade
     }
 }
 

--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -36,15 +36,17 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
-        # packets already sourced from $WAN_IP: that covers rtr's own outbound
-        # v4 (whose source the kernel selects as $WAN_IP) and Jool's NAT64
-        # output (pool4 self-SNATs to $WAN_IP). Masquerading rtr's own
-        # locally-originated TCP left the conntrack entry stuck in SYN_RECV so
-        # the local socket never saw the SYN-ACK — rtr's own `curl -4` timed
-        # out despite working NAT64 (#23). NAT64 needs no masq here (Jool
-        # already set the public source); infra/customer ranges are v6-only.
-        oifname $WAN_IF ip saddr != $WAN_IP masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
+        # type != local` excludes any packet whose source is a router-local
+        # address — that covers rtr's own outbound v4 AND Jool's NAT64 output
+        # (pool4 self-SNATs to the local $WAN_IP), and stays correct if a
+        # secondary WAN IP / per-service /32 is ever added (unlike a single
+        # `ip saddr != $WAN_IP` test). Masquerading rtr's own locally-
+        # originated TCP left conntrack stuck in SYN_RECV so the local socket
+        # never saw the SYN-ACK — rtr's `curl -4` timed out despite working
+        # NAT64 (#23). NAT64 needs no masq here (Jool already set the public
+        # source); infra/customer ranges are v6-only.
+        oifname $WAN_IF fib saddr type != local masquerade
     }
 }
 

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -36,9 +36,15 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
-        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
-        oifname $WAN_IF masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
+        # packets already sourced from $WAN_IP: that covers rtr's own outbound
+        # v4 (whose source the kernel selects as $WAN_IP) and Jool's NAT64
+        # output (pool4 self-SNATs to $WAN_IP). Masquerading rtr's own
+        # locally-originated TCP left the conntrack entry stuck in SYN_RECV so
+        # the local socket never saw the SYN-ACK — rtr's own `curl -4` timed
+        # out despite working NAT64 (#23). NAT64 needs no masq here (Jool
+        # already set the public source); infra/customer ranges are v6-only.
+        oifname $WAN_IF ip saddr != $WAN_IP masquerade
     }
 }
 

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -36,15 +36,17 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
-        # packets already sourced from $WAN_IP: that covers rtr's own outbound
-        # v4 (whose source the kernel selects as $WAN_IP) and Jool's NAT64
-        # output (pool4 self-SNATs to $WAN_IP). Masquerading rtr's own
-        # locally-originated TCP left the conntrack entry stuck in SYN_RECV so
-        # the local socket never saw the SYN-ACK — rtr's own `curl -4` timed
-        # out despite working NAT64 (#23). NAT64 needs no masq here (Jool
-        # already set the public source); infra/customer ranges are v6-only.
-        oifname $WAN_IF ip saddr != $WAN_IP masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
+        # type != local` excludes any packet whose source is a router-local
+        # address — that covers rtr's own outbound v4 AND Jool's NAT64 output
+        # (pool4 self-SNATs to the local $WAN_IP), and stays correct if a
+        # secondary WAN IP / per-service /32 is ever added (unlike a single
+        # `ip saddr != $WAN_IP` test). Masquerading rtr's own locally-
+        # originated TCP left conntrack stuck in SYN_RECV so the local socket
+        # never saw the SYN-ACK — rtr's `curl -4` timed out despite working
+        # NAT64 (#23). NAT64 needs no masq here (Jool already set the public
+        # source); infra/customer ranges are v6-only.
+        oifname $WAN_IF fib saddr type != local masquerade
     }
 }
 

--- a/configs/rtr/nftables.conf
+++ b/configs/rtr/nftables.conf
@@ -32,9 +32,14 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
-        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
-        oifname $WAN_IF masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
+        # packets already sourced from $WAN_IP (rtr's own outbound v4, and
+        # Jool NAT64 output which self-SNATs to $WAN_IP). Masquerading rtr's
+        # own locally-originated TCP stuck conntrack in SYN_RECV so the local
+        # socket never saw the SYN-ACK (#23). NOTE: this legacy static file is
+        # superseded by ansible/roles/firewall (nftables-rtr.conf.j2); kept in
+        # sync for reference.
+        oifname $WAN_IF ip saddr != $WAN_IP masquerade
     }
 }
 

--- a/configs/rtr/nftables.conf
+++ b/configs/rtr/nftables.conf
@@ -32,14 +32,14 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. Exclude
-        # packets already sourced from $WAN_IP (rtr's own outbound v4, and
-        # Jool NAT64 output which self-SNATs to $WAN_IP). Masquerading rtr's
-        # own locally-originated TCP stuck conntrack in SYN_RECV so the local
-        # socket never saw the SYN-ACK (#23). NOTE: this legacy static file is
-        # superseded by ansible/roles/firewall (nftables-rtr.conf.j2); kept in
-        # sync for reference.
-        oifname $WAN_IF ip saddr != $WAN_IP masquerade
+        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
+        # type != local` excludes any router-local source (rtr's own outbound
+        # v4 + Jool NAT64 output which self-SNATs to the local $WAN_IP), and
+        # stays correct if a secondary WAN IP is ever added. Masquerading rtr's
+        # own locally-originated TCP stuck conntrack in SYN_RECV (#23). NOTE:
+        # this legacy static file is superseded by ansible/roles/firewall
+        # (nftables-rtr.conf.j2); kept in sync for reference.
+        oifname $WAN_IF fib saddr type != local masquerade
     }
 }
 


### PR DESCRIPTION
## Confirmed live
`nft list table ip nat` on rtr shows the rule the triage suspected:
```
chain postrouting { type nat hook postrouting priority srcnat; policy accept;
    oifname "enX4" masquerade }
```
It masquerades **all** WAN-egress v4, including rtr's own locally-originated traffic (the kernel selects `$WAN_IP` = 46.105.40.223 as the source). That's what stuck conntrack in `SYN_RECV` — the SYN-ACK was on the wire but the local socket never advanced — so `curl -4` from rtr timed out despite working NAT64.

## Fix (surgical, not removal)
`oifname $WAN_IF ip saddr != $WAN_IP masquerade` — masquerade forwarded v4 only, exclude anything already sourced from `$WAN_IP`. That excludes:
- rtr's own egress (fixes #23), and
- Jool's NAT64 output — `configs/rtr/jool/jool.conf` pool4 self-SNATs to `46.105.40.223/32`, so NAT64 packets are already correctly sourced and never needed masquerading.

Infra + customer ranges are v6-only, so no legitimate forwarded v4 loses NAT. Chose narrowing over full removal so any future forwarded-v4 source still works.

Updated the template (`nftables-rtr.conf.j2`, the live source), the legacy `configs/rtr/nftables.conf`, and re-rendered `generated/rtr/nftables.conf`.

## ⚠️ Operator apply + verification (read-only pass did not mutate live)
Apply via the firewall role's `serial:1` + `at(1)` watchdog runbook, then verify:
1. `ssh root@rtr 'curl -m5 -4 https://api.github.com/zen'` → succeeds (was timing out).
2. `nat64-ipv4-reachability` Icinga check stays green; a NAT64 transfer from an overlay VM still works.
3. Likely also unblocks **#74** (rtr apt over the v4 path).

Closes #23

## Summary by Sourcery

Adjust router NAT configuration to stop masquerading its own IPv4 egress while preserving NAT for forwarded traffic.

Bug Fixes:
- Prevent locally-originated IPv4 connections from the router from hanging in SYN_RECV due to unnecessary masquerading.

Enhancements:
- Scope WAN postrouting masquerade rules to forwarded IPv4 traffic only, excluding packets already sourced from the WAN IP.
- Keep legacy and generated nftables router configs in sync with the updated NAT behavior.