### PR TITLE
firewall: make Cancel-watchdog conditional boolean (ansible-core 2.21)

### DIFF
--- a/ansible/roles/firewall/tasks/nftables.yml
+++ b/ansible/roles/firewall/tasks/nftables.yml
@@ -60,6 +60,6 @@
   command: "atrm {{ _firewall_at_job.stdout }}"
   changed_when: false
   when:
-    - firewall_apply
+    - firewall_apply | default(false) | bool
     - _firewall_at_job.stdout | default('') | length > 0
   tags: [apply]

--- a/ansible/roles/firewall/tasks/pf.yml
+++ b/ansible/roles/firewall/tasks/pf.yml
@@ -95,6 +95,6 @@
   command: "atrm {{ _firewall_at_job.stdout }}"
   changed_when: false
   when:
-    - firewall_apply
+    - firewall_apply | default(false) | bool
     - _firewall_at_job.stdout | default('') | length > 0
   tags: [apply]


### PR DESCRIPTION
The `Cancel rollback watchdog` task used a bare `when: firewall_apply`. ansible-core 2.21 rejects it (`-e firewall_apply=true` is a string → 'Conditionals must have a boolean result'). Effect: every firewall apply swapped the ruleset + scheduled the watchdog, failed at Cancel, and got rolled back 3 min later — the role was un-appliable via CI (surfaced deploying #126/#23 to rtr; rtr was cleanly rolled back each time, NAT64 verified healthy). Wrap both nftables.yml + pf.yml in `| default(false) | bool` like every other apply task.

## Summary by Sourcery

Bug Fixes:
- Ensure nftables and pf firewall watchdog cancellation tasks treat firewall_apply as a boolean with a safe default to avoid ansible-core 2.21 conditional evaluation errors and unintended rule rollbacks.