### PR TITLE
ci: allow containerlab to adjust kernel tunables (#143)

### DIFF
--- a/ansible/roles/github_runner/defaults/main.yml
+++ b/ansible/roles/github_runner/defaults/main.yml
@@ -149,10 +149,12 @@ github_runner_containerlab_admin_group: clab_admins
 # containerlab CI gate. Path the .deb installs to. See network-operations#143.
 github_runner_containerlab_bin: /usr/bin/containerlab
 # The deploy runner runs the dynamic FRR lab in containerlab. That needs `sudo`
-# plus netns/veth/cgroup operations, so when containerlab is enabled the systemd
-# sandbox must allow those. Runners with containerlab disabled (notably ci-pr)
-# keep the stricter defaults.
+# plus netns/veth/cgroup operations and `/proc/sys` writes for rp_filter, so
+# when containerlab is enabled the systemd sandbox must allow those. Runners
+# with containerlab disabled (notably ci-pr) keep the stricter defaults.
 github_runner_service_no_new_privileges: >-
+  {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}
+github_runner_service_protect_kernel_tunables: >-
   {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}
 github_runner_service_protect_kernel_modules: >-
   {{ 'false' if github_runner_containerlab_enabled | bool else 'true' }}

--- a/ansible/roles/github_runner/templates/github-runner.service.j2
+++ b/ansible/roles/github_runner/templates/github-runner.service.j2
@@ -22,15 +22,15 @@ Environment=HOME={{ github_runner_home }}
 Environment=TMPDIR={{ github_runner_tmp_dir }}
 
 # Hardening. When containerlab is enabled, this runner intentionally relaxes the
-# privilege/cgroup/module guards below so `sudo containerlab` can create the
-# FRR lab's netns/veth topology (network-operations#143). Runners without
-# containerlab keep the stricter defaults from role vars.
+# privilege/tunable/cgroup/module guards below so `sudo containerlab` can create
+# the FRR lab's netns/veth topology and adjust rp_filter (network-operations#143).
+# Runners without containerlab keep the stricter defaults from role vars.
 NoNewPrivileges={{ github_runner_service_no_new_privileges }}
 ProtectSystem=full
 ProtectHome=read-only
 ReadWritePaths={{ github_runner_install_dir }} {{ github_runner_home }}
 PrivateTmp=true
-ProtectKernelTunables=true
+ProtectKernelTunables={{ github_runner_service_protect_kernel_tunables }}
 ProtectKernelModules={{ github_runner_service_protect_kernel_modules }}
 ProtectControlGroups={{ github_runner_service_protect_control_groups }}
 

--- a/docs/ci/provision.md
+++ b/docs/ci/provision.md
@@ -96,10 +96,11 @@ The `ci` runner is intentionally privileged enough to run the trusted
 Containerlab FRR gate (`containerlab-frr`). The `github_runner` role grants
 `runner` passwordless `sudo /usr/bin/containerlab` and relaxes the
 `github-runner.service` sandbox when `github_runner_containerlab_enabled=true`
-(`NoNewPrivileges=false`, `ProtectKernelModules=false`,
-`ProtectControlGroups=false`). This is not suitable for untrusted pull request
-jobs; the separate `ci-pr` runner keeps containerlab disabled and retains the
-stricter sandbox.
+(`NoNewPrivileges=false`, `ProtectKernelTunables=false`,
+`ProtectKernelModules=false`, `ProtectControlGroups=false`). Containerlab needs
+these to create netns/veth/cgroup resources and adjust rp_filter on the Docker
+host. This is not suitable for untrusted pull request jobs; the separate
+`ci-pr` runner keeps containerlab disabled and retains the stricter sandbox.
 
 ## 5. Verify
 


### PR DESCRIPTION
## What

Adds `ProtectKernelTunables` to the same containerlab-aware service hardening knobs introduced in #162.

When `github_runner_containerlab_enabled=true`, the trusted `ci` runner now gets:

- `NoNewPrivileges=false`
- `ProtectKernelTunables=false`
- `ProtectKernelModules=false`
- `ProtectControlGroups=false`

Runners with containerlab disabled, including `ci-pr`, keep the stricter values.

## Why

After #162, `sudo containerlab` works and Docker network creation starts, but containerlab fails when it tries to disable rp_filter:

```text
Failed to disable RP filter on docker host for the 'all' scope: open /proc/sys/net/ipv4/conf/all/rp_filter: read-only file system.
```

That comes from `ProtectKernelTunables=true` in the runner unit.

## Validation

Local:

- `ansible-playbook playbooks/ci.yml --syntax-check`
- `yamllint ansible/roles/github_runner/defaults/main.yml`
- `python3 -m unittest discover -s tests/iac -p 'test_*.py'` (41 tests)

Rollout after merge: update the unit on `ci`, restart `github-runner`, dispatch `iac-tests.yml`, and enable `ENABLE_CONTAINERLAB_TESTS=true` only if `containerlab-frr` passes.

Refs #143.