### PR TITLE
icinga2: deploy icinga-snapshot helper to make the deploy bracket work (#149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ __pycache__/
 # (knot is not in render-all.sh's default set, so untracking it doesn't weaken
 # the render guard.)
 ansible/generated/**/knot.conf
+
+# Deploy-bracket Icinga snapshots are runtime state captured on the runner during
+# an apply (network-operations#149), not desired state — never commit them.
+ansible/generated/snapshots/

--- a/ansible/generated/mon/icinga2/icinga-snapshot.env
+++ b/ansible/generated/mon/icinga2/icinga-snapshot.env
@@ -1,0 +1,7 @@
+# /etc/icinga2/scripts/.icinga-snapshot.env — managed by ansible (roles/icinga2)
+# Sourced by /usr/local/bin/icinga-snapshot to query the local icinga2 API as the
+# read-only noc-agent ApiUser. Mode 0640 nagios:nagios; root reads it via the
+# deploy bracket's become. Never commit the rendered file.
+ICINGA_API_URL=https://localhost:5665
+ICINGA_API_USER=noc-agent
+ICINGA_API_PASS=__REDACTED_ICINGA_API_PASSWORD__

--- a/ansible/roles/firewall/tasks/snapshot.yml
+++ b/ansible/roles/firewall/tasks/snapshot.yml
@@ -1,22 +1,39 @@
 ---
-# Pre/post Icinga snapshot — calls a small script on mon to capture
-# current problem state. Used to diff "what was broken before" vs "after".
+# Pre/post Icinga snapshot — captures the current HARD-state problem list from
+# mon and writes it to the controller's ansible/generated/snapshots/<phase>/ so
+# the apply.yml "Capture snapshot diff" step can compare pre vs post and surface
+# regressions the rollout introduced.
 #
-# Skipped silently if mon is unreachable or the script doesn't exist yet;
-# this keeps the firewall play usable before the icinga_master role lands.
+# The helper (/usr/local/bin/icinga-snapshot) and its API creds are deployed by
+# the icinga2 role. Degrades gracefully (failed_when: false) — a missing helper,
+# unreachable mon, or empty problem set just yields an empty snapshot, keeping
+# the play usable. See network-operations#149.
 #
 # Connects as mon's inventory user (svag from the workstation, ci from the
-# runner) and escalates with sudo — never a hardcoded root login, which only
-# ever worked with the operator's broadly-authorized id_servify.
+# runner) and escalates with sudo — never a hardcoded root login.
 
-- name: "{{ snapshot_phase | capitalize }}-deploy Icinga snapshot"
+- name: "Capture {{ snapshot_phase }}-deploy Icinga problem state on mon"
   delegate_to: mon
   become: true
   shell: |
     if [ -x /usr/local/bin/icinga-snapshot ]; then
-      /usr/local/bin/icinga-snapshot {{ snapshot_phase }} firewall-rollout
+      /usr/local/bin/icinga-snapshot
     else
       echo "skip: /usr/local/bin/icinga-snapshot not present yet"
     fi
+  register: _icinga_snapshot
+  changed_when: false
+  failed_when: false
+
+- name: "Write {{ snapshot_phase }} snapshot to the controller for diffing"
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: |
+      # icinga {{ snapshot_phase }}-deploy snapshot — HARD-state service problems
+      {{ _icinga_snapshot.stdout | default('') }}
+    dest: "{{ playbook_dir }}/../generated/snapshots/{{ snapshot_phase }}/icinga.txt"
+    mode: "0644"
   changed_when: false
   failed_when: false

--- a/ansible/roles/icinga2/tasks/install.yml
+++ b/ansible/roles/icinga2/tasks/install.yml
@@ -60,6 +60,35 @@
   notify: validate and reload icinga2
   tags: [apply]
 
+# --- Deploy-bracket snapshot helper (network-operations#149) ---
+- name: Ensure icinga-snapshot helper dependencies (jq, curl)
+  package:
+    name:
+      - jq
+      - curl
+    state: present
+  tags: [apply]
+
+- name: Install icinga-snapshot helper to /usr/local/bin
+  copy:
+    src: "{{ icinga2_repo_configs }}/scripts/icinga-snapshot"
+    dest: /usr/local/bin/icinga-snapshot
+    owner: root
+    group: root
+    mode: "0755"
+  tags: [apply]
+
+- name: Render icinga-snapshot API creds (read-only noc-agent ApiUser)
+  template:
+    src: icinga-snapshot.env.j2
+    dest: "{{ icinga2_scripts_dir }}/.icinga-snapshot.env"
+    owner: nagios
+    group: nagios
+    mode: "0640"
+  no_log: true
+  when: icinga2_noc_agent_api_password | default('') | length > 0
+  tags: [apply]
+
 - name: Install notifications.conf (templated — carries webhook secret)
   template:
     src: notifications.conf.j2

--- a/ansible/roles/icinga2/tasks/render.yml
+++ b/ansible/roles/icinga2/tasks/render.yml
@@ -26,6 +26,18 @@
   become: false
   tags: [validate, diff, apply]
 
+- name: Render icinga-snapshot.env (review — API password redacted)
+  template:
+    src: icinga-snapshot.env.j2
+    dest: "{{ playbook_dir }}/../generated/mon/icinga2/icinga-snapshot.env"
+    mode: "0640"
+  vars:
+    icinga2_noc_agent_api_password: "__REDACTED_ICINGA_API_PASSWORD__"
+  delegate_to: localhost
+  connection: local
+  become: false
+  tags: [validate, diff, apply]
+
 - name: Pre-flight — fail if discord webhook URL is empty for apply
   fail:
     msg: |

--- a/ansible/roles/icinga2/templates/icinga-snapshot.env.j2
+++ b/ansible/roles/icinga2/templates/icinga-snapshot.env.j2
@@ -1,0 +1,7 @@
+# /etc/icinga2/scripts/.icinga-snapshot.env — managed by ansible (roles/icinga2)
+# Sourced by /usr/local/bin/icinga-snapshot to query the local icinga2 API as the
+# read-only noc-agent ApiUser. Mode 0640 nagios:nagios; root reads it via the
+# deploy bracket's become. Never commit the rendered file.
+ICINGA_API_URL=https://localhost:5665
+ICINGA_API_USER=noc-agent
+ICINGA_API_PASS={{ icinga2_noc_agent_api_password }}

--- a/configs/mon/icinga2/scripts/icinga-snapshot
+++ b/configs/mon/icinga2/scripts/icinga-snapshot
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Deploy path: /usr/local/bin/icinga-snapshot (also copied to
+# /etc/icinga2/scripts/ by roles/icinga2). Managed by ansible (roles/icinga2).
+#
+# Emit a stable, sorted list of the current HARD-state Icinga service problems
+# (host!service + numeric state) to stdout. The frr/firewall deploy bracket
+# captures this before and after a change and diffs the two to catch regressions
+# the rollout introduced (network-operations#149).
+#
+# Reads the local icinga2 API as the read-only `noc-agent` ApiUser (creds in
+# /etc/icinga2/scripts/.icinga-snapshot.env, rendered by the icinga2 role).
+# Degrades gracefully — any missing dependency or API error exits 0 with empty
+# output, so it never fails a deploy (the caller uses failed_when: false too).
+
+set -eu
+
+env_file=/etc/icinga2/scripts/.icinga-snapshot.env
+if [ ! -r "$env_file" ]; then
+  echo "icinga-snapshot: $env_file missing (run the icinga2 role)" >&2
+  exit 0
+fi
+# shellcheck disable=SC1090
+. "$env_file"
+
+: "${ICINGA_API_URL:=https://localhost:5665}"
+: "${ICINGA_API_USER:?ICINGA_API_USER unset in env file}"
+: "${ICINGA_API_PASS:?ICINGA_API_PASS unset in env file}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "icinga-snapshot: jq not installed" >&2
+  exit 0
+fi
+
+# Services not OK (state != 0) and in a HARD state (state_type == 1). POST with a
+# GET override carries the filter as a JSON body (cleaner than URL-encoding).
+resp=$(curl -fsS -k \
+  -u "${ICINGA_API_USER}:${ICINGA_API_PASS}" \
+  -H 'Accept: application/json' \
+  -H 'X-HTTP-Method-Override: GET' \
+  -d '{"filter":"service.state!=0 && service.state_type==1","attrs":["state"],"joins":["host.name"]}' \
+  "${ICINGA_API_URL}/v1/objects/services" 2>/dev/null) || {
+  echo "icinga-snapshot: icinga2 API query failed" >&2
+  exit 0
+}
+
+printf '%s' "$resp" | jq -r '.results[]? | "\(.name)\tstate=\(.attrs.state)"' | sort


### PR DESCRIPTION
## What

The pre/post Icinga snapshot bracket (`roles/firewall/tasks/snapshot.yml`, reused
by every apply playbook) was a **silent no-op** — the helper never existed on mon,
and the task never returned its output to the runner's `ansible/generated/snapshots/`
where `apply.yml`'s "Capture snapshot diff" reads (it warned `no snapshots directory found`).

## Changes

- **`configs/mon/icinga2/scripts/icinga-snapshot`** — queries the local icinga2 API
  as the read-only `noc-agent` ApiUser (`objects/query/Service`) and emits a stable,
  sorted list of HARD-state service problems. Degrades gracefully (exit 0 / empty)
  on any missing dep or API error, so it never fails a deploy.
- **icinga2 role** installs it to `/usr/local/bin/icinga-snapshot`, ensures `jq`/`curl`,
  and renders the API creds to `/etc/icinga2/scripts/.icinga-snapshot.env`
  (`0640 nagios`, `no_log`; redacted in the `generated/` review artifact).
- **`snapshot.yml` rewrite** — capture on mon, then write to
  `generated/snapshots/<phase>/icinga.txt` on the controller so the diff step
  compares pre vs post.
- `.gitignore` the runtime `generated/snapshots/` dir.

## Validation

`sh -n` (helper) · yamllint · `ansible-playbook --syntax-check` (icinga2 + firewall) ·
icinga2 render dry-run produces the redacted env · 41 IaC tests — all green.

## Not yet done (needs live)

This is **static-validated only**. To activate + confirm end-to-end it needs:
1. An `icinga2` role apply to mon (`apply.yml -F playbook=icinga2 -F limit=mon`) to
   install the helper + creds.
2. One real bracketed apply to confirm the API query returns + the pre/post diff
   renders. (Current problem set is empty, so the first snapshots will be empty —
   that's correct.)

Leaving #149 open until that live check passes.

Refs #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)