### PR TITLE
docs(ci): security model, PR-Agent, Semgrep, branch protection (Wave 6)

### DIFF
--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -1,0 +1,79 @@
+# Branch protection — required checks per repo
+
+Current `main` protection across the org (set in Wave 6). PR-Agent is **never**
+required (advisory, same-repo-only — requiring it would wedge fork/dependabot
+PRs). Semgrep is required as a *presence* gate while reporting-only; flip it to
+a blocking gate per `docs/ci/semgrep.md` once each repo's baseline is triaged.
+
+| Repo | Required checks | strict | reviews | enforce_admins |
+|------|-----------------|:------:|:-------:|:--------------:|
+| `network-operations` | `yamllint, ansible-lint, shellcheck, jinja-syntax, render, iac-gate, semgrep` | ✓ | 1 | off |
+| `hyrule-web` | `test, frontend` | ✓ | 1 | off |
+| `hyrule-cloud` | `test, semgrep` | ✓ | 0 | off |
+| `noc-agent` | `semgrep` | ✓ | 0 | off |
+| `hyrule-mcp` | `semgrep` | ✓ | 0 | off |
+| `as215932.net` | `semgrep` | ✓ | 0 | off |
+
+`Sourcery review` was removed from `network-operations` **before** the
+`sourcery-ai` app was uninstalled (no window where merges blocked on a check
+that could never report). The app is gone (`gh api orgs/AS215932/installations`
+lists only `claude-for-github`, `claude`).
+
+## Why these settings
+
+- **No required reviews on the four newly-protected repos** (and `enforce_admins`
+  off everywhere): this is a solo-maintainer org. Requiring an approval with no
+  second maintainer forces an `--admin` bypass on every merge (self-approval is
+  forbidden) and risks a merge lockout. `network-operations`/`hyrule-web` keep
+  their pre-existing 1-review rule; the rest protect via status checks + no
+  force-push/deletion. Tighten later when there's a second reviewer. The
+  `@AS215932/ops` team exists and backs `.github/CODEOWNERS`, but
+  `require_code_owner_reviews` is intentionally left **off** for now.
+- **`semgrep`-only on `noc-agent`/`hyrule-mcp`/`as215932.net`**: those repos have
+  no test/lint workflow yet — `semgrep` is the only existing green check. Adding
+  a real `ruff`+`pytest` gate (uv-managed 3.14, deselect `test_live_smoke.py`)
+  is tracked as follow-up, after which it should be added as required.
+
+## The `iac-gate` deadlock guard (acceptance #7)
+
+`network-operations` requires **`iac-gate`**, not the individual Tier-0 jobs.
+`iac-tests.yml` is path-filtered (runs only when IaC files change), so a
+docs-only PR doesn't trigger it. GitHub treats a required check whose workflow
+is **skipped by path/branch filtering as passing**, so such a PR is not wedged.
+This is already proven on this repo: `render` (from the path-filtered
+`render-check.yml`) has long been required and docs-only PRs merge fine.
+`iac-gate` behaves identically. Always re-verify after changing required checks
+with a docs-only PR that touches none of the IaC paths — it must not show a
+stuck "Expected" check. (This very doc set was merged as that verification PR.)
+
+`iac-gate` itself (`if: always()`, `needs:` all tiers) passes only when the
+required tiers succeed and the trusted lab tiers are success-or-skipped — see
+`docs/netops/testing-strategy.md`.
+
+## Reproducing the protection
+
+```bash
+# Four repos protected on existing green contexts (no required reviews):
+gh api -X PUT repos/AS215932/<repo>/branches/main/protection --input - <<'EOF'
+{ "required_status_checks": {"strict": true, "contexts": [...]},
+  "enforce_admins": false, "required_pull_request_reviews": null,
+  "restrictions": null, "allow_force_pushes": false, "allow_deletions": false }
+EOF
+
+# Add a context to an already-protected repo without disturbing the rest:
+gh api -X POST repos/AS215932/network-operations/branches/main/protection/required_status_checks/contexts \
+  -f 'contexts[]=iac-gate' -f 'contexts[]=semgrep'
+```
+
+## admin:org token — revoke when done
+
+The org-level changes (runner groups, `OPENROUTER_API_KEY` secret, `ops` team,
+Sourcery removal, these protection edits) are the *only* steady-state need for
+`admin:org`. Once branch protection is settled, downscope the token:
+
+```bash
+gh auth refresh -h github.com --reset-scopes   # resets to repo,read:org,gist,workflow
+```
+
+(or revoke the "GitHub CLI" OAuth grant in github.com → Settings → Applications
+and re-login with minimal scopes).

--- a/docs/ci/pr-agent.md
+++ b/docs/ci/pr-agent.md
@@ -1,0 +1,60 @@
+# PR-Agent (advisory AI review)
+
+PR-Agent replaces the hosted Sourcery app with a self-controlled reviewer that
+uses **our own OpenRouter key**. It is advisory only — read + PR/issue-comment
+permissions, never deploys, never writes code, never auto-merges, and is **not**
+a required check.
+
+- Action: `The-PR-Agent/pr-agent@0bd56c0508504c718cc03d504cd4ceb6725ba3c7` (v0.35.0, Docker-based), SHA-pinned.
+- Runner: `hyrule-public-pr` (unprivileged `ci-pr`) only.
+- Model: primary `openrouter/deepseek/deepseek-v4-flash`, fallback `openrouter/minimax/minimax-m2.7`.
+- Key: `OPENROUTER_API_KEY` org secret (visibility = the six repos), delivered per-job as `OPENROUTER__KEY`.
+- Config: `.pr_agent.toml` per repo (model, fallback, `extra_instructions`).
+
+## The model-pin gotcha (important)
+
+PR-Agent reads `.pr_agent.toml` from the **default branch**, not the PR head
+(its action has no checkout step; "Applying repo settings" loads from the
+default branch). So until a new repo's `.pr_agent.toml` is merged to `main`,
+PR-Agent silently falls back to its packaged default (`gpt-5.5…` → `gpt-5.4-mini`)
+and the gpt-5.5 call errors "not a valid model ID".
+
+Fix = pin via dynaconf env in `pr-agent.yml` `env:` (double-underscore, same path
+that delivers `OPENROUTER__KEY`), which is honoured immediately:
+
+```yaml
+CONFIG__MODEL: openrouter/deepseek/deepseek-v4-flash
+CONFIG__FALLBACK_MODELS: '["openrouter/minimax/minimax-m2.7"]'
+CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
+```
+
+Both models are *custom* (litellm) models → `custom_model_max_tokens` is
+required. Keep the env pin even after `.pr_agent.toml` lands (belt and braces).
+
+## Fork / trust policy
+
+```yaml
+if: >
+  (github.event_name == 'pull_request' &&
+   github.event.pull_request.head.repo.full_name == github.repository) ||
+  (github.event_name == 'issue_comment' &&
+   github.event.issue.pull_request &&
+   startsWith(github.event.comment.body, '/') &&
+   contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+```
+
+Auto-review only for same-repo PRs; slash commands (`/review`, `/improve`,
+`/ask`) only from trusted authors. This keeps `OPENROUTER_API_KEY` off fork PRs
+and stops random users burning OpenRouter budget. Auto-review fires on
+`opened`/`reopened`/`ready_for_review` — to re-run on an existing PR, close and
+reopen it (a bare `synchronize` push is intentionally skipped).
+
+## Triage
+
+- **Wrong model / "not a valid model ID"** → the env pin is missing or
+  `.pr_agent.toml` isn't on the default branch. Check the run's "Applying repo
+  settings" log; confirm `CONFIG__MODEL` is in `env:`.
+- **No comment posted** → check the `if:` (fork PR? untrusted commenter?) and
+  that the job ran on `hyrule-public-pr`.
+- **OpenRouter spend / noise** → it's advisory; tune `.pr_agent.toml`
+  `extra_instructions`, never make it a required check.

--- a/docs/ci/security-model.md
+++ b/docs/ci/security-model.md
@@ -1,0 +1,69 @@
+# CI/CD security model — the two-runner architecture
+
+AS215932 CI runs on self-hosted runners with reach into a production ISP
+network. The governing rule: **untrusted PR code and the LLM reviewer never
+touch deploy credentials or the production network.** That is enforced by
+splitting work across two runner classes.
+
+## The two runners
+
+| | `ci` (privileged) | `ci-pr` (unprivileged) |
+|---|---|---|
+| Host | `ci` VM, infra segment `2a0c:b641:b50:2::d0` | `ci-pr` VM, **customer** segment `2a0c:b641:b51::c1` |
+| Labels | `hyrule`, `hyrule-infra` | `hyrule-public-pr` |
+| Org runner group | `hyrule-ci` | `public-pr` |
+| Vault / `id_ci` / `secrets.env` | yes | **no** |
+| Reach to infra mgmt | yes | **no** (customer-isolated) |
+| Docker / Containerlab | yes | Docker only |
+| Runs | deploy/apply, Vault-backed Ansible, `production` jobs, Batfish/Containerlab labs | PR-Agent, Semgrep, all untrusted-PR test/lint jobs |
+
+`ci-pr` is treated as **disposable and potentially attacker-controlled**: it
+runs untrusted PR code and keeps Docker, so a malicious PR may be able to root
+it — and that must not matter. Nothing of value lives there (no Vault, no
+`id_ci`, no `secrets.env`, no mgmt route, no privileged bind-mounts). The
+inventory schema gate (`tests/iac/test_inventory_schema.py`) pins the data-layer
+half of this invariant: `ci-pr` must be in `customer_subnet` and never in
+`infra_subnet`.
+
+## Enforcement is layered (runner groups are necessary but not sufficient)
+
+Runner-group ACLs control *which repositories* may target a runner class. They
+do **not**, by themselves, stop a workflow inside a repo permitted to both
+groups from selecting the wrong label. Job-level separation is the combination
+of:
+
+1. **Runner groups** (`public-pr` → all six repos; `hyrule-ci` → only repos that
+   deploy). A repo not in a group can't use it even if a workflow names the label.
+2. **Trigger discipline** — privileged labels (`hyrule`/`hyrule-infra`) appear
+   only in trusted `push`/`workflow_dispatch`/`schedule`/deploy/`environment`
+   jobs, **never** in a `pull_request` job. The heavy labs keep the privileged
+   label only because they are `if`-gated off `pull_request`
+   (`workflow_dispatch` / repo var).
+3. **Contract test** — `tests/iac/test_vault_and_runner_contracts.py`
+   (`test_pull_request_jobs_use_the_unprivileged_runner`) fails CI if any
+   `pull_request` job uses a privileged label without that if-gate, and
+   (`test_privileged_deploy_workflows_stay_on_ci_runner`) that apply/drift stay
+   on `ci` and never leak onto `ci-pr`.
+4. **CODEOWNERS** (`.github/CODEOWNERS` → `@AS215932/ops`) on workflows + the
+   high-blast-radius router/firewall configs.
+5. **Branch protection** (`docs/ci/branch-protection.md`).
+6. **Semgrep** flags `pull_request_target`, `permissions: write-all`, unpinned
+   third-party actions, and privileged-runner use in PR workflows.
+
+No `pull_request_target` anywhere. Least-privilege `permissions:` on every job.
+
+## The Wave 4 migration guard
+
+Before any `network-operations` job was moved from `ci` to `ci-pr`, it was
+proven unprivileged: no Vault read, no `secrets.env` source, no `id_ci`, no
+mgmt-overlay reach, no privileged Docker/Containerlab, repo-local files +
+normal toolchain only. Jobs that fail any check stay on `ci` (the Batfish and
+Containerlab labs) and are classified trusted-only. See
+`docs/netops/testing-strategy.md` for the resulting tier placement.
+
+## Public-fork policy
+
+Repos are public and PR-Agent needs `OPENROUTER_API_KEY`. External-fork PRs do
+**not** receive the secret and do **not** get LLM review; PR-Agent auto-runs
+only for same-repo PRs and slash commands only from
+`OWNER`/`MEMBER`/`COLLABORATOR`. See `docs/ci/pr-agent.md`.

--- a/docs/ci/semgrep.md
+++ b/docs/ci/semgrep.md
@@ -1,0 +1,47 @@
+# Semgrep (token-less SAST)
+
+Semgrep is the real security gate (PR-Agent is advisory). It runs token-less —
+no `SEMGREP_APP_TOKEN`, no dashboard — and uploads SARIF to GitHub Code Scanning
+(free for public repos).
+
+- Image: `semgrep/semgrep@sha256:bc8b15e245d7bd392bcadce7ef4db36601b375fab35bfd8070ed8ae3d7824c74`, pinned by digest, run via `docker run` (not a job `container:`, so the Node-based upload-sarif action runs in the normal runner env).
+- Upload: `github/codeql-action/upload-sarif@84498526a009a99c875e83ef4821a8ba52de7c22`.
+- Runner: `hyrule-public-pr` (unprivileged).
+- Triggers: every PR, `workflow_dispatch`, push on workflow/rule changes, nightly cron.
+
+## Reporting-only baseline → gate
+
+The `Run Semgrep` step is `continue-on-error: true` during the baseline, so
+findings land in the Security tab without failing the job. The `semgrep` job
+itself therefore (almost) always reports success — which is why it is safe to
+require as a status check now: it guarantees the scan *runs* on every PR.
+
+To turn Semgrep into a true blocking gate once the baseline is triaged: drop
+`continue-on-error` from the scan step (or use `semgrep ci --error`). Do this
+per repo only after the existing findings are reviewed — don't block on
+historical findings. Recommended progression: baseline (reporting-only) → block
+new high-severity → high-confidence medium+ on the security-sensitive repos
+(`hyrule-cloud`, `noc-agent`, `hyrule-mcp`).
+
+## Packs
+
+Curated `p/` rulesets per stack (`p/ci`, `p/github-actions`, `p/secrets`, plus
+`p/python` / `p/javascript` / `p/typescript` as relevant). The Actions rules are
+the security-critical ones for this org: they flag `pull_request_target`,
+`permissions: write-all`, unpinned third-party actions, `curl | sh`, secrets
+echoed to logs, and self-hosted-runner use on PR workflows.
+
+## Fork note
+
+Code Scanning SARIF upload may be restricted on external fork PRs (no
+`security-events: write`). For fork PRs, surface findings via the job log /
+`$GITHUB_STEP_SUMMARY` so they remain visible without org secrets. The upload
+step is `if: always() && hashFiles('semgrep.sarif') != ''` + `continue-on-error`
+so a restricted upload never fails the job.
+
+## Triage
+
+- **SARIF not in Security tab** → check the upload step ran and `security-events:
+  write` is granted; on forks this is expected to be unavailable (see above).
+- **Job red unexpectedly** → during baseline the scan step can't fail the job;
+  a red `semgrep` job means the *upload* or Docker run errored, not a finding.


### PR DESCRIPTION
## Summary
Wave 6 docs for the CI/CD modernization:
- `docs/ci/security-model.md` — two-runner architecture + layered enforcement
- `docs/ci/pr-agent.md` — model-pin gotcha, fork/trust policy, triage
- `docs/ci/semgrep.md` — token-less SARIF, reporting-only → gate, triage
- `docs/ci/branch-protection.md` — per-repo required-check matrix, iac-gate deadlock guard, admin:org downscope

## Doubles as the acceptance-#7 verification
This is a **docs-only PR** (touches only `docs/ci/**`, none of the IaC paths
`ansible/** configs/** scripts/ci/** tests/**`). It confirms the path-filtered
required checks (`iac-gate`, `render`) are treated as passing rather than
wedging the PR — i.e. branch protection does not depend on a path-filtered job
that may never report a context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)