### PR TITLE
rtr firewall: allow rtr's own DNS to its Unbound (#135)

### DIFF
--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -95,8 +95,8 @@ table inet filter {
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
-        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64 } tcp dport 53 counter accept comment "DNS recursion from overlay"
-        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64 } udp dport 53 counter accept comment "DNS recursion from overlay"
+        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2001:41d0:303:48a::2 } tcp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
+        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2001:41d0:303:48a::2 } udp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9342 counter accept comment "frr_exporter scrape"
         ip6 saddr { 2a0c:b641:b50::a, 2a0c:b641:b50::b } tcp dport 179 counter accept comment "iBGP from cr1-* loopbacks"

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -22,7 +22,13 @@ firewall_log_only: false
 
 firewall_extra_rules:
   # DNS recursion — overlay VMs and customer VMs use rtr's Unbound resolver.
-  - { proto: tcp+udp, dport: 53, src: ["{{ infra_subnet }}", "{{ customer_subnet }}", "{{ vpn_clients_subnet }}"], comment: "DNS recursion from overlay" }
+  # peers.rtr.underlay is rtr's OWN queries: Unbound is `ip vrf exec overlay`-
+  # confined (it must, to bind the overlay client addr + forward over the
+  # overlay transit), so it can't bind a default-VRF loopback. rtr's own
+  # default-VRF processes (apt, curl, unbound-anchor) therefore query the
+  # overlay Unbound with rtr's underlay source — allow it so rtr can resolve.
+  # See issue #135. (Goes away with the OpenBSD/rdomain migration, #14.)
+  - { proto: tcp+udp, dport: 53, src: ["{{ infra_subnet }}", "{{ customer_subnet }}", "{{ vpn_clients_subnet }}", "{{ peers.rtr.underlay }}"], comment: "DNS recursion from overlay + rtr's own (underlay src, VRF)" }
 
   # Monitoring scrapes from mon.
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -61,6 +61,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
 | infra subnet, customer subnet, vpn-clients | TCP/UDP | 53 | DNS recursion (Unbound + DNS64) |
+| rtr underlay (`2001:41d0:303:48a::2`) | TCP/UDP | 53 | rtr's **own** DNS queries to its Unbound — Unbound is overlay-VRF-confined so rtr's default-VRF processes query it with the underlay source (#135) |
 | mon | TCP | 9100 | node_exporter scrape |
 | mon | TCP | 9342 | frr_exporter scrape |
 | cr1-nl1, cr1-de1 loopbacks | TCP | 179 | iBGP |


### PR DESCRIPTION
rtr's Unbound is `ip vrf exec overlay`-confined, so it can't bind a default-VRF loopback; rtr's own processes query it with the underlay source, which the overlay DNS allow-list dropped → rtr resolved nothing (apt/curl by name failed) while overlay clients were fine. Add `peers.rtr.underlay` to the DNS allow-list. Applied + verified live (resolution + `apt-get update` succeed). Goes away with the OpenBSD/rdomain migration (#14). Closes #135, refs #74.