### PR TITLE
monitoring: fix rtr by_ssh checks

### DIFF
--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -38,8 +38,12 @@ monitoring_disks:
 # Hostname and address derive automatically from the host being registered.
 monitoring_extra_services: []
 
+# Remote account used by by_ssh. Most hosts use the dedicated monitoring user;
+# rtr temporarily overrides this to root until its privileged checks are migrated
+# to sudo/doas under the dedicated account.
+monitoring_by_ssh_user: monitoring
+
 # by_ssh known_hosts target on mon. Debian's icinga2 package runs as the
-# `nagios` user but stores SSH state under /var/lib/icinga2; the daemon's
-# HOME is set to this directory. Override per-inventory if the package
-# changes layout.
-monitoring_by_ssh_known_hosts_path: /var/lib/icinga2/.ssh/known_hosts
+# `nagios` user with HOME=/var/lib/nagios, so OpenSSH reads this file when
+# check_by_ssh runs from Icinga.
+monitoring_by_ssh_known_hosts_path: /var/lib/nagios/.ssh/known_hosts

--- a/ansible/roles/monitoring/tasks/by_ssh_user.yml
+++ b/ansible/roles/monitoring/tasks/by_ssh_user.yml
@@ -1,24 +1,24 @@
 ---
-# Dedicated `monitoring` system user for icinga2 by_ssh checks.
+# Remote user for icinga2 by_ssh checks.
 #
-# Replaces the older convention of authorizing root@<host> (rtr) and the
-# never-existed `nagios` user (cr1.*). Human SSH stays as svag, root,
-# etc. — those are untouched. This user has nologin shell and is only
-# reachable via the by_ssh pubkey provisioned below.
+# Most hosts use the dedicated `monitoring` system user. rtr temporarily
+# overrides `monitoring_by_ssh_user: root` while its privileged checks still run
+# without sudo. Human SSH users are otherwise untouched.
 #
-# Privileged checks (FRR vtysh, jool stats, etc.) get a sudoers/doas drop
-# scoped to /usr/local/lib/nagios/plugins/* so the trust surface stays
-# narrow.
+# Privileged checks (FRR vtysh, jool stats, etc.) for the dedicated user get a
+# sudoers/doas drop scoped to /usr/local/lib/nagios/plugins/* so the trust
+# surface stays narrow.
 
 - name: Ensure dedicated monitoring user exists
   user:
-    name: monitoring
-    system: yes
+    name: "{{ monitoring_by_ssh_user }}"
+    system: true
     shell: "{{ monitoring_user_shell }}"
     home: "{{ monitoring_user_home }}"
-    create_home: yes
-    comment: "icinga2 by_ssh remote user (managed by hyrule-infra)"
+    create_home: true
+    comment: "icinga2 by_ssh remote user (managed by network-operations)"
   register: monitoring_user
+  when: monitoring_by_ssh_user != 'root'
   tags: [apply]
 
 # Use the primary group the OS assigned to the monitoring user (looked up
@@ -29,15 +29,29 @@
   file:
     path: "{{ monitoring_user_home }}/.ssh"
     state: directory
-    owner: monitoring
+    owner: "{{ monitoring_by_ssh_user }}"
     group: "{{ monitoring_user.group }}"
     mode: "0700"
+  when: monitoring_by_ssh_user != 'root'
   tags: [apply]
 
-- name: Authorize mon's icinga2 by_ssh pubkey for the monitoring user
+- name: Validate mon source address for by_ssh key restriction
+  assert:
+    that:
+      - peers[monitoring_mon_host] is defined
+      - peers[monitoring_mon_host].ipv6 is defined
+      - peers[monitoring_mon_host].ipv6 | length > 0
+    fail_msg: >-
+      peers[{{ monitoring_mon_host }}].ipv6 is required so the by_ssh
+      authorized_key is always installed with a restrictive from= option.
+  tags: [apply]
+
+- name: Authorize mon's icinga2 by_ssh pubkey for the remote user
   authorized_key:
-    user: monitoring
+    user: "{{ monitoring_by_ssh_user }}"
     key: "{{ monitoring_by_ssh_pubkey }}"
+    key_options: >-
+      from="{{ peers[monitoring_mon_host].ipv6 }}",no-port-forwarding,no-X11-forwarding,no-agent-forwarding
     comment: "icinga2 by_ssh from mon"
     state: present
   tags: [apply]
@@ -50,5 +64,7 @@
     group: "{{ 'wheel' if ansible_os_family == 'FreeBSD' else 'root' }}"
     mode: "{{ monitoring_user_privesc_mode }}"
     validate: "{{ '/usr/sbin/visudo -cf %s' if ansible_os_family != 'FreeBSD' else omit }}"
-  when: monitoring_user_privesc_template is defined
+  when:
+    - monitoring_by_ssh_user != 'root'
+    - monitoring_user_privesc_template is defined
   tags: [apply]

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -56,6 +56,22 @@
     - monitoring_by_ssh_pubkey | length > 0
   tags: [apply]
 
+- name: Ensure mon's icinga2 SSH dir exists
+  file:
+    path: "{{ monitoring_by_ssh_known_hosts_path | dirname }}"
+    state: directory
+    owner: nagios
+    group: nagios
+    mode: "0700"
+  delegate_to: "{{ monitoring_mon_host }}"
+  when:
+    - monitoring_apply | default(false) | bool
+    - monitoring_by_ssh_pubkey is defined
+    - monitoring_by_ssh_pubkey | length > 0
+    - by_ssh_host_keyscan.stdout is defined
+    - by_ssh_host_keyscan.stdout | length > 0
+  tags: [apply]
+
 - name: Populate mon's icinga2 known_hosts for by_ssh
   known_hosts:
     path: "{{ monitoring_by_ssh_known_hosts_path }}"

--- a/configs/mon/icinga2/services/rtr-checks.conf
+++ b/configs/mon/icinga2/services/rtr-checks.conf
@@ -6,10 +6,13 @@
 //
 // All three use the by_ssh CheckCommand from mon → rtr. rtr currently uses
 // the legacy root-based by_ssh path (root has the icinga2 pubkey authorized
-// per rtr.yml: monitoring_by_ssh_user=root); migration to the dedicated
-// `monitoring` user is deferred until rtr's apt-cache failure (blocks the
-// monitoring role's node_exporter task) is resolved. cr1.* already use the
-// `monitoring` user — see configs/mon/icinga2/services/cr-bogon-egress.conf.
+// per rtr.yml: monitoring_by_ssh_user=root), so each service must set
+// vars.by_ssh_logname = "root" explicitly. Without that, check_by_ssh runs
+// as the local nagios user and fails before the remote command executes.
+// Migration to the dedicated `monitoring` user is deferred until rtr's
+// apt-cache failure (blocks the monitoring role's node_exporter task) is
+// resolved. cr1.* already use the `monitoring` user — see
+// configs/mon/icinga2/services/cr-bogon-egress.conf.
 //
 // Filed by issue #20. The host.name match changed from "rtr.ovh1" to "rtr"
 // in PR for issue #21 (monitoring_register migration).
@@ -20,6 +23,7 @@ apply Service "rtr-ipv4-gateway-arp" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ping -c2 -W2 -I enX4 193.70.32.254 >/dev/null"
+  vars.by_ssh_logname = "root"
   notes = "rtr's WAN default gateway is reachable on the underlay interface (catches enX4 down, ARP failure)."
 
   assign where host.name == "rtr"
@@ -31,6 +35,7 @@ apply Service "rtr-ipv4-default-route" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ip -4 route show default | grep -q '193.70.32.254'"
+  vars.by_ssh_logname = "root"
   notes = "rtr has the expected v4 default route via OVH gateway 193.70.32.254 (catches FRR or systemd-networkd misconfig)."
 
   assign where host.name == "rtr"
@@ -46,6 +51,7 @@ apply Service "rtr-jool-success-delta" {
   // by_ssh user is still root, so no sudo wrap needed yet — that lands
   // alongside the rtr migration once apt-cache works.
   vars.by_ssh_command = "/usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
+  vars.by_ssh_logname = "root"
   notes = "JSTAT_SUCCESS counter should advance between checks — flat counter signals NAT64 pipeline broken (jool down, pool4/pool6 mismatch, VRF leak missing)."
 
   assign where host.name == "rtr"

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -153,7 +153,7 @@ daemon left stale by a botched reload still gets reconverged on a re-run.
 > <prefix>`) — a reload exiting 0 is not proof it applied. (cr1-nl1 also lacks
 > frr10-pythontools until its first frr-role apply installs it.)
 
-## Monitoring user — dedicated `monitoring` system account on every host
+## Monitoring user — dedicated `monitoring` system account on by_ssh hosts
 
 The `monitoring` role provisions a dedicated `monitoring` system user
 (nologin shell, home under `/var/lib/monitoring` on Linux,
@@ -166,14 +166,16 @@ untouched.
 Privileged checks (FRR vtysh, jool stats) need root. A scoped
 sudoers (Linux) / doas (FreeBSD) drop allows `monitoring` to invoke
 exactly `/usr/local/lib/nagios/plugins/*` as root, nothing else. In
-Icinga, those `vars.by_ssh_command` strings prepend `sudo`. The new
-convention replaces the old per-host `monitoring_by_ssh_user: root`
-override on rtr (now removed) and the never-existed `nagios` user on
-cr1.*.
+Icinga, those `vars.by_ssh_command` strings prepend `sudo`.
+
+Exception: rtr still sets `monitoring_by_ssh_user: root` while its legacy
+checks run without sudo. rtr service definitions must therefore set
+`vars.by_ssh_logname = "root"` explicitly until it is migrated.
 
 The first connection from icinga2 to a new by_ssh target fails with
-*"Host key verification failed"* until mon's `~icinga2/.ssh/known_hosts`
-is populated; the role does this via `ssh-keyscan` delegated to mon.
+*"Host key verification failed"* until mon's nagios-user known_hosts file
+(`/var/lib/nagios/.ssh/known_hosts` on Debian) is populated; the role does
+this via `ssh-keyscan` delegated to mon.
 
 ## Memory ops should know about
 


### PR DESCRIPTION
## Summary
- fix rtr by_ssh service definitions to explicitly SSH as root while rtr remains on the legacy root path
- manage mon's by_ssh known_hosts in the actual nagios HOME path (`/var/lib/nagios/.ssh/known_hosts`)
- make the monitoring role honor `monitoring_by_ssh_user` for root vs dedicated-user targets and restrict authorized keys to mon
- document the rtr exception and known_hosts path

## Live remediation already applied
- installed mon's Icinga pubkey for root@rtr with source restriction from mon
- populated mon nagios known_hosts for rtr
- deployed fixed `rtr-checks.conf` and reloaded Icinga
- cleaned rtr disk pressure by removing old kernel/header packages and apt source metadata

## Verification
- `git diff --check`
- `ansible-playbook playbooks/monitoring.yml --syntax-check --limit rtr`
- `ansible-playbook playbooks/icinga2.yml --syntax-check --limit mon`
- `ansible-playbook playbooks/monitoring.yml --tags validate --skip-tags snapshot --connection=local --limit rtr`
- `ansible-lint roles/monitoring playbooks/monitoring.yml` (passes; pre-existing schema warnings only)
- live Icinga: rtr host OK and no non-OK rtr services after forced rechecks
