### PR TITLE
ci: enable bgpd in the containerlab FRR fixture (#143)

### DIFF
--- a/tests/iac/containerlab/as215932.clab.yml
+++ b/tests/iac/containerlab/as215932.clab.yml
@@ -7,6 +7,7 @@ topology:
       image: quay.io/frrouting/frr:10.4.1
       binds:
         - /lib/modules:/lib/modules:ro
+        - ./configs/daemons:/etc/frr/daemons:ro
 
   nodes:
     rtr:

--- a/tests/iac/containerlab/configs/daemons
+++ b/tests/iac/containerlab/configs/daemons
@@ -1,0 +1,9 @@
+zebra=yes
+bgpd=yes
+ospf6d=no
+staticd=yes
+
+vtysh_enable=yes
+zebra_options="  -A 127.0.0.1 -s 90000000"
+bgpd_options="   -A 127.0.0.1"
+staticd_options="-A 127.0.0.1"


### PR DESCRIPTION
## What

Adds a lab-specific `/etc/frr/daemons` fixture and binds it into all FRR containerlab nodes.

The fixture enables `bgpd` so the existing lab configs can actually start BGP.

## Why

Once the runner/containerlab host blockers were fixed, the lab booted containers but FRR reported:

```text
bgpd is not running
Configuration file[/etc/frr/frr.conf] processing failure: 11
```

The FRR image's default `/etc/frr/daemons` ships with `bgpd=no`, so the lab-specific BGP configs were mounted but never applied to a running BGP daemon.

## Validation

Local:

- `python3 -m unittest discover -s tests/iac -p 'test_*.py'` (41 tests)
- `yamllint tests/iac/containerlab/as215932.clab.yml`
- Manual runner cleanup completed after prior debug lab

After merge I will dispatch `iac-tests.yml` on `main` and only enable `ENABLE_CONTAINERLAB_TESTS=true` once `containerlab-frr` passes.

Refs #143.