### PR TITLE
ansible: frr role — gated FRR config deploy + hot-reload for the routers

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -28,6 +28,7 @@ on:
           - ci-runner-key
           - knot
           - extmon
+          - frr
           - rtr_routing
           - networkd_resolved
           - mail_openbsd

--- a/ansible/playbooks/frr.yml
+++ b/ansible/playbooks/frr.yml
@@ -1,0 +1,31 @@
+---
+- name: FRR — apply
+  hosts: routers
+  # One router at a time: a bad policy change blocks the next host instead of
+  # taking the whole mesh down at once.
+  serial: 1
+  # Facts come from group_vars (ansible_os_family preset), so render/validate
+  # runs don't require connectivity to the hosts.
+  gather_facts: false
+  become: true
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
+  roles:
+    - frr
+  post_tasks:
+    - name: Post-deploy Icinga snapshot
+      include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
+  tags: [frr]

--- a/ansible/roles/frr/README.md
+++ b/ansible/roles/frr/README.md
@@ -1,0 +1,56 @@
+# frr role
+
+Deploys the committed FRRouting config (`configs/<host>/frr.conf`) to a router
+and hot-reloads it. The repo's `configs/<host>/frr.conf` stays the single source
+of truth — this role does **not** template/render it; it pushes the file verbatim
+and applies a delta-reload so iBGP/OSPF sessions are not flapped.
+
+## What it does (on `--tags apply` + `frr_apply=true`)
+
+1. Asserts `configs/<host>/frr.conf` exists (the validate/dry-run stops here).
+2. Stages it to `<conf>.new` on the host.
+3. Syntax-checks the staged file (`vtysh -C -f`).
+4. Backs up the currently-loaded config.
+5. Schedules an `at(1)` watchdog (default 5 min) that restores + reloads the
+   backup if the play does not cancel it — covers a lockout from a bad policy.
+6. Moves the new config into place and fires the handler chain:
+   **validate → reload → `clear bgp ipv6 unicast * soft`**.
+7. Cancels the watchdog once the reload completes cleanly.
+
+`serial: 1` and the pre/post Icinga snapshot bracket are on the playbook
+(`playbooks/frr.yml`), matching the `firewall` role.
+
+## OS differences (`vars/<os_family>.yml`)
+
+| | FreeBSD (cr1-nl1, cr1-de1) | Debian (rtr) |
+|---|---|---|
+| `frr_conf_path` | `/usr/local/etc/frr/frr.conf` | `/etc/frr/frr.conf` |
+| `frr_reload_cmd` | `service frr reload` | `systemctl reload frr` |
+| `frr_validate_cmd` | `vtysh -C -f` | `vtysh -C -f` |
+
+> The FreeBSD `frr_reload_cmd` (`service frr reload`) assumes the frr port's rc
+> script wires a `reload` verb. If a first apply shows it does not, override in
+> `host_vars`/`group_vars` to call frr-reload directly:
+> `/usr/local/lib/frr/frr-reload.py --reload --bindir /usr/local/bin --confdir /usr/local/etc/frr /usr/local/etc/frr/frr.conf`.
+> The syntax check + backup + watchdog make a wrong reload command safe (it
+> reverts), but confirm it before relying on the pipeline for FreeBSD.
+
+## Key variables (`defaults/main.yml`)
+
+- `frr_apply` (false) — push + reload, or validate-only.
+- `frr_clear_bgp` (true) / `frr_clear_bgp_cmd` — soft policy re-eval after reload.
+- `frr_watchdog_minutes` (5) — rollback window.
+
+## Usage
+
+```bash
+cd ansible
+# Validate-only (no host connection, no change):
+ansible-playbook playbooks/frr.yml --tags validate --connection=local --skip-tags=snapshot
+
+# Apply to one router (Icinga-bracketed, serial:1):
+ansible-playbook playbooks/frr.yml --tags apply --limit rtr -e frr_apply=true
+```
+
+Or via the gated workflow:
+`gh workflow run apply.yml -F playbook=frr -F limit=rtr -F dry_run=false`.

--- a/ansible/roles/frr/defaults/main.yml
+++ b/ansible/roles/frr/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# Defaults consumed by the role. Override per-host or per-group.
+
+# Whether to push the config into place + reload. False = validate/render only.
+# apply.yml derives `frr_apply=true` from the playbook name on a non-dry-run.
+frr_apply: false
+
+# Source of truth: the committed live configs at repo configs/<host>/frr.conf.
+# inventory_hostname matches the configs/ subdir (cr1-nl1, cr1-de1, rtr).
+frr_config_src_dir: "{{ playbook_dir }}/../../configs"
+
+# After a successful reload, re-evaluate inbound + outbound policy without
+# bouncing sessions. soft-reconfiguration inbound is enabled on the transit
+# peers (see configs/cr1-*/frr.conf), so this is non-disruptive.
+frr_clear_bgp: true
+frr_clear_bgp_cmd: "vtysh -c 'clear bgp ipv6 unicast * soft'"
+
+# Rollback watchdog window. If the play does not cancel within this long, the
+# pre-change config is restored and FRR reloaded. BGP convergence is fast; the
+# margin covers a wedged session or a lockout from a bad policy change.
+frr_watchdog_minutes: 5

--- a/ansible/roles/frr/handlers/main.yml
+++ b/ansible/roles/frr/handlers/main.yml
@@ -1,0 +1,20 @@
+---
+# Handlers listening on the same topic fire in definition order, so a notify of
+# "reload frr" runs: validate (parse the in-place file) → reload (delta apply)
+# → clear bgp soft (re-evaluate policy without bouncing sessions).
+
+- name: validate frr
+  command: "{{ frr_validate_cmd }} {{ frr_conf_path }}"
+  changed_when: false
+  listen: reload frr
+
+- name: reload frr
+  command: "{{ frr_reload_cmd }}"
+  changed_when: false
+  listen: reload frr
+
+- name: clear bgp soft
+  command: "{{ frr_clear_bgp_cmd }}"
+  changed_when: false
+  when: frr_clear_bgp | default(true) | bool
+  listen: reload frr

--- a/ansible/roles/frr/meta/main.yml
+++ b/ansible/roles/frr/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: frr
+  author: AS215932 ops
+  description: >-
+    Deploy the committed FRRouting config (configs/<host>/frr.conf) to the
+    routers and hot-reload it, with a syntax check, backup, at(1) rollback
+    watchdog, and a soft BGP clear — no full daemon restart, no session flap.
+  license: proprietary
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions: ["13"]
+    - name: FreeBSD
+      versions: ["14", "15"]
+dependencies: []

--- a/ansible/roles/frr/tasks/deploy.yml
+++ b/ansible/roles/frr/tasks/deploy.yml
@@ -1,0 +1,62 @@
+---
+# Live config push + hot-reload. Mirrors the firewall role's pf/nftables apply:
+# stage → syntax-check → backup → schedule rollback watchdog → swap → reload
+# (validate → reload → clear bgp soft handler chain) → cancel watchdog.
+#
+# FRR is assumed already installed + running on a router. We never install or
+# restart the daemon here — only push config and delta-reload, so iBGP/OSPF
+# sessions are not flapped.
+
+- name: Check FRR + watchdog prerequisites are present
+  command: sh -c 'command -v vtysh >/dev/null 2>&1 && command -v at >/dev/null 2>&1 && command -v atrm >/dev/null 2>&1'
+  changed_when: false
+  tags: [apply]
+
+- name: Stage new FRR config on host (.new)
+  copy:
+    src: "{{ frr_config_src_dir }}/{{ inventory_hostname }}/frr.conf"
+    dest: "{{ frr_conf_path }}.new"
+    mode: "0640"
+  tags: [apply]
+
+- name: Syntax-check the staged FRR config
+  command: "{{ frr_validate_cmd }} {{ frr_conf_path }}.new"
+  changed_when: false
+  tags: [apply]
+
+- name: Backup the currently-loaded FRR config before swap
+  copy:
+    src: "{{ frr_conf_path }}"
+    dest: "{{ frr_backup_path }}"
+    remote_src: true
+    mode: "0640"
+  changed_when: false
+  tags: [apply]
+
+- name: Schedule rollback watchdog — restores + reloads the backup if not cancelled
+  shell: |
+    echo 'cp {{ frr_backup_path }} {{ frr_conf_path }} && {{ frr_reload_cmd }} 2>&1 | logger -t frr-rollback' \
+      | at now + {{ frr_watchdog_minutes }} minutes 2>&1 \
+      | awk 'tolower($1) == "job" {print $2}'
+  register: _frr_at_job
+  changed_when: false
+  tags: [apply]
+
+- name: Move new FRR config into place
+  copy:
+    src: "{{ frr_conf_path }}.new"
+    dest: "{{ frr_conf_path }}"
+    remote_src: true
+    mode: "0640"
+  notify: reload frr
+  tags: [apply]
+
+- name: Flush handlers now (validate → reload → clear bgp soft)
+  meta: flush_handlers
+  tags: [apply]
+
+- name: Cancel rollback watchdog
+  command: "atrm {{ _frr_at_job.stdout }}"
+  changed_when: false
+  when: _frr_at_job.stdout | default('') | length > 0
+  tags: [apply]

--- a/ansible/roles/frr/tasks/main.yml
+++ b/ansible/roles/frr/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Load OS-specific vars
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags: [always]
+
+- name: Locate the committed FRR config for this host (controller)
+  delegate_to: localhost
+  become: false
+  stat:
+    path: "{{ frr_config_src_dir }}/{{ inventory_hostname }}/frr.conf"
+  register: _frr_src
+  tags: [validate, diff, apply]
+
+- name: Assert a committed FRR config exists for this host
+  assert:
+    that:
+      - _frr_src.stat.exists
+      - _frr_src.stat.size | default(0) | int > 0
+    fail_msg: >-
+      No committed config at configs/{{ inventory_hostname }}/frr.conf — the frr
+      role deploys the repo's live config verbatim. Add the file (or limit the
+      run to hosts that have one) before applying.
+    success_msg: >-
+      Will deploy configs/{{ inventory_hostname }}/frr.conf
+      ({{ _frr_src.stat.size }} bytes) to {{ frr_conf_path }}.
+  tags: [validate, diff, apply]
+
+- name: Deploy + reload FRR config
+  include_tasks: deploy.yml
+  when: frr_apply | default(false) | bool
+  tags: [apply]

--- a/ansible/roles/frr/vars/Debian.yml
+++ b/ansible/roles/frr/vars/Debian.yml
@@ -1,0 +1,9 @@
+---
+# Debian router (rtr) — frr package under /etc, systemd-managed.
+frr_conf_path: /etc/frr/frr.conf
+frr_backup_path: /etc/frr/frr.conf.backup
+# Standalone parse check of a config file (no daemon connection needed).
+frr_validate_cmd: "vtysh -C -f"
+# systemctl reload frr runs /usr/lib/frr/frr-reload.py --reload internally,
+# computing + applying the delta against the running config.
+frr_reload_cmd: "systemctl reload frr"

--- a/ansible/roles/frr/vars/FreeBSD.yml
+++ b/ansible/roles/frr/vars/FreeBSD.yml
@@ -1,0 +1,12 @@
+---
+# FreeBSD core routers (cr1-nl1, cr1-de1) — frr package under /usr/local.
+frr_conf_path: /usr/local/etc/frr/frr.conf
+frr_backup_path: /usr/local/etc/frr/frr.conf.backup
+# Standalone parse check of a config file (no daemon connection needed).
+frr_validate_cmd: "vtysh -C -f"
+# Hot-reload (delta apply via frr-reload). If the frr port's rc script lacks a
+# `reload` verb, override to the direct script in host_vars/group_vars:
+#   frr_reload_cmd: "/usr/local/lib/frr/frr-reload.py --reload
+#     --bindir /usr/local/bin --confdir /usr/local/etc/frr
+#     /usr/local/etc/frr/frr.conf"
+frr_reload_cmd: "service frr reload"

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -108,6 +108,41 @@ Rule shape:
 For pf-only constructs that don't fit the data model (e.g. `match all scrub`,
 new transit pass rules), use `firewall_extra_raw_pf:` (string) in host_vars.
 
+## FRR config deploys (`frr` role)
+
+FRR configs were historically pushed to the routers by hand (scp + reload). The
+`frr` role (`ansible/roles/frr/`, playbook `playbooks/frr.yml`) brings them under
+the same gated pipeline as `firewall`. The committed `configs/<host>/frr.conf`
+stays the **single source of truth** — the role pushes that file verbatim and
+delta-reloads it; it does not template/render the config.
+
+The apply path mirrors the firewall role: stage `<conf>.new` → `vtysh -C -f`
+syntax check → backup → schedule an `at(1)` rollback watchdog
+(`frr_watchdog_minutes`, default 5) → swap into place → handler chain
+**validate → reload → `clear bgp ipv6 unicast * soft`** → cancel the watchdog.
+`serial: 1` and the pre/post Icinga snapshot bracket are on the play, so a bad
+policy change blocks the next router instead of taking the mesh down.
+
+```bash
+cd ansible
+# Validate-only (no connection, no change) — confirms each targeted host has a
+# committed configs/<host>/frr.conf to deploy:
+ansible-playbook playbooks/frr.yml --tags validate --connection=local --skip-tags=snapshot
+
+# Apply to one router (Icinga-bracketed):
+ansible-playbook playbooks/frr.yml --tags apply --limit rtr -e frr_apply=true
+```
+
+Or via the gated workflow: `gh workflow run apply.yml -F playbook=frr -F limit=rtr -F dry_run=false`.
+
+**Rollout order:** `--limit rtr` first (Debian; `systemctl reload frr` is certain),
+then `--limit cr1-de1`, then `--limit cr1-nl1`. The FreeBSD `frr_reload_cmd`
+(`service frr reload`) assumes the frr port's rc script has a `reload` verb —
+**confirm on the first FreeBSD apply**; if absent, override `frr_reload_cmd` in
+host_vars to call `/usr/local/lib/frr/frr-reload.py --reload` directly (see the
+role README). The syntax check + backup + watchdog make a wrong reload command
+self-reverting, but the first FreeBSD apply is the point to verify it.
+
 ## Monitoring user — dedicated `monitoring` system account on every host
 
 The `monitoring` role provisions a dedicated `monitoring` system user

--- a/scripts/ci/goss-validate.sh
+++ b/scripts/ci/goss-validate.sh
@@ -21,7 +21,7 @@ case "$playbook" in
     echo "::notice::hyrule-cloud Goss spec is staged, but target-side execution is paused with the cloud/web refactor"
     exit 0
     ;;
-  rtr_routing|firewall)
+  rtr_routing|firewall|frr)
     echo "::notice::router Goss spec is staged; remote target execution must be wired before making it a hard apply gate"
     exit 0
     ;;


### PR DESCRIPTION
## What

Brings the routers' FRR configs under the same gated Ansible pipeline as `firewall`.
Until now `apply.yml` could deploy every layer (firewall, monitoring, logs, knot,
rtr_routing…) **except** the core-router FRR config, which was pushed by hand — surfaced
while trying to ship the AS24961 de-pref (#140 / #138).

New `frr` role + `playbooks/frr.yml`:

- Deploys the committed `configs/<host>/frr.conf` **verbatim** (stays the single source of
  truth; no templating/rendering).
- Mirrors the firewall role's safety chain: `serial: 1`, pre/post Icinga snapshot bracket
  (reuses firewall's snapshot task), stage `.new` → `vtysh -C -f` syntax check → backup →
  `at(1)` rollback watchdog → swap → handler chain
  **validate → reload → `clear bgp ipv6 unicast * soft`** → cancel watchdog. Delta-reload
  (no daemon restart) → no iBGP/OSPF session flap.
- OS-split vars: FreeBSD (`/usr/local/etc/frr`, `service frr reload`) vs Debian
  (`/etc/frr`, `systemctl reload frr`).
- Wires `frr` into `apply.yml` playbook choices + `goss-validate.sh`; documents rollout in
  `docs/ansible.md` + role `README.md`.

## Validation

- `ansible-playbook playbooks/frr.yml --syntax-check` ✓
- Validate dry-run (`--tags validate --connection=local --skip-tags=snapshot`) asserts each
  router has a committed config — rtr / cr1-nl1 / cr1-de1 all `ok=3 changed=0`.
- `python3 -m unittest discover -s tests/iac` → 28 passed; yamllint clean; ansible-lint clean
  (only the same `schema[meta]` Debian-version warning the existing firewall meta emits).

## Caveat — confirm on first FreeBSD apply

The FreeBSD `frr_reload_cmd` (`service frr reload`) and the `vtysh -C -f` validate command are
standard FRR but **unconfirmed against the live hosts** — the read-only SSH probe was blocked
by the deploy guardrail. The syntax check + backup + `at(1)` watchdog make a wrong command
self-reverting. Deploy `--limit rtr` (Debian; `systemctl reload frr` is certain) first, then
confirm/override `frr_reload_cmd` on the first `--limit cr1-de1` apply (override path in the
role README).

## Deploy once merged

`gh workflow run apply.yml -F playbook=frr -F limit=rtr -F dry_run=false` (then `cr1-de1`,
`cr1-nl1`). This is the mechanism to ship the #140 AS24961 fix to the routers.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
