### PR TITLE
Revert #126 (masquerade) — wrong diagnosis; real #23 cause is Jool pool4 / port collision

### DIFF
--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -36,17 +36,9 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
-        # type != local` excludes any packet whose source is a router-local
-        # address — that covers rtr's own outbound v4 AND Jool's NAT64 output
-        # (pool4 self-SNATs to the local $WAN_IP), and stays correct if a
-        # secondary WAN IP / per-service /32 is ever added (unlike a single
-        # `ip saddr != $WAN_IP` test). Masquerading rtr's own locally-
-        # originated TCP left conntrack stuck in SYN_RECV so the local socket
-        # never saw the SYN-ACK — rtr's `curl -4` timed out despite working
-        # NAT64 (#23). NAT64 needs no masq here (Jool already set the public
-        # source); infra/customer ranges are v6-only.
-        oifname $WAN_IF fib saddr type != local masquerade
+        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
+        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
+        oifname $WAN_IF masquerade
     }
 }
 

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -36,17 +36,9 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
-        # type != local` excludes any packet whose source is a router-local
-        # address — that covers rtr's own outbound v4 AND Jool's NAT64 output
-        # (pool4 self-SNATs to the local $WAN_IP), and stays correct if a
-        # secondary WAN IP / per-service /32 is ever added (unlike a single
-        # `ip saddr != $WAN_IP` test). Masquerading rtr's own locally-
-        # originated TCP left conntrack stuck in SYN_RECV so the local socket
-        # never saw the SYN-ACK — rtr's `curl -4` timed out despite working
-        # NAT64 (#23). NAT64 needs no masq here (Jool already set the public
-        # source); infra/customer ranges are v6-only.
-        oifname $WAN_IF fib saddr type != local masquerade
+        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
+        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
+        oifname $WAN_IF masquerade
     }
 }
 

--- a/configs/rtr/nftables.conf
+++ b/configs/rtr/nftables.conf
@@ -32,14 +32,9 @@ table ip nat {
     chain postrouting {
         type nat hook postrouting priority srcnat; policy accept;
 
-        # Masquerade WAN-egress v4 for *forwarded* traffic only. `fib saddr
-        # type != local` excludes any router-local source (rtr's own outbound
-        # v4 + Jool NAT64 output which self-SNATs to the local $WAN_IP), and
-        # stays correct if a secondary WAN IP is ever added. Masquerading rtr's
-        # own locally-originated TCP stuck conntrack in SYN_RECV (#23). NOTE:
-        # this legacy static file is superseded by ansible/roles/firewall
-        # (nftables-rtr.conf.j2); kept in sync for reference.
-        oifname $WAN_IF fib saddr type != local masquerade
+        # Masquerade on WAN — preserves source IPs through DNAT (no masq on enX2),
+        # and allows infra VMs to reach IPv4 internet (outgoing NAT).
+        oifname $WAN_IF masquerade
     }
 }
 


### PR DESCRIPTION
#126 narrowed rtr's WAN masquerade to fix the #23 SYN_RECV hang. Live debugging (full SSH access) proved the masquerade was **never** the cause — flushing it entirely changed nothing. The real root cause: **Jool pool4 (`46.105.40.223` ports 1024-65535) overlaps rtr's `ip_local_port_range` (32768-60999)**, so rtr's own outbound TCP replies get intercepted by Jool's PREROUTING hook (no BIB match → dropped). Reverting to the original unconditional masquerade; the real fix (carve host ephemeral ports out of pool4) is captured in reopened #23. The masquerade is itself vestigial and will go in the #14 OpenBSD/pf migration.