### PR TITLE
ci: migrate static PR jobs to the unprivileged ci-pr runner (Wave 4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned third-party GitHub Actions (PR-Agent, codeql upload-sarif,
+  # checkout, etc.) fresh. github-actions PRs land like any other PR: they run on
+  # the unprivileged ci-pr runner and require review before merge.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/iac-tests.yml
+++ b/.github/workflows/iac-tests.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   static-iac:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     env:
       ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles
     steps:
@@ -70,7 +70,7 @@ jobs:
         run: scripts/ci/containerlab-frr-test.sh
 
   ansible-idempotency:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     needs: static-iac
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ permissions:
 
 jobs:
   yamllint:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     steps:
       - uses: actions/checkout@v4
       - name: yamllint
         run: yamllint -c .yamllint .
 
   ansible-lint:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     # roles_path lives in ansible/ansible.cfg, which isn't picked up when lint
     # runs from the repo root — point ansible at ansible/roles explicitly so
     # syntax-check can resolve role references.
@@ -32,7 +32,7 @@ jobs:
         run: ansible-lint -c .ansible-lint ansible/playbooks/ ansible/roles/
 
   shellcheck:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
@@ -49,7 +49,7 @@ jobs:
           fi
 
   jinja-syntax:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     steps:
       - uses: actions/checkout@v4
       - name: jinja2 syntax check

--- a/.github/workflows/render-check.yml
+++ b/.github/workflows/render-check.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   render:
-    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -15,11 +15,40 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         labels = {str(label).replace("{{ github_runner_arch }}", defaults["github_runner_arch"]) for label in defaults["github_runner_labels"]}
         self.assertTrue({"self-hosted", "linux", "x64", "hyrule", "hyrule-infra"} <= labels)
 
-    def test_infra_workflows_target_hyrule_infra_runner_label(self):
+    def test_pull_request_jobs_use_the_unprivileged_runner(self):
+        # Two-runner model (Wave 4): every job reachable on a `pull_request`
+        # event must run on the unprivileged ci-pr runner (hyrule-public-pr),
+        # never on a privileged self-hosted label (hyrule / hyrule-infra). The
+        # heavy labs (batfish, containerlab-frr) may keep the privileged label
+        # ONLY because they are if-gated off pull_request (workflow_dispatch /
+        # repo var). Privileged deploy workflows (apply, drift-detection) are not
+        # pull_request-triggered, so they legitimately stay on hyrule-infra.
+        privileged = {"hyrule", "hyrule-infra"}
         for workflow in (REPO / ".github/workflows").glob("*.yml"):
-            text = workflow.read_text()
-            if "runs-on:" in text:
-                self.assertIn("hyrule-infra", text, workflow)
+            spec = yaml.safe_load(workflow.read_text())
+            triggers = spec.get("on", spec.get(True))  # PyYAML maps `on:` -> True
+            if not _triggers_on_pull_request(triggers):
+                continue
+            for job_name, job in (spec.get("jobs") or {}).items():
+                runs_on = job.get("runs-on")
+                labels = set(runs_on) if isinstance(runs_on, list) else {runs_on}
+                offending = labels & privileged
+                if not offending:
+                    continue
+                cond = str(job.get("if", ""))
+                self.assertTrue(
+                    "workflow_dispatch" in cond or "vars." in cond,
+                    f"{workflow.name}:{job_name} uses privileged label {offending} on a "
+                    f"pull_request workflow without an if-gate restricting it off PRs",
+                )
+
+    def test_privileged_deploy_workflows_stay_on_ci_runner(self):
+        # apply/drift must keep the privileged runner and must NOT leak onto the
+        # unprivileged ci-pr runner (they carry Vault + id_ci).
+        for name in ("apply.yml", "drift-detection.yml"):
+            text = (REPO / ".github/workflows" / name).read_text()
+            self.assertIn("hyrule-infra", text, name)
+            self.assertNotIn("hyrule-public-pr", text, name)
 
     def test_apply_workflow_can_gate_ci_runner_key_bootstrap(self):
         workflow = (REPO / ".github/workflows/apply.yml").read_text()
@@ -119,6 +148,21 @@ def _groups_for(value):
     if isinstance(value, list):
         return {str(item) for item in value}
     return {part.strip() for part in str(value).replace(",", " ").split() if part.strip()}
+
+
+def _triggers_on_pull_request(triggers):
+    # `on:` may be a string ("pull_request"), a list, or a mapping
+    # ({pull_request: {...}, push: {...}}); PyYAML also turns the bare key `on`
+    # into the boolean True, which the caller resolves before passing here.
+    if triggers is None:
+        return False
+    if isinstance(triggers, str):
+        return triggers == "pull_request"
+    if isinstance(triggers, dict):
+        return "pull_request" in triggers
+    if isinstance(triggers, (list, tuple, set)):
+        return "pull_request" in triggers
+    return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Moves the **static / unprivileged** `pull_request` jobs off the privileged `ci` runner (`hyrule-infra`) onto the disposable, customer-isolated `ci-pr` runner (`hyrule-public-pr`):
- **lint.yml**: yamllint, ansible-lint, shellcheck, jinja-syntax
- **render-check.yml**: render
- **iac-tests.yml**: static-iac, ansible-idempotency

## Migration guard (why these are safe to move)
Each migrated job runs **only repo-local files** via the runner toolchain (ansible/ansible-lint/yamllint/shellcheck/jinja2/jsonschema/pytest — all present on ci-pr), reads **no** Vault / `/etc/github-runner/secrets.env`, needs **no** `id_ci`, and touches **no** management overlay. Verified: `render-all.sh` is `--connection=local --tags validate`; `iac-static.sh` and `ansible-idempotency.sh` have no ssh/secret/connection access.

## Kept on the privileged `ci` runner (trusted-only)
- **batfish** + **containerlab-frr** — heavy Docker labs, already gated to `workflow_dispatch` / repo-var (skipped on normal PRs).
- **apply.yml** / **drift-detection.yml** — Vault + `id_ci` deploy paths.

Check **names** (job ids) are unchanged, so required-status-check contexts still match — no branch-protection churn. This PR's own `pull_request` run executes the migrated jobs on `ci-pr`, self-validating the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)