### PR TITLE
unbound(rtr): force Docker CloudFront CDN over NAT64 (dns64-ignore-aaaa) — CI unblock #119

### DIFF
--- a/configs/rtr/unbound/as215932.conf
+++ b/configs/rtr/unbound/as215932.conf
@@ -19,6 +19,14 @@ server:
 
     dns64-prefix: 64:ff9b::/96
 
+    # Force Docker Hub's CloudFront blob CDN over NAT64/IPv4. Native CloudFront
+    # IPv6 is degraded via the DE transit path (issue #119: loss/reordering);
+    # CloudFront-IPv4-through-NAT64 is fast. Ignoring AAAA for this name makes
+    # DNS64 synthesize 64:ff9b:: from its A records (the fast path). Only the CI
+    # runners (ci, ci-pr) ever resolve this Docker-CDN hostname — infra apps are
+    # bare-metal/no-Docker — so the blast radius is effectively CI.
+    dns64-ignore-aaaa: production.cloudfront.docker.com
+
 forward-zone:
     name: "."
     forward-addr: 2606:4700:4700::1111


### PR DESCRIPTION
## Context
Docker image pulls on the customer segment (ci-pr) crawled at ~75 KB/s, blocking the CI pilot. Root cause (#119): native CloudFront IPv6 is degraded via the **DE transit path**; CloudFront-IPv4-through-NAT64 is fast. Track 1 CI bypass — steer the Docker blob CDN onto NAT64 at the resolver.

## Change
`dns64-ignore-aaaa: production.cloudfront.docker.com` on rtr's Unbound → DNS64 synthesizes `64:ff9b::` from the CDN's A records instead of the degraded native AAAA. Hostname-scoped on the shared resolver (only the CI runners ever resolve this Docker-CDN name; infra apps are bare-metal/no-Docker). Dynamic (IPs rotate); no global IPv6 disable, no Docker-daemon change, no hardcoded IPs.

## Verified live (ci-pr)
- `getent ahostsv6 production.cloudfront.docker.com` → `64:ff9b::12ef:12xx` (synthesized); other domains unaffected.
- `docker pull semgrep/semgrep@sha256:bc8b15e2…`: **16 s** (was glacial 19+ min).

## ⚠️ Incident #130 (live divergence, separate)
Applying this surfaced a **pre-existing** 0-byte `/var/lib/unbound/root.key` → unbound failed to init the validator on reload → brief overlay DNS outage, **mitigated** by temporarily dropping the validator (DNSSEC OFF on live rtr; `unbound-anchor` not installed). This file keeps the validator (desired state); live re-converges once #130 restores the anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Configure Unbound to ignore AAAA records for production.cloudfront.docker.com so DNS64 synthesizes NAT64 IPv6 from IPv4 A records for CI Docker pulls.