### PR TITLE
NetOps tiers (Wave 5): SoT schema gate + iac-gate + nightly labs

### DIFF
--- a/.github/workflows/iac-tests.yml
+++ b/.github/workflows/iac-tests.yml
@@ -1,6 +1,21 @@
 ---
 name: iac-tests
 
+# Tiered IaC test pipeline (Wave 5).
+#
+#   Tier 0  static-iac, ansible-idempotency   unprivileged ci-pr   required (via iac-gate)
+#   Tier 1  batfish                            privileged   ci      trusted-only (dispatch/nightly/var)
+#   Tier 2  containerlab-frr                   privileged   ci      trusted-only (dispatch/nightly/var)
+#
+# Tier 0 runs untrusted PR code, so it lives on the unprivileged hyrule-public-pr
+# runner. Tiers 1-2 spin up Batfish / Containerlab (heavy lab infra + Docker) on
+# the privileged ci runner and only run on a trusted trigger — never automatically
+# on an arbitrary PR. The `iac-gate` job is the single REQUIRED status context:
+# it always reports, so a PR that touches none of the path-filtered IaC files
+# (where this whole workflow is skipped) is treated as passing, while an IaC PR
+# only passes when the required tiers succeed and the lab tiers are
+# success-or-skipped (never failed). See docs/netops/testing-strategy.md.
+
 on:
   pull_request:
     branches: [main]
@@ -27,6 +42,7 @@ permissions:
   pull-requests: read
 
 jobs:
+  # ---- Tier 0: static, unprivileged, required ---------------------------
   static-iac:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     env:
@@ -45,6 +61,16 @@ jobs:
             ansible-playbook "$playbook" --syntax-check
           done
 
+  ansible-idempotency:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    needs: static-iac
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render/validate idempotency gate
+        run: scripts/ci/ansible-idempotency.sh
+
+  # ---- Tier 1: Batfish control-plane model (privileged, trusted-only) ---
   batfish:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
     needs: static-iac
@@ -54,11 +80,24 @@ jobs:
 
       - name: Batfish AS215932 model tests
         run: |
+          set -euo pipefail
           python3 -m venv .venv-batfish
           . .venv-batfish/bin/activate
           pip install pytest pybatfish
           scripts/ci/batfish-test.sh
 
+      - name: Upload Batfish artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: batfish-artifacts
+          path: |
+            tests/iac/batfish/_artifacts/**
+            .venv-batfish/batfish-*.log
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ---- Tier 2: Containerlab dynamic FRR (privileged, trusted-only) ------
   containerlab-frr:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
     needs: static-iac
@@ -69,11 +108,52 @@ jobs:
       - name: Containerlab dynamic FRR smoke test
         run: scripts/ci/containerlab-frr-test.sh
 
-  ansible-idempotency:
-    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    needs: static-iac
-    steps:
-      - uses: actions/checkout@v4
+      - name: Upload Containerlab artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: containerlab-artifacts
+          path: |
+            tests/iac/containerlab/_artifacts/**
+            clab-*/**
+          if-no-files-found: ignore
+          retention-days: 14
 
-      - name: Render/validate idempotency gate
-        run: scripts/ci/ansible-idempotency.sh
+  # ---- Aggregating gate: the single REQUIRED context --------------------
+  iac-gate:
+    name: iac-gate
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    needs: [static-iac, ansible-idempotency, batfish, containerlab-frr]
+    if: always()
+    steps:
+      - name: Evaluate tier results
+        env:
+          STATIC_IAC: ${{ needs.static-iac.result }}
+          ANSIBLE_IDEMPOTENCY: ${{ needs.ansible-idempotency.result }}
+          BATFISH: ${{ needs.batfish.result }}
+          CONTAINERLAB: ${{ needs.containerlab-frr.result }}
+        run: |
+          set -euo pipefail
+          echo "Tier results:"
+          echo "  static-iac          = ${STATIC_IAC}"
+          echo "  ansible-idempotency = ${ANSIBLE_IDEMPOTENCY}"
+          echo "  batfish (trusted)   = ${BATFISH}"
+          echo "  containerlab (trust)= ${CONTAINERLAB}"
+          fail=0
+          # Required tiers must succeed.
+          for pair in "static-iac:${STATIC_IAC}" "ansible-idempotency:${ANSIBLE_IDEMPOTENCY}"; do
+            name="${pair%%:*}"; res="${pair##*:}"
+            if [ "${res}" != "success" ]; then
+              echo "::error::required tier ${name} did not pass (${res})"
+              fail=1
+            fi
+          done
+          # Trusted lab tiers may be skipped on PRs, but must never be failed.
+          for pair in "batfish:${BATFISH}" "containerlab-frr:${CONTAINERLAB}"; do
+            name="${pair%%:*}"; res="${pair##*:}"
+            if [ "${res}" != "success" ] && [ "${res}" != "skipped" ]; then
+              echo "::error::lab tier ${name} reported a failure (${res})"
+              fail=1
+            fi
+          done
+          exit "${fail}"

--- a/.github/workflows/netops-nightly.yml
+++ b/.github/workflows/netops-nightly.yml
@@ -1,0 +1,89 @@
+---
+name: netops-nightly
+
+# Nightly cadence for the heavy NetOps lab tiers (Wave 5, Stage 1: manual +
+# nightly). Batfish (control-plane model) and Containerlab (dynamic FRR) are
+# too heavy / lab-bound to run on every PR, and they need the privileged ci
+# runner (Docker + lab infra), so they run here on a schedule and on manual
+# dispatch — never automatically on an untrusted PR. Live check-mode drift is
+# owned by drift-detection.yml; render validation by render-check.yml; this
+# workflow does not duplicate either. Failures alert the NOC via Discord.
+
+on:
+  schedule:
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  batfish-full:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Batfish AS215932 model tests
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv-batfish
+          . .venv-batfish/bin/activate
+          pip install pytest pybatfish
+          scripts/ci/batfish-test.sh
+
+      - name: Upload Batfish artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: nightly-batfish-artifacts
+          path: |
+            tests/iac/batfish/_artifacts/**
+            .venv-batfish/batfish-*.log
+          if-no-files-found: ignore
+          retention-days: 30
+
+  containerlab-full:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Containerlab dynamic FRR smoke test
+        run: scripts/ci/containerlab-frr-test.sh
+
+      - name: Upload Containerlab artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: nightly-containerlab-artifacts
+          path: |
+            tests/iac/containerlab/_artifacts/**
+            clab-*/**
+          if-no-files-found: ignore
+          retention-days: 30
+
+  notify-failure:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    needs: [batfish-full, containerlab-full]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Source runner-scoped secrets
+        run: |
+          set -euo pipefail
+          scripts/ci/deploy-preflight.sh --runner
+          set -a
+          . /etc/github-runner/secrets.env
+          set +a
+          grep -E '^[A-Z_][A-Z0-9_]*=' /etc/github-runner/secrets.env >> "$GITHUB_ENV"
+
+      - name: Alert NOC on nightly NetOps failure
+        if: env.DISCORD_WEBHOOK_URL != ''
+        env:
+          DISCORD_WEBHOOK_URL: ${{ env.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n --arg content "AS215932 nightly NetOps labs failed: ${RUN_URL}" '{content: $content}' \
+            | curl -fsS -H 'Content-Type: application/json' -d @- "$DISCORD_WEBHOOK_URL"

--- a/docs/netops/testing-strategy.md
+++ b/docs/netops/testing-strategy.md
@@ -1,0 +1,93 @@
+# NetOps testing strategy
+
+How AS215932 IaC changes are validated, from a cheap stdlib check on every PR
+up to full control-plane modelling and a live dynamic lab. The tiers map onto
+the two-runner security model (`docs/ci/security-model.md`): untrusted PR code
+runs only on the unprivileged `hyrule-public-pr` runner; the heavy labs run on
+the privileged `ci` runner on trusted triggers only.
+
+## Tiers
+
+| Tier | Jobs | Runner | Trigger | Gating |
+|------|------|--------|---------|--------|
+| 0 — static | `static-iac`, `ansible-idempotency` | `hyrule-public-pr` (unprivileged) | every PR touching IaC paths | **required** via `iac-gate` |
+| 1 — Batfish | `batfish` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_BATFISH_TESTS`, nightly | advisory / trusted-only |
+| 2 — Containerlab | `containerlab-frr` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_CONTAINERLAB_TESTS`, nightly | advisory / trusted-only |
+| 3 — deploy safety | `apply.yml` (manual, `production`, Icinga pre/post + Goss), `drift-detection.yml` (nightly check-mode) | `ci` (privileged) | manual / schedule | deploy-time |
+
+All of Tier 0 is in `.github/workflows/iac-tests.yml`. Tiers 1–2 also live there
+(gated off PRs) and run nightly via `.github/workflows/netops-nightly.yml`.
+
+### Tier 0 — static (required)
+
+`static-iac` runs `scripts/ci/iac-static.sh`, which is intentionally
+dependency-light: a stdlib `unittest` discovery over `tests/iac/` plus external
+validators (`named-checkzone`, `systemd-analyze`, `caddy adapt`,
+`unbound-checkconf`, `nft -c`) when the tool is present on the runner.
+
+The `unittest` suite includes the **source-of-truth schema gate**
+(`tests/iac/test_inventory_schema.py`): it validates the structure and internal
+consistency of `ansible/inventory/{hosts.yml,group_vars/all.yml}` before
+anything is rendered — every referenced host resolves to a canonical
+`ansible_host`, addresses are valid and unique, infra VMs sit in
+`infra_subnet`, the **ci-pr runner sits on the customer segment and never the
+infra segment** (the two-runner isolation invariant, pinned at the data layer),
+subnets nest under the allocation and are pairwise disjoint, the `peers` map
+agrees with `hosts.yml`, router loopbacks live in the loopback subnet, and eBGP
+neighbours are global addresses outside our own prefix.
+
+`ansible-idempotency` re-renders and asserts the idempotency contract via
+`scripts/ci/ansible-idempotency.sh`. Both are pure local rendering / syntax
+checks — no Vault, no `id_ci`, no fleet SSH — which is why they are safe on the
+unprivileged runner (see the Wave 4 migration guard in
+`docs/ci/security-model.md`).
+
+### Tiers 1–2 — Batfish & Containerlab (trusted-only)
+
+These spin up `batfish/allinone` and Containerlab (Docker + lab infra) and are
+**never** run automatically on an arbitrary PR. Enable them on a trusted PR by
+setting the repo variable `ENABLE_BATFISH_TESTS` / `ENABLE_CONTAINERLAB_TESTS`
+to `true`, or run `iac-tests` / `netops-nightly` via **Run workflow**
+(`workflow_dispatch`). Both upload their artifacts (Batfish answer frames /
+logs, Containerlab inspect / `show bgp summary json` / logs) on every run for
+post-mortem.
+
+Current Batfish assertions (`tests/iac/batfish/batfish_as215932_test.py`): BGP
+session compatibility, iBGP full mesh across the three core routers, unique
+router-IDs, no undefined references, customer segment cannot reach infra
+management, authorized CI can reach management ports. Containerlab
+(`tests/iac/containerlab/`) deploys the core topology and checks FRR/BGP comes
+up. Deeper assertions (no unexpected eBGP, prefix-export hygiene,
+default-route/failover, topology-from-source-of-truth, advertise/withdraw sims)
+are tracked as a follow-up — they need the lab to develop and verify.
+
+## The `iac-gate` and branch protection
+
+`iac-tests.yml` is path-filtered (it only runs when IaC files change). Marking
+a path-filtered job *directly* required risks the classic deadlock: on a PR
+that touches none of those paths the job never reports, and a naive required
+context waits forever.
+
+The fix is the **`iac-gate`** aggregator job (`if: always()`, `needs:` all
+tiers). It is the single required status context:
+
+- It **always reports** when the workflow runs, passing only when the required
+  tiers (`static-iac`, `ansible-idempotency`) succeed and the trusted lab tiers
+  are *success or skipped* — never failed.
+- When the whole workflow is skipped by path filtering (a docs-only PR), GitHub
+  treats the required `iac-gate` context as passing, so the PR is not blocked.
+
+Therefore branch protection requires **`iac-gate`** (plus the lint/render
+contexts from `lint.yml` / `render-check.yml` and `semgrep`), **not** the
+individual path-filtered tier jobs. Verify after any change with a docs-only PR
+that touches none of the IaC paths: it must not show a stuck "Expected" check.
+
+## Adding a check
+
+1. Static contract (preferred): add a `tests/iac/test_*.py` `unittest` case —
+   it runs in Tier 0 automatically, on every IaC PR, for free.
+2. Control-plane property: add a Batfish assertion (Tier 1).
+3. Dynamic/runtime behaviour: extend the Containerlab topology/checks (Tier 2).
+
+Keep Tier 0 stdlib-only (`unittest` + PyYAML); push anything needing Docker or
+the lab into Tiers 1–2 so the unprivileged runner stays dependency-light.

--- a/tests/iac/test_inventory_schema.py
+++ b/tests/iac/test_inventory_schema.py
@@ -1,0 +1,219 @@
+"""Tier-0 source-of-truth schema validation for the AS215932 inventory.
+
+This is the schema gate the Wave 5 plan calls for, implemented stdlib-only
+(``unittest`` + PyYAML) to match the rest of ``tests/iac`` and keep
+``iac-static.sh`` dependency-light — no pydantic/jsonschema runtime dep.
+
+It validates the *structure and internal consistency* of the inventory
+source-of-truth (``hosts.yml`` + ``group_vars/all.yml``) before anything is
+rendered, so addressing drift, a mis-segmented host, or an inconsistency
+between the ``peers`` map and ``hosts.yml`` fails fast instead of producing a
+silently-wrong rendered config. The customer/infra segmentation checks also
+pin the two-runner isolation invariant (ci-pr must live on the customer
+segment, never the infra segment) at the data layer.
+"""
+
+import ipaddress
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+INVENTORY = REPO / "ansible/inventory"
+HOSTS = INVENTORY / "hosts.yml"
+GROUP_VARS = INVENTORY / "group_vars/all.yml"
+
+# Groups whose host entries are *references* to a canonical definition that
+# lives in an OS/role group (linux/openbsd/freebsd/external/xcpng). They carry
+# no ``ansible_host`` of their own.
+REFERENCE_GROUPS = {"routers", "infra_vms", "public_facing", "nameservers"}
+
+PLACEHOLDER_ADDRS = {"0.0.0.0", "::"}
+
+
+def _ip(value):
+    return ipaddress.ip_address(value)
+
+
+def _net(value):
+    return ipaddress.ip_network(value)
+
+
+class InventorySchemaTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.inv = yaml.safe_load(HOSTS.read_text())
+        cls.vars = yaml.safe_load(GROUP_VARS.read_text())
+
+        children = cls.inv["all"]["children"]
+        cls.groups = {
+            name: dict((g or {}).get("hosts") or {}) for name, g in children.items()
+        }
+
+        # Canonical ansible_host per host, gathered from every group that
+        # actually defines one. A host may appear in several groups; only the
+        # definition(s) carrying ansible_host count.
+        cls.host_addr = {}
+        for hosts in cls.groups.values():
+            for host, data in hosts.items():
+                if isinstance(data, dict) and data.get("ansible_host"):
+                    cls.host_addr.setdefault(host, data["ansible_host"])
+
+        cls.infra = _net(cls.vars["infra_subnet"])
+        cls.customer = _net(cls.vars["customer_subnet"])
+        cls.prefix = _net(cls.vars["as215932_prefix"])
+        cls.loopbacks = _net(cls.vars["router_loopback_subnet"])
+
+    # ---- structure -------------------------------------------------------
+
+    def test_inventory_parses_with_expected_top_level_groups(self):
+        expected = {
+            "linux",
+            "external",
+            "openbsd",
+            "freebsd",
+            "routers",
+            "xcpng",
+            "infra_vms",
+            "public_facing",
+            "nameservers",
+        }
+        self.assertTrue(expected.issubset(set(self.groups)))
+
+    def test_every_referenced_host_has_a_canonical_address(self):
+        for group in REFERENCE_GROUPS:
+            for host in self.groups[group]:
+                with self.subTest(group=group, host=host):
+                    self.assertIn(
+                        host,
+                        self.host_addr,
+                        f"{host} is referenced by group '{group}' but has no "
+                        f"ansible_host definition in any OS/role group",
+                    )
+
+    def test_ansible_hosts_are_valid_and_unique(self):
+        seen = {}
+        for host, addr in self.host_addr.items():
+            with self.subTest(host=host):
+                ip = _ip(addr)  # raises if malformed
+                if addr in PLACEHOLDER_ADDRS:
+                    continue
+                self.assertNotIn(
+                    addr,
+                    seen,
+                    f"{host} reuses ansible_host {addr} already used by {seen.get(addr)}",
+                )
+                seen[addr] = host
+                self.assertFalse(ip.is_loopback, f"{host} ansible_host is loopback")
+
+    # ---- segmentation / isolation invariants ----------------------------
+
+    def test_infra_vms_live_on_the_infra_segment(self):
+        for host in self.groups["infra_vms"]:
+            addr = self.host_addr[host]
+            with self.subTest(host=host):
+                self.assertIn(
+                    _ip(addr),
+                    self.infra,
+                    f"infra VM {host} ({addr}) is outside infra_subnet {self.infra}",
+                )
+
+    def test_ci_pr_runner_is_isolated_on_the_customer_segment(self):
+        # The two-runner security model requires the unprivileged PR runner to
+        # sit on the customer-isolated segment, never the infra segment.
+        addr = self.host_addr["ci-pr"]
+        ip = _ip(addr)
+        self.assertIn(ip, self.customer, f"ci-pr ({addr}) must be in customer_subnet")
+        self.assertNotIn(ip, self.infra, f"ci-pr ({addr}) must NOT be in infra_subnet")
+        self.assertNotIn(
+            "ci-pr",
+            self.groups["infra_vms"],
+            "ci-pr must not be a member of the infra_vms group",
+        )
+
+    def test_routers_group_is_exactly_the_three_routers(self):
+        self.assertEqual(set(self.groups["routers"]), {"rtr", "cr1-nl1", "cr1-de1"})
+
+    def test_nameservers_are_a_subset_of_public_facing(self):
+        ns = set(self.groups["nameservers"])
+        self.assertEqual(ns, {"dns", "ns2"})
+        self.assertTrue(ns.issubset(set(self.groups["public_facing"])))
+
+    # ---- subnet plan -----------------------------------------------------
+
+    def test_subnets_nest_under_the_allocation_and_are_disjoint(self):
+        named = {
+            "infra_subnet": self.infra,
+            "customer_subnet": self.customer,
+            "router_loopback_subnet": self.loopbacks,
+            "vpn_clients_subnet": _net(self.vars["vpn_clients_subnet"]),
+            "wg_link_prefix": _net(self.vars["wg_link_prefix"]),
+        }
+        for name, net in named.items():
+            with self.subTest(subnet=name):
+                self.assertTrue(
+                    net.subnet_of(self.prefix),
+                    f"{name} {net} is not within as215932_prefix {self.prefix}",
+                )
+        items = list(named.items())
+        for i in range(len(items)):
+            for j in range(i + 1, len(items)):
+                (na, a), (nb, b) = items[i], items[j]
+                with self.subTest(pair=f"{na}|{nb}"):
+                    self.assertFalse(
+                        a.overlaps(b), f"{na} {a} overlaps {nb} {b}"
+                    )
+
+    # ---- peers <-> hosts consistency -------------------------------------
+
+    def test_peer_addresses_match_host_inventory(self):
+        # Where a peer carries an in-allocation ipv6 and names a real host
+        # (underscores normalised to hyphens), it must equal that host's
+        # ansible_host — catches drift between the peers map and hosts.yml.
+        for name, data in self.vars["peers"].items():
+            host = name.replace("_", "-")
+            v6 = data.get("ipv6")
+            if not v6 or v6 in PLACEHOLDER_ADDRS:
+                continue
+            if _ip(v6) not in self.prefix:
+                continue  # external peer (e.g. ns2) — not an inventory host addr
+            if host not in self.host_addr:
+                continue
+            with self.subTest(peer=name):
+                self.assertEqual(
+                    v6,
+                    self.host_addr[host],
+                    f"peer {name} ipv6 {v6} != hosts.yml {host} {self.host_addr[host]}",
+                )
+
+    def test_router_loopbacks_live_in_the_loopback_subnet(self):
+        for name in ("rtr", "cr1_nl1", "cr1_de1"):
+            lo = self.vars["peers"][name].get("loopback")
+            with self.subTest(peer=name):
+                self.assertIsNotNone(lo, f"{name} has no loopback")
+                self.assertIn(
+                    _ip(lo),
+                    self.loopbacks,
+                    f"{name} loopback {lo} outside {self.loopbacks}",
+                )
+
+    def test_bgp_neighbors_are_external_global_addresses(self):
+        # eBGP neighbor addresses must be valid, global, and NOT inside our own
+        # allocation (a neighbor in as215932_prefix would be a config error).
+        for name, addr in self.vars["bgp_peers"].items():
+            with self.subTest(neighbor=name):
+                ip = _ip(addr)
+                self.assertTrue(ip.is_global, f"{name} {addr} is not a global address")
+                self.assertNotIn(
+                    ip,
+                    self.prefix,
+                    f"eBGP neighbor {name} {addr} is inside our own {self.prefix}",
+                )
+
+    def test_ssh_users_has_a_default(self):
+        self.assertIn("default", self.vars["ssh_users"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Wave 5 of the CI/CD modernization — NetOps maturity, layered on the merged Wave 4 two-runner placement.

- **Tier-0 source-of-truth schema gate** — `tests/iac/test_inventory_schema.py` (stdlib `unittest` + PyYAML, no new deps; runs inside the existing `static-iac` discovery on the unprivileged runner). Validates inventory structure/consistency before render: canonical addresses, validity+uniqueness, infra-VM segmentation, the **ci-pr customer-segment isolation invariant**, subnet nesting/disjointness, `peers`↔`hosts.yml` agreement, router loopbacks, external eBGP neighbours. 12 tests.
- **Tiered `iac-tests.yml` + `iac-gate`** — explicit tiers (0 static on `ci-pr`; 1 Batfish / 2 Containerlab on privileged `ci`, trusted-only). New always-reporting **`iac-gate`** aggregator is the single context to mark required in branch protection — deadlock-safe for path-filtered/docs-only PRs (acceptance #7). Lab tiers upload artifacts.
- **`netops-nightly.yml`** — gives Batfish + Containerlab a nightly cadence on the privileged runner (Stage 1: manual + nightly), with artifacts + Discord NOC alert. No overlap with `drift-detection.yml` / `render-check.yml`.
- **`docs/netops/testing-strategy.md`** — documents the tiers, the gate, and how to enable the labs.

## Verification
- `python3 -m unittest discover -s tests/iac` → **41 passed** locally (29 → 41).
- `yamllint` clean on both new workflows; the Wave 4 runner-placement contract test still passes (batfish/containerlab keep the privileged label only because they are `if`-gated off `pull_request`; `iac-gate` is on the unprivileged label).
- Deep Batfish/Containerlab assertion expansion (no-unexpected-eBGP, prefix-export hygiene, default-route/failover, topology-from-SoT, advertise/withdraw sims) needs the lab to develop+verify → tracked as a follow-up issue, not shipped unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)