### PR TITLE
[codex] Fix rtr ci-pr monitoring path

### DIFF
--- a/ansible/generated/ci-pr/nftables.conf
+++ b/ansible/generated/ci-pr/nftables.conf
@@ -47,6 +47,10 @@ table inet filter {
         type filter hook forward priority filter; policy drop;
         ct state established,related accept
         ct state invalid drop
+
+        # --- raw forward escape hatch ---
+        iifname docker0 ip6 saddr 2a0c:b641:b51:c1::/64 counter accept comment "ci-pr Docker IPv6 egress"
+
     }
 
     chain output {

--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -46,14 +46,15 @@ table ip filter {
     chain forward {
         type filter hook forward priority filter; policy accept;
 
+        # Allow return traffic before customer isolation drops.
+        ct state established,related accept
+        ct state invalid drop
+
         # Customer VM isolation: packets from the customer bridge must not
         # reach infrastructure/mgmt ranges.  Match destination prefixes first
         # so enforcement does not depend solely on VRF slave oifname exposure.
         iifname enX3 ip daddr { 10.0.0.0/24, 10.0.2.0/24 } counter drop comment "customer→infra/mgmt v4 isolation"
         iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
-
-        # Allow established/related
-        ct state established,related accept
 
         # Allow DNAT'd traffic to infra VMs
         ip daddr $DNS_IP tcp dport 53 accept
@@ -118,6 +119,10 @@ table inet filter {
 
     chain forward {
         type filter hook forward priority filter; policy accept;
+
+        # Allow return traffic before customer isolation drops.
+        ct state established,related accept
+        ct state invalid drop
 
         # Customer VM isolation for IPv6.  The source/destination-prefix rule is
         # VRF-safe (does not rely on oifname); the bridge rule catches spoofed

--- a/ansible/inventory/host_vars/ci-pr.yml
+++ b/ansible/inventory/host_vars/ci-pr.yml
@@ -31,11 +31,30 @@ github_runner_ssh_key_path: ""            # no id_ci deploy key
 github_runner_containerlab_enabled: false # labs stay on the privileged `ci` runner
 github_runner_caddy_rfc2136_enabled: false
 github_runner_storage_enabled: false      # no separate data disk
+# Routed-GUA container networking. Containers get GUAs from this /64 (a slice of
+# our customer /48); ci-pr forwards (net.ipv6.conf.all.forwarding=1, set by the
+# role) and rtr routes the /64 back via a static route
+# (2a0c:b641:b51:c1::/64 via 2a0c:b641:b51::c1, issue #132). Docker 26.x leaves
+# ip6tables/IPv6-NAT off, so this is true routing — no masquerade — which the
+# rtr return route depends on.
+github_runner_docker_ipv6_enabled: true
+github_runner_docker_fixed_cidr_v6: "2a0c:b641:b51:c1::/64"
+# Container resolver = rtr's Unbound. It binds ONLY the infra address
+# 2a0c:b641:b50:2::1 (no listener on the customer gateway 2a0c:b641:b51::1 —
+# verified live), and rtr's input chain explicitly accepts :53 from the whole
+# customer /48 ("DNS recursion from overlay"). Querying rtr's own recursive
+# resolver is router-input, not a customer→infra-HOST forward, so it does not
+# breach ci-pr's customer isolation — and it inherits the #131 DNS64 CloudFront
+# override (Docker blob pulls take the fast NAT64 path).
+github_runner_docker_dns:
+  - "2a0c:b641:b50:2::1"
 
 # --- Firewall: default-deny inbound + node_exporter scrape from mon only ---
 # node_exporter is pull-only; mon -> ci-pr is infra->customer, which rtr permits.
 firewall_extra_rules:
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape (mon, pull-only)" }
+firewall_forward_extra_raw_nft: |
+  iifname docker0 ip6 saddr {{ github_runner_docker_fixed_cidr_v6 }} counter accept comment "ci-pr Docker IPv6 egress"
 
 # --- Monitoring: register on mon (Icinga host + node_exporter scrape) ---
 monitoring_register: true

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -46,14 +46,15 @@ table ip filter {
     chain forward {
         type filter hook forward priority filter; policy accept;
 
+        # Allow return traffic before customer isolation drops.
+        ct state established,related accept
+        ct state invalid drop
+
         # Customer VM isolation: packets from the customer bridge must not
         # reach infrastructure/mgmt ranges.  Match destination prefixes first
         # so enforcement does not depend solely on VRF slave oifname exposure.
         iifname enX3 ip daddr { {{ customer_isolation_block_v4 | join(', ') }} } counter drop comment "customer→infra/mgmt v4 isolation"
         iifname enX3 oifname { enX2, enX0 } counter drop comment "customer→infra/mgmt bridge isolation"
-
-        # Allow established/related
-        ct state established,related accept
 
         # Allow DNAT'd traffic to infra VMs
         ip daddr $DNS_IP tcp dport 53 accept
@@ -88,6 +89,10 @@ table inet filter {
 
     chain forward {
         type filter hook forward priority filter; policy accept;
+
+        # Allow return traffic before customer isolation drops.
+        ct state established,related accept
+        ct state invalid drop
 
         # Customer VM isolation for IPv6.  The source/destination-prefix rule is
         # VRF-safe (does not rely on oifname); the bridge rule catches spoofed

--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -48,6 +48,9 @@ github_runner_tmp_retention: 7d
 github_runner_bootstrap_dir: "{{ github_runner_home }}/bootstrap"
 github_runner_bootstrap_retention: 3d
 github_runner_docker_data_root: "{{ github_runner_home }}/docker"
+github_runner_docker_ipv6_enabled: false
+github_runner_docker_fixed_cidr_v6: ""
+github_runner_docker_dns: []
 github_runner_docker_prune_enabled: true
 github_runner_docker_prune_interval: daily
 github_runner_docker_prune_randomized_delay: 15m

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -249,6 +249,17 @@
   notify: restart docker
   tags: [apply]
 
+- name: Enable IPv6 forwarding for Docker routed subnet
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: "1"
+    sysctl_file: /etc/sysctl.d/99-github-runner-docker.conf
+    state: present
+    reload: true
+  when: github_runner_docker_ipv6_enabled | bool
+  notify: restart docker
+  tags: [apply]
+
 - name: Ensure runner is in docker group
   user:
     name: "{{ github_runner_user }}"

--- a/ansible/roles/github_runner/templates/docker-daemon.json.j2
+++ b/ansible/roles/github_runner/templates/docker-daemon.json.j2
@@ -1,3 +1,15 @@
-{
-  "data-root": "{{ github_runner_docker_data_root }}"
-}
+{% set docker_daemon_config = {
+  "data-root": github_runner_docker_data_root
+} %}
+{% if github_runner_docker_ipv6_enabled | bool %}
+{% set _ = docker_daemon_config.update({
+  "ipv6": true,
+  "fixed-cidr-v6": github_runner_docker_fixed_cidr_v6
+}) %}
+{% endif %}
+{% if github_runner_docker_dns | length > 0 %}
+{% set _ = docker_daemon_config.update({
+  "dns": github_runner_docker_dns
+}) %}
+{% endif %}
+{{ docker_daemon_config | to_nice_json }}

--- a/configs/rtr/frr.conf
+++ b/configs/rtr/frr.conf
@@ -13,6 +13,8 @@ vrf overlay
  ipv6 route 2a0c:b641:b50::/44 blackhole
  ! VPN client subnet → vpn VM
  ipv6 route 2a0c:b641:b50:3::/64 2a0c:b641:b50:2::60
+ ! ci-pr Docker container subnet
+ ipv6 route 2a0c:b641:b51:c1::/64 2a0c:b641:b51::c1
 exit-vrf
 !
 interface enX2 vrf overlay

--- a/tests/iac/test_firewall_contracts.py
+++ b/tests/iac/test_firewall_contracts.py
@@ -65,13 +65,19 @@ def test_rtr_customer_isolation_is_destination_prefix_enforced():
     )
 
 
-def test_rtr_customer_isolation_runs_before_established_accept():
+def test_rtr_forward_state_handling_runs_before_customer_isolation():
     ruleset = (REPO / "ansible/generated/rtr/nftables.conf").read_text()
 
+    v4_forward = ruleset.index("table ip filter")
+    v4_established = ruleset.index("ct state established,related accept", v4_forward)
+    v4_invalid = ruleset.index("ct state invalid drop", v4_forward)
     v4_drop = ruleset.index("customer→infra/mgmt v4 isolation")
-    v4_established = ruleset.index("ct state established,related accept", v4_drop)
-    assert v4_drop < v4_established
+    assert v4_established < v4_drop
+    assert v4_invalid < v4_drop
 
+    v6_forward = ruleset.index("chain forward", ruleset.index("table inet filter"))
+    v6_established = ruleset.index("ct state established,related accept", v6_forward)
+    v6_invalid = ruleset.index("ct state invalid drop", v6_forward)
     v6_drop = ruleset.index("customer→infra/router v6 isolation")
-    output_chain = ruleset.index("chain output", v6_drop)
-    assert v6_drop < output_chain
+    assert v6_established < v6_drop
+    assert v6_invalid < v6_drop


### PR DESCRIPTION
## Summary

- add the missing `rtr` overlay VRF static route for the `ci-pr` Docker container `/64`
- move `rtr` forward-chain conntrack handling ahead of customer-isolation drops so monitoring return traffic is accepted
- enable routed IPv6 Docker networking on `ci-pr` and allow scoped Docker IPv6 egress from the container `/64`
- update generated nftables artifacts and firewall contract coverage

## Root cause

`ci-pr` was reachable from `rtr`, but return traffic for monitoring flows could be dropped by `rtr` customer-isolation rules because established/related forwarding was evaluated after the isolation drops. The Docker container subnet also needed a route back through `ci-pr`; once routed Docker IPv6 was enabled, `ci-pr` needed a local forward allow for new container egress.

## Validation

- `ansible-playbook playbooks/firewall.yml --tags validate --connection=local --skip-tags snapshot --limit rtr`
- `ansible-playbook playbooks/firewall.yml --tags validate --connection=local --skip-tags snapshot --limit ci-pr`
- `scripts/ci/iac-static.sh`
- live `rtr` FRR route lookup for `2a0c:b641:b51:c1::/64`
- live `mon -> ci-pr` IPv6 ping
- live Icinga state check for `ci-pr` host and services
- live Docker container DNS/HTTPS smoke test from `ci-pr` to `openrouter.ai` and `semgrep.dev`
