### PR TITLE
cr1-de1: de-prefer AS24961 transit paths, prepend DE upstreams (#119 #131)

### DIFF
--- a/configs/cr1-de1/frr.conf
+++ b/configs/cr1-de1/frr.conf
@@ -65,11 +65,11 @@ router bgp 215932
   neighbor 2a0c:b640:10::ffff activate
   neighbor 2a0c:b640:10::ffff soft-reconfiguration inbound
   neighbor 2a0c:b640:10::ffff route-map TRANSIT-IN in
-  neighbor 2a0c:b640:10::ffff route-map TRANSIT-OUT out
+  neighbor 2a0c:b640:10::ffff route-map TRANSIT-OUT-PREPEND-3X out
   neighbor 2a0c:b641:870::ffff activate
   neighbor 2a0c:b641:870::ffff soft-reconfiguration inbound
   neighbor 2a0c:b641:870::ffff route-map TRANSIT-IN in
-  neighbor 2a0c:b641:870::ffff route-map TRANSIT-OUT out
+  neighbor 2a0c:b641:870::ffff route-map TRANSIT-OUT-PREPEND-3X out
   ! IXP peers — route-map filtered
   ! neighbor DUS_IP activate
   ! neighbor DUS_IP soft-reconfiguration inbound
@@ -115,12 +115,30 @@ bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
 ! Permit routes with reasonable path length (implicit deny for longer)
 bgp as-path access-list 1 seq 100 permit ^.{0,200}$
 !
+! De-prefer any path transiting AS24961 (lossy myLoc DE upstream — #119/#131):
+! tag lp 80 in TRANSIT-IN so the clean NL copy learned via iBGP (lp 100) wins.
+bgp as-path access-list 24961 permit _24961_
+!
+route-map TRANSIT-IN permit 5
+ match as-path 24961
+ set local-preference 80
+ on-match next
+exit
+!
 route-map TRANSIT-IN permit 10
  match as-path 1
 exit
 !
 route-map TRANSIT-OUT permit 10
  match ipv6 address prefix-list AS215932v6-out
+exit
+!
+! Emergency inbound traffic steering for degraded DE transit paths.
+! To de-preference cr1-de1, apply this outbound route-map to DE transit
+! neighbors instead of TRANSIT-OUT, then clear the affected BGP sessions.
+route-map TRANSIT-OUT-PREPEND-3X permit 10
+ match ipv6 address prefix-list AS215932v6-out
+ set as-path prepend 215932 215932 215932
 exit
 !
 route-map IXP-IN permit 10


### PR DESCRIPTION
## What

Phase 0 of #138 — BGP path-steering on **cr1-de1** to stop egressing AWS/CloudFront and
GitHub/Fastly through the lossy **AS24961 (myLoc)** DE upstream, the root cause of #119 / #131.

- `bgp as-path access-list 24961 permit _24961_`
- `TRANSIT-IN` seq-5 clause: `match as-path 24961` / `set local-preference 80` / `on-match next`
  — tags any `_24961_` path lp 80, then falls through to the seq-10 `match as-path 1` sanity
  filter (loop/private/over-length protection still applies). The clean NL copy learned via iBGP
  at lp 100 then wins best-path.
- `TRANSIT-OUT-PREPEND-3X` applied **outbound to both DE upstreams** (Servperso-DE + Extra-Transit)
  so return traffic also enters via the NL edge.

Config-only and reversible — `soft-reconfiguration inbound` is on both transit peers, so
`clear bgp ipv6 unicast * soft` applies/rolls back with no session flap.

## Live evidence (cr1-de1, hyrule MCP, 2026-06-02)

| Destination | Current best (via 24961) | Clean iBGP NL copy already in RIB |
|---|---|---|
| CloudFront `2600:9000:274d::/48` | `210233 24961 3356 16509` | `34872 35133 3356 16509` @ lp 100 |
| GitHub/Fastly `2a04:4e42::/48` | `34872 24961 54113` | `34872 6939 54113` @ lp 100 |

## Tests

`python3 -m unittest discover -s tests/iac -p 'test_*.py'` → **28 passed** (router-id uniqueness,
iBGP mesh, ext-neighbor in+out maps, egress prefix-list lock, route-map/prefix-list reference checks).

## Deploy — manual (not auto-deployed by `apply.yml`)

⚠️ cr1-* FRR configs are **not yet Ansible-managed** — there is no `frr` playbook in `apply.yml`,
so merging this does **not** push to cr1-de1. Deploy is manual, bracketed by Icinga snapshots:

1. `icinga_list_problems` (pre baseline)
2. scp `configs/cr1-de1/frr.conf` → `/usr/local/etc/frr/frr.conf`; reload FRR; `vtysh -c 'clear bgp ipv6 unicast * soft'`
3. `icinga_list_problems` (post — diff must show no new problems)
4. verify best path flips to NL (`…35133…` / `…6939…`) and a ci-pr `docker pull` drops to seconds

Building an `frr` Ansible role + deploy runbook is tracked as a follow-up in #138 (Phase 5).

Refs #119 #131 #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
