### PR TITLE
ci: fix dynamic FRR validators — batfish --network host + IPv6 xfails, containerlab sudo (#143)

### DIFF
--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -145,6 +145,9 @@ github_runner_containerlab_deb_url: >-
 github_runner_containerlab_deb_path: >-
   {{ github_runner_bootstrap_dir }}/containerlab_{{ github_runner_containerlab_version }}_linux_amd64.deb
 github_runner_containerlab_admin_group: clab_admins
+# containerlab needs root; the runner runs it via passwordless sudo for the FRR
+# containerlab CI gate. Path the .deb installs to. See network-operations#143.
+github_runner_containerlab_bin: /usr/bin/containerlab
 github_runner_xcaddy_path: /usr/local/bin/xcaddy
 github_runner_caddy_path: /usr/local/bin/caddy
 github_runner_caddy_build_dir: "{{ github_runner_tmp_dir }}/caddy-build"

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -322,6 +322,20 @@
   when: github_runner_containerlab_enabled | bool
   tags: [apply]
 
+# containerlab needs root to create netns/veth; the runner runs unprivileged
+# (User=runner). Scope a passwordless sudo to exactly the containerlab binary so
+# the containerlab-frr CI gate can `sudo containerlab` (network-operations#143).
+- name: Allow the runner passwordless sudo for containerlab
+  copy:
+    content: "{{ github_runner_user }} ALL=(root) NOPASSWD: {{ github_runner_containerlab_bin }}\n"
+    dest: /etc/sudoers.d/github-runner-containerlab
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"
+  when: github_runner_containerlab_enabled | bool
+  tags: [apply]
+
 - name: Install xcaddy builder
   command: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
   environment:

--- a/scripts/ci/batfish-test.sh
+++ b/scripts/ci/batfish-test.sh
@@ -34,7 +34,11 @@ if [[ -z "${BATFISH_HOST:-}" ]]; then
     exit 1
   fi
   docker rm -f "$container_name" >/dev/null 2>&1 || true
-  docker run -d --name "$container_name" -p 9997:9997 -p 9996:9996 batfish/allinone >/dev/null
+  # --network host (not -p) so Batfish binds 9997/9996 directly on the host: the
+  # self-hosted runner's Docker daemon can't program the iptables DOCKER nat chain
+  # for published ports, which fails `-p` with "iptables: No chain/target/match"
+  # (network-operations#143). Host networking needs no DNAT, so it sidesteps that.
+  docker run -d --name "$container_name" --network host batfish/allinone >/dev/null
   started_container=1
   export BATFISH_HOST=127.0.0.1
   sleep 15

--- a/scripts/ci/containerlab-frr-test.sh
+++ b/scripts/ci/containerlab-frr-test.sh
@@ -13,12 +13,16 @@ fi
 
 topology="tests/iac/containerlab/as215932.clab.yml"
 
+# containerlab needs root to create netns/veth; the runner runs unprivileged
+# (UID 995). It's granted passwordless `sudo containerlab` via the github_runner
+# role (clab_admins + /etc/sudoers.d/github-runner-containerlab). See
+# network-operations#143.
 cleanup() {
-  containerlab destroy -t "$topology" --cleanup >/dev/null 2>&1 || true
+  sudo containerlab destroy -t "$topology" --cleanup >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-containerlab deploy -t "$topology"
+sudo containerlab deploy -t "$topology"
 
 for node in rtr cr1-nl1 cr1-de1; do
   docker exec "clab-as215932-${node}" vtysh -c 'show bgp summary'

--- a/tests/iac/batfish/batfish_as215932_test.py
+++ b/tests/iac/batfish/batfish_as215932_test.py
@@ -18,6 +18,17 @@ CORE_PAIRS = {
 LOCAL_AS = 215932
 CANONICAL_PREFIX = "2a0c:b641:b50::/44"
 
+# Batfish's reachability/dataplane analysis and BGP-edge modelling are IPv4-only;
+# AS215932 is IPv6-only, so these checks error out parsing IPv6 specifiers
+# ("Error parsing '2a0c:b641:b50:2::/64' as ipSpecifier"). Mark them xfail rather
+# than delete them, so they reactivate automatically if Batfish gains IPv6
+# support; real IPv6 reachability is covered by the containerlab gate (it boots
+# the FRR configs and pings). See network-operations#143.
+_BATFISH_NO_IPV6 = pytest.mark.xfail(
+    reason="Batfish lacks IPv6 reachability/BGP-edge support; AS215932 is IPv6-only (#143)",
+    strict=False,
+)
+
 
 @pytest.fixture(scope="session")
 def bf():
@@ -34,6 +45,7 @@ def test_bgp_session_compatibility(bf):
     assert bad.empty, bad
 
 
+@_BATFISH_NO_IPV6
 def test_ibgp_full_mesh(bf):
     df = bf.q.bgpEdges().answer().frame()
     ibgp = df[(df["AS_Number"] == LOCAL_AS) & (df["Remote_AS_Number"] == LOCAL_AS)]
@@ -57,6 +69,7 @@ def test_no_undefined_references(bf):
     assert df.empty, df
 
 
+@_BATFISH_NO_IPV6
 def test_customer_networks_cannot_reach_infra_management(bf):
     result = bf.q.reachability(
         pathConstraints={"startLocation": "@enter(rtr[enX3])"},
@@ -65,6 +78,7 @@ def test_customer_networks_cannot_reach_infra_management(bf):
     assert result.empty, result
 
 
+@_BATFISH_NO_IPV6
 def test_authorized_ci_can_reach_management_ports(bf):
     result = bf.q.reachability(
         pathConstraints={"startLocation": "@enter(rtr[enX2])"},


### PR DESCRIPTION
## What

Fixes both dynamic FRR validators (#143), which failed on runner-infra issues.

### batfish
- **`--network host`** instead of `-p` (`scripts/ci/batfish-test.sh`): the runner's
  Docker daemon can't program the iptables `DOCKER` chain, so `-p` failed with
  `iptables: No chain/target/match`. Host networking needs no DNAT. **Verified live**
  — Batfish now starts and runs the model tests.
- **xfail the IPv6-incompatible tests** (`tests/iac/batfish/…`): Batfish's
  reachability/dataplane + BGP-edge analysis is IPv4-only, but AS215932 is
  IPv6-only, so 3 tests error parsing IPv6 specifiers. Marked `xfail(strict=False)`
  (kept, not deleted — reactivate if Batfish gains IPv6). The suite stays green on
  the structural checks Batfish *can* do (router-id uniqueness, undefined refs);
  real IPv6 reachability is the containerlab gate's job.

### containerlab
- **`sudo containerlab`** in `scripts/ci/containerlab-frr-test.sh` + a scoped
  NOPASSWD sudoers drop for the runner (`github_runner` role, visudo-validated).
  The runner is unprivileged (UID 995); containerlab needs root for netns/veth.
  **Takes effect after a `ci` playbook apply** installs the sudoers on the runner.

## Rollout

1. Merge.
2. `apply.yml -F playbook=ci -F limit=ci` to install the containerlab sudoers.
3. Dispatch `iac-tests` to confirm both validators pass.
4. Flip `ENABLE_BATFISH_TESTS` / `ENABLE_CONTAINERLAB_TESTS` repo vars → run on every FRR PR.

Refs #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)