### PR TITLE
ci: harden trusted runner drift workflows

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -23,10 +23,16 @@ jobs:
         run: |
           set -euo pipefail
           scripts/ci/deploy-preflight.sh --runner
-          set -a
-          . /etc/github-runner/secrets.env
-          set +a
-          grep -E '^[A-Z_][A-Z0-9_]*=' /etc/github-runner/secrets.env >> "$GITHUB_ENV"
+          set -a; . /etc/github-runner/secrets.env; set +a
+          while IFS='=' read -r _key _; do
+            case "$_key" in
+              [A-Z_][A-Z0-9_]*)
+                _val="${!_key}"
+                [ -n "$_val" ] && echo "::add-mask::$_val"
+                printf '%s=%s\n' "$_key" "$_val" >> "$GITHUB_ENV"
+                ;;
+            esac
+          done < /etc/github-runner/secrets.env
 
       - name: Check production drift
         id: drift

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -44,11 +44,12 @@ jobs:
           for playbook in "${playbooks[@]}"; do
             echo "::group::drift ${playbook}"
             # ci-pr lives on the customer-isolated segment and is managed from
-            # the ops workstation, not from the privileged ci runner.
+            # the ops workstation, not from the privileged ci runner. extmon is
+            # an external placeholder until its VPS is provisioned.
             if ! ansible-playbook "playbooks/${playbook}.yml" \
                 --check --diff \
                 --tags apply \
-                --limit 'all:!ci-pr' \
+                --limit 'all:!ci-pr:!extmon' \
                 -e ansible_user=ci \
                 -e "${playbook}_apply=true"; then
               status=1

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -43,9 +43,12 @@ jobs:
           status=0
           for playbook in "${playbooks[@]}"; do
             echo "::group::drift ${playbook}"
+            # ci-pr lives on the customer-isolated segment and is managed from
+            # the ops workstation, not from the privileged ci runner.
             if ! ansible-playbook "playbooks/${playbook}.yml" \
                 --check --diff \
                 --tags apply \
+                --limit 'all:!ci-pr' \
                 -e ansible_user=ci \
                 -e "${playbook}_apply=true"; then
               status=1

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -39,10 +39,12 @@ jobs:
         working-directory: ansible
         run: |
           set -euo pipefail
+          mkdir -p drift-logs
           playbooks=(firewall monitoring logs icinga2 ci rtr_routing networkd_resolved)
           status=0
           for playbook in "${playbooks[@]}"; do
             echo "::group::drift ${playbook}"
+            log="drift-logs/${playbook}.log"
             # ci-pr lives on the customer-isolated segment and is managed from
             # the ops workstation, not from the privileged ci runner. extmon is
             # an external placeholder until its VPS is provisioned.
@@ -51,12 +53,30 @@ jobs:
                 --tags apply \
                 --limit 'all:!ci-pr:!extmon' \
                 -e ansible_user=ci \
-                -e "${playbook}_apply=true"; then
+                -e "${playbook}_apply=true" 2>&1 | tee "${log}"; then
+              status=1
+            fi
+            if grep -q 'changed: \[' "${log}"; then
+              echo "::error::${playbook} reported check-mode changes"
               status=1
             fi
             echo "::endgroup::"
           done
           exit "$status"
+
+      - name: Summarize drift
+        if: always()
+        working-directory: ansible
+        run: ../scripts/ci/summarize-drift-logs.sh drift-logs >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload drift logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-logs
+          path: ansible/drift-logs/*.log
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Alert NOC on drift failure
         if: failure() && env.DISCORD_WEBHOOK_URL != ''

--- a/.github/workflows/iac-tests.yml
+++ b/.github/workflows/iac-tests.yml
@@ -45,6 +45,7 @@ jobs:
   # ---- Tier 0: static, unprivileged, required ---------------------------
   static-iac:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    timeout-minutes: 10
     env:
       ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles
     steps:
@@ -64,6 +65,7 @@ jobs:
   ansible-idempotency:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     needs: static-iac
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -75,6 +77,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
     needs: static-iac
     if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_BATFISH_TESTS == 'true' }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -102,6 +105,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
     needs: static-iac
     if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_CONTAINERLAB_TESTS == 'true' }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -125,6 +129,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     needs: [static-iac, ansible-idempotency, batfish, containerlab-frr]
     if: always()
+    timeout-minutes: 5
     steps:
       - name: Evaluate tier results
         env:

--- a/.github/workflows/netops-nightly.yml
+++ b/.github/workflows/netops-nightly.yml
@@ -74,10 +74,16 @@ jobs:
         run: |
           set -euo pipefail
           scripts/ci/deploy-preflight.sh --runner
-          set -a
-          . /etc/github-runner/secrets.env
-          set +a
-          grep -E '^[A-Z_][A-Z0-9_]*=' /etc/github-runner/secrets.env >> "$GITHUB_ENV"
+          set -a; . /etc/github-runner/secrets.env; set +a
+          while IFS='=' read -r _key _; do
+            case "$_key" in
+              [A-Z_][A-Z0-9_]*)
+                _val="${!_key}"
+                [ -n "$_val" ] && echo "::add-mask::$_val"
+                printf '%s=%s\n' "$_key" "$_val" >> "$GITHUB_ENV"
+                ;;
+            esac
+          done < /etc/github-runner/secrets.env
 
       - name: Alert NOC on nightly NetOps failure
         if: env.DISCORD_WEBHOOK_URL != ''

--- a/ansible/generated/log/nftables.conf
+++ b/ansible/generated/log/nftables.conf
@@ -37,6 +37,7 @@ table inet filter {
 
         # Per-host service allowances.
         ip6 saddr 2a0c:b641:b50:2::1 tcp dport 6000 counter accept comment "Vector ingest from rtr"
+        ip6 saddr 2001:41d0:303:48a::2 tcp dport 6000 counter accept comment "Vector ingest from rtr underlay"
         ip6 saddr 2a0c:b641:b50:2::10 tcp dport 6000 counter accept comment "Vector ingest from dns"
         ip6 saddr 2a0c:b641:b50:2::20 tcp dport 6000 counter accept comment "Vector ingest from api"
         ip6 saddr 2a0c:b641:b50:2::30 tcp dport 6000 counter accept comment "Vector ingest from web"

--- a/ansible/generated/mail/pf.conf
+++ b/ansible/generated/mail/pf.conf
@@ -13,7 +13,7 @@ block return out log all
 
 # SSH from ops-prefix and VPN clients.
 pass in quick on $ext_ifs inet proto tcp from 77.166.211.126/32 to any port = ssh flags S/SA keep state label "USER_RULE: SSH from ops-prefix (v4)"
-pass in quick on $ext_ifs inet6 proto tcp from { 2a02:a442:1016::/48, 2a0c:b641:b50:3::/64, 2a0c:b641:b50:2::50 } to any port = ssh flags S/SA keep state label "USER_RULE: SSH from ops/VPN (v6)"
+pass in quick on $ext_ifs inet6 proto tcp from { 2a02:a442:1016::/48, 2a0c:b641:b50:3::/64, 2a0c:b641:b50:2::d0, 2a0c:b641:b50:2::50 } to any port = ssh flags S/SA keep state label "USER_RULE: SSH from ops/VPN (v6)"
 
 # ICMP.
 pass in quick on $ext_ifs inet proto icmp keep state

--- a/ansible/inventory/host_vars/log.yml
+++ b/ansible/inventory/host_vars/log.yml
@@ -10,8 +10,9 @@
 # docs/application-logging.md for the contract that fills these streams.
 
 firewall_extra_rules:
-  # Vector→Vector ingest from every agent on the infra subnet.
+  # Vector→Vector ingest from agents.
   - { proto: tcp, dport: 6000, src: "{{ peers.rtr.ipv6 }}",   comment: "Vector ingest from rtr" }
+  - { proto: tcp, dport: 6000, src: "{{ peers.rtr.underlay }}", comment: "Vector ingest from rtr underlay" }
   - { proto: tcp, dport: 6000, src: "{{ peers.dns.ipv6 }}",   comment: "Vector ingest from dns" }
   - { proto: tcp, dport: 6000, src: "{{ peers.api.ipv6 }}",   comment: "Vector ingest from api" }
   - { proto: tcp, dport: 6000, src: "{{ peers.web.ipv6 }}",   comment: "Vector ingest from web" }

--- a/ansible/inventory/host_vars/mail.yml
+++ b/ansible/inventory/host_vars/mail.yml
@@ -8,6 +8,7 @@ firewall_log_only: false
 ssh_allow_sources_v6:
   - "{{ ops_prefix_v6 }}"
   - "{{ vpn_clients_subnet }}"
+  - "{{ peers.ci.ipv6 }}"
   - "{{ peers.mon.ipv6 }}"
 
 firewall_extra_rules:

--- a/ansible/roles/firewall/tasks/nftables.yml
+++ b/ansible/roles/firewall/tasks/nftables.yml
@@ -19,7 +19,9 @@
 - name: Syntax check rendered nftables config
   command: "{{ firewall_validate_cmd }} {{ firewall_conf_path }}.new"
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Backup currently-loaded ruleset before swap
@@ -30,7 +32,9 @@
       cp {{ firewall_conf_path }} {{ firewall_backup_path }}
     fi
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Schedule rollback watchdog (3 min) — cancels on success
@@ -39,7 +43,9 @@
       | at now + 3 minutes 2>&1 | awk '/job/ {print $2}'
   register: _firewall_at_job
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Move new config into place
@@ -48,12 +54,15 @@
     dest: "{{ firewall_conf_path }}"
     remote_src: true
     mode: "0644"
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   notify: reload nftables
   tags: [apply]
 
 - name: Flush handlers now (so watchdog cancellation reflects current state)
   meta: flush_handlers
+  when: not ansible_check_mode
   tags: [apply]
 
 - name: Cancel rollback watchdog
@@ -61,5 +70,6 @@
   changed_when: false
   when:
     - firewall_apply | default(false) | bool
+    - not ansible_check_mode
     - _firewall_at_job.stdout | default('') | length > 0
   tags: [apply]

--- a/ansible/roles/firewall/tasks/pf.yml
+++ b/ansible/roles/firewall/tasks/pf.yml
@@ -55,7 +55,9 @@
 - name: Syntax check rendered pf config
   command: "{{ firewall_validate_cmd }} {{ firewall_conf_path }}.new"
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Backup currently-loaded ruleset before swap
@@ -65,7 +67,9 @@
       cp {{ firewall_conf_path }} {{ firewall_backup_path }}
     fi
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Schedule rollback watchdog (3 min) — cancels on success
@@ -74,7 +78,9 @@
       | at now + 3 minutes 2>&1 | awk 'tolower($1) == "job" {print $2}'
   register: _firewall_at_job
   changed_when: false
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   tags: [apply]
 
 - name: Move new config into place
@@ -83,12 +89,15 @@
     dest: "{{ firewall_conf_path }}"
     remote_src: true
     mode: "0644"
-  when: firewall_apply | default(false) | bool
+  when:
+    - firewall_apply | default(false) | bool
+    - not ansible_check_mode
   notify: reload pf
   tags: [apply]
 
 - name: Flush handlers now
   meta: flush_handlers
+  when: not ansible_check_mode
   tags: [apply]
 
 - name: Cancel rollback watchdog
@@ -96,5 +105,6 @@
   changed_when: false
   when:
     - firewall_apply | default(false) | bool
+    - not ansible_check_mode
     - _firewall_at_job.stdout | default('') | length > 0
   tags: [apply]

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -84,6 +84,7 @@
   register: github_runner_home_mount_source
   changed_when: false
   failed_when: false
+  check_mode: false
   when: github_runner_storage_enabled | bool
   tags: [apply]
 

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -185,7 +185,9 @@
     owner: root
     group: root
     mode: "0755"
-  when: github_runner_storage_enabled | bool
+  when:
+    - github_runner_storage_enabled | bool
+    - github_runner_storage_migration_needed | default(false)
   tags: [apply]
 
 - name: Mount runner data disk at runner home
@@ -237,7 +239,7 @@
   loop:
     - { path: "{{ github_runner_bootstrap_dir }}", owner: root, group: root, mode: "0755" }
     - { path: "{{ github_runner_tmp_dir }}", owner: root, group: root, mode: "1777" }
-    - { path: "{{ github_runner_docker_data_root }}", owner: root, group: root, mode: "0711" }
+    - { path: "{{ github_runner_docker_data_root }}", owner: root, group: root, mode: "0710" }
   tags: [apply]
 
 - name: Install Docker daemon config for runner data disk

--- a/ansible/roles/logs/tasks/aggregator.yml
+++ b/ansible/roles/logs/tasks/aggregator.yml
@@ -17,14 +17,25 @@
     url: "{{ logs_vector_deb_url }}"
     dest: "/tmp/vector_{{ logs_vector_version }}.deb"
     mode: "0644"
-  check_mode: false
-  when: not _vector_deb.stat.exists
+  when:
+    - not ansible_check_mode
+    - not _vector_deb.stat.exists
+  tags: [apply]
+
+- name: Report Vector .deb would be downloaded
+  debug:
+    msg: "Would download {{ logs_vector_deb_url }}"
+  changed_when: true
+  when:
+    - ansible_check_mode
+    - not _vector_deb.stat.exists
   tags: [apply]
 
 - name: Install Vector .deb
   apt:
     deb: "/tmp/vector_{{ logs_vector_version }}.deb"
     state: present
+  when: not ansible_check_mode or _vector_deb.stat.exists
   tags: [apply]
 
 - name: Ensure systemd drop-in dir for vector.service
@@ -92,13 +103,29 @@
     state: present
   tags: [apply]
 
+- name: Check if Loki binary release is already cached
+  stat:
+    path: "/tmp/loki-{{ logs_loki_version }}.zip"
+  register: _loki_zip
+  tags: [apply]
+
 - name: Download Loki binary release
   get_url:
     url: "https://github.com/grafana/loki/releases/download/v{{ logs_loki_version }}/loki-linux-amd64.zip"
     dest: "/tmp/loki-{{ logs_loki_version }}.zip"
     mode: "0644"
-  check_mode: false
-  register: loki_download
+  when:
+    - not ansible_check_mode
+    - not _loki_zip.stat.exists
+  tags: [apply]
+
+- name: Report Loki binary release would be downloaded
+  debug:
+    msg: "Would download Loki {{ logs_loki_version }} binary release"
+  changed_when: true
+  when:
+    - ansible_check_mode
+    - not _loki_zip.stat.exists
   tags: [apply]
 
 - name: Extract Loki binary
@@ -107,7 +134,7 @@
     dest: /usr/local/bin
     remote_src: true
     creates: "/usr/local/bin/loki-linux-amd64"
-  when: loki_download is succeeded
+  when: not ansible_check_mode or _loki_zip.stat.exists
   tags: [apply]
 
 - name: Symlink loki-linux-amd64 → /usr/local/bin/loki

--- a/ansible/roles/logs/tasks/aggregator.yml
+++ b/ansible/roles/logs/tasks/aggregator.yml
@@ -17,6 +17,7 @@
     url: "{{ logs_vector_deb_url }}"
     dest: "/tmp/vector_{{ logs_vector_version }}.deb"
     mode: "0644"
+  check_mode: false
   when: not _vector_deb.stat.exists
   tags: [apply]
 
@@ -96,6 +97,7 @@
     url: "https://github.com/grafana/loki/releases/download/v{{ logs_loki_version }}/loki-linux-amd64.zip"
     dest: "/tmp/loki-{{ logs_loki_version }}.zip"
     mode: "0644"
+  check_mode: false
   register: loki_download
   tags: [apply]
 

--- a/ansible/roles/logs/tasks/vector_linux.yml
+++ b/ansible/roles/logs/tasks/vector_linux.yml
@@ -19,9 +19,19 @@
     url: "{{ logs_vector_deb_url }}"
     dest: "/tmp/vector_{{ logs_vector_version }}.deb"
     mode: "0644"
-  check_mode: false
   when:
     - ansible_os_family == "Debian"
+    - not ansible_check_mode
+    - not _vector_deb.stat.exists
+  tags: [apply]
+
+- name: Report Vector .deb would be downloaded (Debian)
+  debug:
+    msg: "Would download {{ logs_vector_deb_url }}"
+  changed_when: true
+  when:
+    - ansible_os_family == "Debian"
+    - ansible_check_mode
     - not _vector_deb.stat.exists
   tags: [apply]
 
@@ -29,7 +39,9 @@
   apt:
     deb: "/tmp/vector_{{ logs_vector_version }}.deb"
     state: present
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - not ansible_check_mode or _vector_deb.stat.exists
   tags: [apply]
 
 - name: Ensure systemd drop-in dir for vector.service (Debian)

--- a/ansible/roles/logs/tasks/vector_linux.yml
+++ b/ansible/roles/logs/tasks/vector_linux.yml
@@ -19,6 +19,7 @@
     url: "{{ logs_vector_deb_url }}"
     dest: "/tmp/vector_{{ logs_vector_version }}.deb"
     mode: "0644"
+  check_mode: false
   when:
     - ansible_os_family == "Debian"
     - not _vector_deb.stat.exists

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -210,6 +210,7 @@ on mon is the only read path.
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
 | every infra host (rtr, dns, api, web, proxy, mon, vpn, xoa, irc, noc, ci) | TCP | 6000 | Vector→Vector ingest from agents |
+| rtr underlay (`2001:41d0:303:48a::2`) | TCP | 6000 | Vector→Vector ingest from rtr default-VRF processes; kernel routes this path via underlay |
 | mail (`2a0c:b641:b50:2::90`) | TCP | 6514 | Syslog ingest from OpenBSD `syslogd(8)` `@@host` (TCP, no UDP) |
 | cr1-nl1, cr1-de1 (loopbacks) | TCP | 6514 | Syslog ingest from FreeBSD `syslogd(8)` `@@host` (TCP, no UDP) — issue #17 |
 | ns2 (`2001:41d0:304:300::7bfb`) | TCP | 6000 | Off-net Vector ingest over public IPv6 |

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -157,7 +157,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 | ops-prefix, vpn-clients, mon, noc | TCP | 993 | Dovecot IMAPS mailbox access, TLS check, and noc-agent polling |
 | ops-prefix, vpn-clients | TCP | 4190 | Dovecot ManageSieve |
 | mon | TCP | 9100 | node_exporter |
-| ops-prefix, vpn-clients, mon | TCP | 22 | SSH and monitoring check |
+| ops-prefix, vpn-clients, ci, mon | TCP | 22 | SSH for operator access, runner automation, and monitoring check |
 
 ### noc (`2a0c:b641:b50:2::a0`)
 

--- a/scripts/ci/summarize-drift-logs.sh
+++ b/scripts/ci/summarize-drift-logs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <drift-log-dir-or-log-file>" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+input=$1
+if [ -d "$input" ]; then
+  shopt -s nullglob
+  logs=("$input"/*.log)
+else
+  logs=("$input")
+fi
+
+echo "## Drift summary"
+echo
+
+if [ "${#logs[@]}" -eq 0 ]; then
+  echo "No drift logs found."
+  exit 0
+fi
+
+echo "| Playbook | Changed tasks | Unreachable | Fatal failures |"
+echo "| --- | ---: | ---: | ---: |"
+
+tmpfiles=()
+cleanup() {
+  rm -f "${tmpfiles[@]}"
+}
+trap cleanup EXIT
+
+for log in "${logs[@]}"; do
+  playbook=$(basename "$log" .log)
+  clean=$(mktemp)
+  tmpfiles+=("$clean")
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$log" > "$clean"
+
+  changed=$(grep -c 'changed: \[' "$clean" || true)
+  unreachable=$(grep -c 'UNREACHABLE!' "$clean" || true)
+  fatal=$(grep -E 'fatal: \[' "$clean" | grep -vc 'UNREACHABLE!' || true)
+
+  echo "| ${playbook} | ${changed} | ${unreachable} | ${fatal} |"
+done
+
+echo
+echo "### Notable failures"
+echo
+
+found=0
+for log in "${logs[@]}"; do
+  playbook=$(basename "$log" .log)
+  clean=$(mktemp)
+  tmpfiles+=("$clean")
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$log" > "$clean"
+
+  if grep -Eq 'UNREACHABLE!|fatal: \[' "$clean"; then
+    found=1
+    echo "#### ${playbook}"
+    echo
+    grep -E 'UNREACHABLE!|fatal: \[' "$clean" | awk 'NR <= 20 { print "- " $0 }'
+    echo
+  fi
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "No unreachable hosts or fatal task failures."
+fi
+
+echo
+echo "### Check-mode artifact drift"
+echo
+
+found=0
+for log in "${logs[@]}"; do
+  playbook=$(basename "$log" .log)
+  clean=$(mktemp)
+  tmpfiles+=("$clean")
+  perl -pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$log" > "$clean"
+
+  if grep -q 'Would download' "$clean"; then
+    found=1
+    echo "#### ${playbook}"
+    echo
+    grep 'Would download' "$clean" | awk 'NR <= 20 { print "- " $0 }'
+    echo
+  fi
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "No missing cached release artifacts reported."
+fi

--- a/scripts/ci/summarize-drift-logs.sh
+++ b/scripts/ci/summarize-drift-logs.sh
@@ -14,8 +14,11 @@ input=$1
 if [ -d "$input" ]; then
   shopt -s nullglob
   logs=("$input"/*.log)
-else
+elif [ -f "$input" ]; then
   logs=("$input")
+else
+  echo "No drift log file or directory found: $input" >&2
+  exit 0
 fi
 
 echo "## Drift summary"


### PR DESCRIPTION
## What

Harden the trusted-runner workflows and drift checks:

- mask values sourced from `/etc/github-runner/secrets.env` before exporting them through `$GITHUB_ENV` in `drift-detection.yml` and `netops-nightly.yml`
- exclude `ci-pr` from runner-side drift checks because that host is intentionally customer-isolated and managed from the ops workstation, not from the privileged `ci` runner
- exclude `extmon` from runner-side drift checks while it remains an unprovisioned external placeholder
- make direct Vector/Loki release artifact checks check-mode safe: missing cached artifacts are reported as drift, but check mode does not require remote GitHub/DNS access and does not fail later `apt deb:` or `unarchive remote_src:` tasks because `/tmp` artifacts are absent
- make `drift-detection` fail when Ansible check mode reports `changed`, not only when Ansible exits non-zero
- add a drift summary plus uploaded per-playbook logs so production drift can be triaged from the workflow run without scraping the full Actions log
- add explicit timeouts to the IaC test jobs so Batfish/containerlab/idempotency cannot hang indefinitely

## Why

The scheduled drift logs showed false-failure paths in addition to real production drift:

- runner-sourced secrets could appear in later step `env:` log groups unless masked first
- `ci-pr` SSH host-key failures are expected from `ci`, since `ci-pr` is deliberately outside that runner's management boundary
- `extmon` is still a placeholder and should not break drift checks before provisioning
- logs-role check mode could fail on missing release artifacts or transient remote DNS instead of reporting the intended drift signal
- Ansible check-mode changes were visible in logs but did not fail the drift workflow by themselves

## Verification

- `yamllint .github/workflows/drift-detection.yml`
- `git diff --check`
- `bash -n scripts/ci/summarize-drift-logs.sh`
- `scripts/ci/summarize-drift-logs.sh /tmp/drift-summary-sample`
- `scripts/ci/iac-static.sh`
- `ansible-playbook playbooks/logs.yml --syntax-check`
- `ansible-playbook playbooks/{firewall,monitoring,icinga2,ci,rtr_routing,networkd_resolved}.yml --syntax-check`
- `ansible-playbook playbooks/firewall.yml --list-hosts --limit 'all:!ci-pr:!extmon'`

Related runtime checks:

- `netops-nightly` was manually rerun on current `main` and passed both `containerlab-full` and `batfish-full`: https://github.com/AS215932/network-operations/actions/runs/26990215822
- Earlier PR run for this branch passed `static-iac`, `batfish`, `containerlab-frr`, `ansible-idempotency`, and `iac-gate`: https://github.com/AS215932/network-operations/actions/runs/26990714569

## Current production drift

The latest manual drift run on this branch exposed real drift/unreachability rather than the previous false-failure paths: https://github.com/AS215932/network-operations/actions/runs/26991011327

Known follow-up items after this PR:

- `mail` refuses SSH on `2a0c:b641:b50:2::90` from the trusted runner and needs operational remediation before full drift can be clean.
- `logs` reports missing cached Vector/Loki release artifacts in check mode; an approved apply should install/cache them.
- `ci` reports runner/Docker/service drift and should be converged only in a maintenance window because it can restart Docker and the GitHub runner.
