### PR TITLE
frr role: clear soft in the overlay VRF on rtr (#150)

### DIFF
--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -7,6 +7,14 @@
 #     not the mgmt link-local one (enX0 has no DNS to advertise).
 networkd_primary_unit: "10-enX2"
 
+# --- FRR role override ---
+# rtr runs BGP in the overlay VRF, so the frr role's post-reload soft clear must
+# target it. The role default (`clear bgp ipv6 unicast * soft`) hits the empty
+# default VRF and is a no-op here. See network-operations#150. (rtr's iBGP peers
+# carry no inbound route-maps today, so this only matters once rtr gains inbound
+# policy — e.g. future peering — but keep it correct.)
+frr_clear_bgp_cmd: "vtysh -c 'clear bgp vrf overlay ipv6 unicast * soft'"
+
 # --- IPv4 variables for the preserved nat/forward block ---
 rtr_wan_ip:   "46.105.40.223"
 rtr_wan_if:   "enX4"


### PR DESCRIPTION
## What

rtr runs BGP in **`vrf overlay`**, but the frr role's default `frr_clear_bgp_cmd`
(`vtysh -c 'clear bgp ipv6 unicast * soft'`) targets the **default** VRF, which has
no BGP instance on rtr — so the post-reload soft clear was a no-op there. Override
it in `host_vars/rtr.yml` to target `vrf overlay`.

## Impact check

rtr's iBGP peers carry **no inbound route-maps** (next-hop-self +
soft-reconfiguration inbound only), so the earlier no-op clear had **no functional
impact**. Verified via MCP: rtr is converged and healthy — both iBGP peers
Established, `Up 1d22h46m` (no flap). This fix keeps the clear correct for when rtr
gains inbound policy (e.g. future IX peering).

No redeploy needed now (no pending rtr config change); the override applies on
rtr's next frr-role apply.

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)