### PR TITLE
apply: tag Icinga snapshot capture tasks

### DIFF
--- a/ansible/roles/firewall/tasks/snapshot.yml
+++ b/ansible/roles/firewall/tasks/snapshot.yml
@@ -14,7 +14,7 @@
 
 - name: "Capture {{ snapshot_phase }}-deploy Icinga problem state on mon"
   delegate_to: mon
-  become: true
+  become: "{{ not ansible_check_mode }}"
   shell: |
     if [ -x /usr/local/bin/icinga-snapshot ]; then
       /usr/local/bin/icinga-snapshot
@@ -24,6 +24,7 @@
   register: _icinga_snapshot
   changed_when: false
   failed_when: false
+  tags: [snapshot]
 
 - name: "Write {{ snapshot_phase }} snapshot to the controller for diffing"
   delegate_to: localhost
@@ -37,3 +38,4 @@
     mode: "0644"
   changed_when: false
   failed_when: false
+  tags: [snapshot]


### PR DESCRIPTION
## What

Fixes the remaining #149 activation issue found during the `icinga2/mon` apply.

`apply.yml` invokes snapshot brackets via `ansible-playbook ... --tags snapshot`. The playbook's dynamic `include_role` selected `roles/firewall/tasks/snapshot.yml`, but the tasks inside that included file were untagged, so Ansible skipped the actual capture/write tasks. The workflow therefore still saw no `ansible/generated/snapshots` directory.

This adds `tags: [snapshot]` to the two real snapshot tasks:

- capture current Icinga problem state on `mon`
- write `ansible/generated/snapshots/<phase>/icinga.txt` on the controller

## Verification

- `yamllint ansible/roles/firewall/tasks/snapshot.yml`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook playbooks/icinga2.yml --syntax-check`
- `ansible-playbook --list-tasks --tags snapshot --limit mon` confirms the snapshot includes are selected

After merge I will rerun `apply.yml -F playbook=icinga2 -F limit=mon -F dry_run=false` to verify snapshot artifacts are produced.
