### PR TITLE
cr1-de1: add TRANSIT-OUT-PREPEND-3X route-map for DE path steering (#119)

### DIFF
--- a/configs/cr1-de1/frr.conf
+++ b/configs/cr1-de1/frr.conf
@@ -123,6 +123,14 @@ route-map TRANSIT-OUT permit 10
  match ipv6 address prefix-list AS215932v6-out
 exit
 !
+! Emergency inbound traffic steering for degraded DE transit paths.
+! To de-preference cr1-de1, apply this outbound route-map to DE transit
+! neighbors instead of TRANSIT-OUT, then clear the affected BGP sessions.
+route-map TRANSIT-OUT-PREPEND-3X permit 10
+ match ipv6 address prefix-list AS215932v6-out
+ set as-path prepend 215932 215932 215932
+exit
+!
 route-map IXP-IN permit 10
  match as-path 1
 exit


### PR DESCRIPTION
## What
Adds a **definition-only** outbound route-map `TRANSIT-OUT-PREPEND-3X` to `configs/cr1-de1/frr.conf` that prepends `215932` three times on the AS215932 v6 aggregate.

## Why
Track 2 of #119: the DE transit's native IPv6 path is degraded. Applying this map to the DE transit neighbors (in place of `TRANSIT-OUT`) and clearing those sessions de-preferences the aggregate via DE, shifting inbound return traffic toward cr1-nl1.

## Safety
- **No neighbor references change** — the map is defined but not applied, so `render` + a normal apply are inert. Activation is a deliberate, separate operator step (swap the neighbor's outbound route-map + `clear bgp`) during a maintenance window.
- Pairs with the already-merged CI bypass (#131 DNS64 CloudFront override) so CI was never blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)