### PR TITLE
ci: relax runner sandbox for containerlab (#143)

### DIFF
--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -148,6 +148,16 @@ github_runner_containerlab_admin_group: clab_admins
 # containerlab needs root; the runner runs it via passwordless sudo for the FRR
 # containerlab CI gate. Path the .deb installs to. See network-operations#143.
 github_runner_containerlab_bin: /usr/bin/containerlab
+# The deploy runner runs the dynamic FRR lab in containerlab. That needs `sudo`
+# plus netns/veth/cgroup operations, so when containerlab is enabled the systemd
+# sandbox must allow those. Runners with containerlab disabled (notably ci-pr)
+# keep the stricter defaults.
+github_runner_service_no_new_privileges: >-
+  {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}
+github_runner_service_protect_kernel_modules: >-
+  {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}
+github_runner_service_protect_control_groups: >-
+  {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}
 github_runner_xcaddy_path: /usr/local/bin/xcaddy
 github_runner_caddy_path: /usr/local/bin/caddy
 github_runner_caddy_build_dir: "{{ github_runner_tmp_dir }}/caddy-build"

--- a/ansible/roles/github_runner/templates/github-runner.service.j2
+++ b/ansible/roles/github_runner/templates/github-runner.service.j2
@@ -21,15 +21,18 @@ TimeoutStopSec=5min
 Environment=HOME={{ github_runner_home }}
 Environment=TMPDIR={{ github_runner_tmp_dir }}
 
-# Hardening
-NoNewPrivileges=true
+# Hardening. When containerlab is enabled, this runner intentionally relaxes the
+# privilege/cgroup/module guards below so `sudo containerlab` can create the
+# FRR lab's netns/veth topology (network-operations#143). Runners without
+# containerlab keep the stricter defaults from role vars.
+NoNewPrivileges={{ github_runner_service_no_new_privileges }}
 ProtectSystem=full
 ProtectHome=read-only
 ReadWritePaths={{ github_runner_install_dir }} {{ github_runner_home }}
 PrivateTmp=true
 ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectControlGroups=true
+ProtectKernelModules={{ github_runner_service_protect_kernel_modules }}
+ProtectControlGroups={{ github_runner_service_protect_control_groups }}
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/ci/provision.md
+++ b/docs/ci/provision.md
@@ -92,6 +92,15 @@ the first apply after the disk is attached, and keeps transient content bounded:
 `_diag` is pruned after 7 days, runner bootstrap/build scratch is pruned after a
 few days, and a systemd timer runs `docker system prune` with a 7-day cutoff.
 
+The `ci` runner is intentionally privileged enough to run the trusted
+Containerlab FRR gate (`containerlab-frr`). The `github_runner` role grants
+`runner` passwordless `sudo /usr/bin/containerlab` and relaxes the
+`github-runner.service` sandbox when `github_runner_containerlab_enabled=true`
+(`NoNewPrivileges=false`, `ProtectKernelModules=false`,
+`ProtectControlGroups=false`). This is not suitable for untrusted pull request
+jobs; the separate `ci-pr` runner keeps containerlab disabled and retains the
+stricter sandbox.
+
 ## 5. Verify
 
 ```bash


### PR DESCRIPTION
## What

Relaxes the `github-runner.service` sandbox only for runners with `github_runner_containerlab_enabled=true`, so the trusted `ci` runner can run the `containerlab-frr` gate.

Specifically, when containerlab is enabled:

- `NoNewPrivileges=false` so `sudo /usr/bin/containerlab` can work
- `ProtectKernelModules=false`
- `ProtectControlGroups=false`

Runners with containerlab disabled, including `ci-pr`, keep the stricter values.

## Why

`containerlab-frr` currently fails with:

```text
sudo: The "no new privileges" flag is set
```

The prior #143 sudoers fix is necessary but not sufficient because the systemd sandbox blocks privilege escalation and likely containerlab's cgroup/module operations.

This runner is already high-trust production infrastructure: it deploys to prod and reads Vault-rendered apply secrets. Untrusted PR jobs run on the separate `ci-pr` runner, where containerlab stays disabled.

## Validation

Local:

- `ansible-playbook playbooks/ci.yml --syntax-check`
- `yamllint ansible/roles/github_runner/defaults/main.yml ansible/roles/github_runner/tasks/main.yml .github/workflows/iac-tests.yml`
- `python3 -m unittest discover -s tests/iac -p 'test_*.py'` (41 tests)
- `ansible-lint playbooks/ci.yml roles/github_runner` exits 0; only existing warnings remain

## Rollout

After merge:

1. Install the updated systemd unit on `ci` and restart `github-runner`.
2. Dispatch `iac-tests.yml` on `main` to prove `containerlab-frr` passes.
3. Set `ENABLE_CONTAINERLAB_TESTS=true` only after the proof run is green.

Refs #143.