### PR TITLE
rtr: reserve host ephemeral ports out of Jool pool4 — real #23 fix

### DIFF
--- a/configs/rtr/jool/jool.conf
+++ b/configs/rtr/jool/jool.conf
@@ -5,8 +5,8 @@
         "pool6": "64:ff9b::/96"
     },
     "pool4": [
-        { "protocol": "TCP",  "prefix": "46.105.40.223/32", "port range": "1024-65535" },
-        { "protocol": "UDP",  "prefix": "46.105.40.223/32", "port range": "1024-65535" },
+        { "protocol": "TCP",  "prefix": "46.105.40.223/32", "port range": "1024-60999" },
+        { "protocol": "UDP",  "prefix": "46.105.40.223/32", "port range": "1024-60999" },
         { "protocol": "ICMP", "prefix": "46.105.40.223/32", "port range": "0-65535" }
     ]
 }

--- a/configs/rtr/sysctl.conf
+++ b/configs/rtr/sysctl.conf
@@ -14,3 +14,10 @@ net.core.wmem_max=8388608
 # in the default VRF but are scraped from mon VM in the overlay VRF.
 net.ipv4.tcp_l3mdev_accept=1
 net.ipv4.udp_l3mdev_accept=1
+# Reserve the host's ephemeral source ports ABOVE Jool's NAT64 pool4
+# (46.105.40.223:1024-60999). Without this, rtr's own outbound v4 picks an
+# ephemeral port inside pool4, so its reply lands on a pool4 address+port and
+# Jool's PREROUTING hook grabs it as NAT64 return traffic (no BIB match) and
+# drops it — rtr's own curl/apt over v4 hang in SYN_RECV. See issue #23.
+# Must stay in lock-step with configs/rtr/jool/jool.conf pool4 ranges.
+net.ipv4.ip_local_port_range=61000 65535


### PR DESCRIPTION
The actual fix for #23 (the reverted #126 was a wrong diagnosis). Jool pool4 (`46.105.40.223:1024-65535`) overlapped rtr's `ip_local_port_range` (32768-60999), so rtr's own v4 replies got grabbed by Jool's PREROUTING hook and dropped. Narrow pool4 to `1024-60999` and reserve host ephemeral ports to `61000-65535`. Applied + verified live (`curl -4` by IP → 0; NAT64 unaffected). Persisted on rtr in `/etc/jool/jool.conf` + `/etc/sysctl.d/`. Refs #23 #74; dedicated pool4 IP is the long-term fix (#14).