### PR TITLE
frr role: install frr10-pythontools + use port reload wrapper (FreeBSD)

### DIFF
--- a/ansible/roles/frr/README.md
+++ b/ansible/roles/frr/README.md
@@ -30,17 +30,19 @@ where the on-disk file already matches the repo but the daemon never ingested it
 | | FreeBSD (cr1-nl1, cr1-de1) | Debian (rtr) |
 |---|---|---|
 | `frr_conf_path` | `/usr/local/etc/frr/frr.conf` | `/etc/frr/frr.conf` |
-| `frr_reload_cmd` | `frr-reload.py --reload …` (direct) | `systemctl reload frr` |
+| `frr_reload_cmd` | `/usr/local/sbin/frr-reload` (port wrapper) | `systemctl reload frr` |
 | `frr_validate_cmd` | `vtysh -C -f` | `vtysh -C -f` |
+| `frr_pythontools_pkg` | `frr10-pythontools` | `""` (bundled) |
 
-> FreeBSD's `service frr reload` does **not** invoke FRR's integrated reload — on
-> first use it silently applied nothing. So the FreeBSD `frr_reload_cmd` calls
-> `/usr/local/lib/frr/frr-reload.py --reload --bindir /usr/local/bin --confdir
-> /usr/local/etc/frr --stdout /usr/local/etc/frr/frr.conf` directly (the same
-> tool Debian's `systemctl reload frr` runs internally). Confirmed working on
-> cr1-de1 (FRR 10.4.1 / FreeBSD 15). Always verify the change actually took with
-> `vtysh -c 'show route-map …'` after — a reload returning rc 0 is not proof the
-> running config converged.
+> FreeBSD's `service frr reload` does **not** invoke FRR's integrated reload — it
+> returns rc 0 but applies nothing. The role uses the port's wrapper
+> `/usr/local/sbin/frr-reload` (→ `frr-reload.py --reload …`), which **requires
+> the `frr10-pythontools` package** — without it the wrapper just prints "Please
+> install frr10-pythontools" and exits non-zero, so the role installs it as a
+> prerequisite (`frr_pythontools_pkg`). Confirmed working on cr1-de1 (FRR 10.4.1
+> / FreeBSD 15). Always verify the change actually took
+> (`vtysh -c 'show route-map …'`, `show bgp … <prefix>`) — a reload returning rc 0
+> is not proof the running config converged.
 
 ## Key variables (`defaults/main.yml`)
 

--- a/ansible/roles/frr/tasks/deploy.yml
+++ b/ansible/roles/frr/tasks/deploy.yml
@@ -18,6 +18,15 @@
   changed_when: false
   tags: [apply]
 
+- name: Ensure the integrated-reload tooling package is installed
+  # On FreeBSD frr-reload.py ships in a separate package (frr10-pythontools);
+  # without it the reload silently applies nothing. Debian bundles it (pkg = "").
+  package:
+    name: "{{ frr_pythontools_pkg }}"
+    state: present
+  when: frr_pythontools_pkg | default('') | length > 0
+  tags: [apply]
+
 - name: Stage new FRR config on host (.new)
   copy:
     src: "{{ frr_config_src_dir }}/{{ inventory_hostname }}/frr.conf"

--- a/ansible/roles/frr/vars/Debian.yml
+++ b/ansible/roles/frr/vars/Debian.yml
@@ -7,3 +7,5 @@ frr_validate_cmd: "vtysh -C -f"
 # systemctl reload frr runs /usr/lib/frr/frr-reload.py --reload internally,
 # computing + applying the delta against the running config.
 frr_reload_cmd: "systemctl reload frr"
+# Debian's frr package ships frr-reload.py — no separate tools package needed.
+frr_pythontools_pkg: ""

--- a/ansible/roles/frr/vars/FreeBSD.yml
+++ b/ansible/roles/frr/vars/FreeBSD.yml
@@ -4,10 +4,10 @@ frr_conf_path: /usr/local/etc/frr/frr.conf
 frr_backup_path: /usr/local/etc/frr/frr.conf.backup
 # Standalone parse check of a config file (no daemon connection needed).
 frr_validate_cmd: "vtysh -C -f"
-# FreeBSD `service frr reload` does NOT invoke FRR's integrated reload — it
-# silently applies nothing. Call frr-reload.py directly (the same tool Debian's
-# `systemctl reload frr` runs internally), pointed at the FreeBSD bin/conf dirs.
-# It computes the delta against the running daemon and applies it — no restart.
-frr_reload_cmd: >-
-  /usr/local/lib/frr/frr-reload.py --reload --bindir /usr/local/bin
-  --confdir /usr/local/etc/frr --stdout /usr/local/etc/frr/frr.conf
+# Integrated delta-reload via the port's wrapper, which execs
+# `frr-reload.py --reload /usr/local/etc/frr/frr.conf`. NB: the wrapper needs the
+# frr-reload.py script from the frr10-pythontools package (frr_pythontools_pkg) —
+# without it `service frr reload` / the wrapper silently fail and apply nothing.
+frr_reload_cmd: "/usr/local/sbin/frr-reload"
+# Package providing frr-reload.py on FreeBSD. The reload is a no-op without it.
+frr_pythontools_pkg: "frr10-pythontools"

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -142,12 +142,16 @@ daemon left stale by a botched reload still gets reconverged on a re-run.
 
 > **FreeBSD reload gotcha (learned the hard way):** `service frr reload` on the
 > FreeBSD frr port does **not** invoke FRR's integrated reload — it returns rc 0
-> but silently applies nothing. The role therefore calls
-> `/usr/local/lib/frr/frr-reload.py --reload --bindir /usr/local/bin --confdir
-> /usr/local/etc/frr` directly on FreeBSD (Debian keeps `systemctl reload frr`,
-> which runs frr-reload internally). **Always verify the running config actually
-> converged** (`vtysh -c 'show route-map …'`, `show bgp … <prefix>`) — a reload
-> exiting 0 is not proof it applied.
+> but silently applies nothing. The real reload is the port wrapper
+> `/usr/local/sbin/frr-reload` (→ `frr-reload.py --reload …`), which **requires
+> the `frr10-pythontools` package** — it is NOT installed by the base frr10
+> package, and without it the wrapper exits with "Please install
+> frr10-pythontools". The role installs it as a prerequisite
+> (`frr_pythontools_pkg`) and reloads via the wrapper; Debian bundles frr-reload
+> in the frr package and keeps `systemctl reload frr`. **Always verify the running
+> config actually converged** (`vtysh -c 'show route-map …'`, `show bgp …
+> <prefix>`) — a reload exiting 0 is not proof it applied. (cr1-nl1 also lacks
+> frr10-pythontools until its first frr-role apply installs it.)
 
 ## Monitoring user — dedicated `monitoring` system account on every host
 


### PR DESCRIPTION
## What

The cr1-de1 apply exposed the real reason FreeBSD reloads were silent no-ops: the
**`frr10-pythontools`** package (which provides `frr-reload.py`) is **not installed
by the base `frr10` package**. So `service frr reload` and the port wrapper
`/usr/local/sbin/frr-reload` both do nothing ("Please install frr10-pythontools"),
and #146's guessed path `/usr/local/lib/frr/frr-reload.py` doesn't exist on FreeBSD.

## Changes

- `vars/FreeBSD.yml`: `frr_reload_cmd` → **`/usr/local/sbin/frr-reload`** (the port
  wrapper, which execs `frr-reload.py --reload /usr/local/etc/frr/frr.conf`). Add
  `frr_pythontools_pkg: frr10-pythontools`.
- `vars/Debian.yml`: `frr_pythontools_pkg: ""` (Debian bundles frr-reload).
- `tasks/deploy.yml`: ensure `frr_pythontools_pkg` is installed before reloading.
- README + `docs/ansible.md`: document the gotcha and the package requirement.

## Verified end-to-end on cr1-de1 (FRR 10.4.1 / FreeBSD 15)

After installing `frr10-pythontools`, `frr-reload` applied the AS24961 de-pref
cleanly — **no session flap** (all BGP/OSPF uptimes continuous) — and both
CloudFront (`2600:9000:274d::`) and GitHub/Fastly (`2a04:4e42::`) best-paths
flipped to the clean NL leg (`localpref 100`), with `_24961_` paths de-preferred
to `localpref 80`. The #119/#131 acute pain on the cr1-de1 leg is resolved.

Validation: syntax-check ✓ · dry-run cr1-de1 `ok=3` ✓ · yamllint clean ·
ansible-lint clean · 28 IaC tests ✓.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)