### PR TITLE
apply.yml: mask Vault-rendered secrets in CI logs (#148)

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -87,8 +87,18 @@ jobs:
           # here so playbooks pick up DISCORD_WEBHOOK_URL, ICINGA_API_*, etc.
           if [ -r /etc/github-runner/secrets.env ]; then
             set -a; . /etc/github-runner/secrets.env; set +a
-            # Re-export for subsequent steps via GITHUB_ENV.
-            grep -E '^[A-Z_][A-Z0-9_]*=' /etc/github-runner/secrets.env >> "$GITHUB_ENV"
+            # Mask each value in the run log BEFORE exporting to later steps.
+            # Values placed in $GITHUB_ENV are otherwise echoed in plaintext in
+            # every subsequent step's "env:" group (network-operations#148).
+            while IFS='=' read -r _key _; do
+              case "$_key" in
+                [A-Z_][A-Z0-9_]*)
+                  _val="${!_key}"
+                  [ -n "$_val" ] && echo "::add-mask::$_val"
+                  printf '%s=%s\n' "$_key" "$_val" >> "$GITHUB_ENV"
+                  ;;
+              esac
+            done < /etc/github-runner/secrets.env
           else
             echo "::warning::/etc/github-runner/secrets.env not found — apply may fail on env-var lookups"
           fi


### PR DESCRIPTION
## What

`apply.yml`'s "Source Vault-rendered secrets" step appended `secrets.env`
`KEY=VALUE` lines straight into `$GITHUB_ENV`. GitHub echoes every `$GITHUB_ENV`
var in plaintext in each subsequent step's `env:` group, so `ICINGA_API_PASSWORD`
and `DISCORD_WEBHOOK_URL` leaked into the run logs (and the `snapshots-*` artifacts).

## Fix

Source the file, then for each `KEY` emit `::add-mask::<value>` **before** writing
it to `$GITHUB_ENV` — values are redacted in all subsequent log output while still
reaching the playbook steps. Quoting and `=`-in-value are handled by the shell's
own parse (indirect expansion; runner shell is bash). Verified under bash that the
mask directives fire and `$GITHUB_ENV` is repopulated intact.

## Note

The previously-leaked plaintext is being scrubbed separately by deleting the
affected `apply.yml` run logs + artifacts. Per operator decision the exposed
credentials are **not** being rotated at this time.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)