### PR TITLE
monitoring: migrate rtr by_ssh to monitoring user

### DIFF
--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -76,15 +76,13 @@ monitoring_check_vars:
 monitoring_check_scripts:
   - check_jool_success_delta.sh
 
-# mon's icinga2 by_ssh pubkey, currently authorized for root@rtr (legacy
-# convention). The fleet-wide migration to the dedicated `monitoring`
-# user is deferred for rtr — the monitoring role's node_exporter step
-# fails on rtr with "Failed to update apt cache" (pre-existing issue,
-# tracked separately). cr1.* already use `monitoring`. Set
-# MONITORING_BY_SSH_PUBKEY in secrets.local.sh until the icinga2 role
+# mon's icinga2 by_ssh pubkey, authorized for the dedicated `monitoring`
+# user by the monitoring role. Privileged checks run through the scoped
+# sudoers drop for /usr/local/lib/nagios/plugins/*.
+# Set MONITORING_BY_SSH_PUBKEY in secrets.local.sh until the icinga2 role
 # lands a Vault-rendered pubkey distribution path.
-monitoring_by_ssh_user: root
 monitoring_by_ssh_pubkey: "{{ lookup('env', 'MONITORING_BY_SSH_PUBKEY') | default('', true) }}"
+monitoring_remove_legacy_root_by_ssh_key: true
 
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -38,10 +38,10 @@ monitoring_disks:
 # Hostname and address derive automatically from the host being registered.
 monitoring_extra_services: []
 
-# Remote account used by by_ssh. Most hosts use the dedicated monitoring user;
-# rtr temporarily overrides this to root until its privileged checks are migrated
-# to sudo/doas under the dedicated account.
-monitoring_by_ssh_user: monitoring
+# When true, remove mon's by_ssh pubkey from root's authorized_keys after the
+# dedicated monitoring user is provisioned. Used for one-way migrations from
+# legacy root-based checks (rtr).
+monitoring_remove_legacy_root_by_ssh_key: false
 
 # by_ssh known_hosts target on mon. Debian's icinga2 package runs as the
 # `nagios` user with HOME=/var/lib/nagios, so OpenSSH reads this file when

--- a/ansible/roles/monitoring/tasks/by_ssh_user.yml
+++ b/ansible/roles/monitoring/tasks/by_ssh_user.yml
@@ -1,24 +1,19 @@
 ---
-# Remote user for icinga2 by_ssh checks.
+# Dedicated `monitoring` system user for icinga2 by_ssh checks.
 #
-# Most hosts use the dedicated `monitoring` system user. rtr temporarily
-# overrides `monitoring_by_ssh_user: root` while its privileged checks still run
-# without sudo. Human SSH users are otherwise untouched.
-#
-# Privileged checks (FRR vtysh, jool stats, etc.) for the dedicated user get a
-# sudoers/doas drop scoped to /usr/local/lib/nagios/plugins/* so the trust
-# surface stays narrow.
+# Human SSH users (`svag`, `root`, etc.) are untouched. Privileged checks (FRR
+# vtysh, jool stats, etc.) get a sudoers/doas drop scoped to
+# /usr/local/lib/nagios/plugins/* so the trust surface stays narrow.
 
 - name: Ensure dedicated monitoring user exists
   user:
-    name: "{{ monitoring_by_ssh_user }}"
+    name: monitoring
     system: true
     shell: "{{ monitoring_user_shell }}"
     home: "{{ monitoring_user_home }}"
     create_home: true
     comment: "icinga2 by_ssh remote user (managed by network-operations)"
   register: monitoring_user
-  when: monitoring_by_ssh_user != 'root'
   tags: [apply]
 
 # Use the primary group the OS assigned to the monitoring user (looked up
@@ -29,10 +24,9 @@
   file:
     path: "{{ monitoring_user_home }}/.ssh"
     state: directory
-    owner: "{{ monitoring_by_ssh_user }}"
+    owner: monitoring
     group: "{{ monitoring_user.group }}"
     mode: "0700"
-  when: monitoring_by_ssh_user != 'root'
   tags: [apply]
 
 - name: Validate mon source address for by_ssh key restriction
@@ -46,9 +40,9 @@
       authorized_key is always installed with a restrictive from= option.
   tags: [apply]
 
-- name: Authorize mon's icinga2 by_ssh pubkey for the remote user
+- name: Authorize mon's icinga2 by_ssh pubkey for the monitoring user
   authorized_key:
-    user: "{{ monitoring_by_ssh_user }}"
+    user: monitoring
     key: "{{ monitoring_by_ssh_pubkey }}"
     key_options: >-
       from="{{ peers[monitoring_mon_host].ipv6 }}",no-port-forwarding,no-X11-forwarding,no-agent-forwarding
@@ -64,7 +58,13 @@
     group: "{{ 'wheel' if ansible_os_family == 'FreeBSD' else 'root' }}"
     mode: "{{ monitoring_user_privesc_mode }}"
     validate: "{{ '/usr/sbin/visudo -cf %s' if ansible_os_family != 'FreeBSD' else omit }}"
-  when:
-    - monitoring_by_ssh_user != 'root'
-    - monitoring_user_privesc_template is defined
+  when: monitoring_user_privesc_template is defined
+  tags: [apply]
+
+- name: Remove legacy root by_ssh authorization
+  authorized_key:
+    user: root
+    key: "{{ monitoring_by_ssh_pubkey }}"
+    state: absent
+  when: monitoring_remove_legacy_root_by_ssh_key | bool
   tags: [apply]

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -76,13 +76,14 @@
   known_hosts:
     path: "{{ monitoring_by_ssh_known_hosts_path }}"
     name: "{{ ansible_host | default(inventory_hostname) }}"
-    key: "{{ by_ssh_host_keyscan.stdout }}"
+    key: "{{ item }}"
     state: present
+  loop: "{{ by_ssh_host_keyscan.stdout_lines | reject('match', '^#') | list }}"
   delegate_to: "{{ monitoring_mon_host }}"
   when:
     - monitoring_apply | default(false) | bool
     - monitoring_by_ssh_pubkey is defined
     - monitoring_by_ssh_pubkey | length > 0
-    - by_ssh_host_keyscan.stdout is defined
-    - by_ssh_host_keyscan.stdout | length > 0
+    - by_ssh_host_keyscan.stdout_lines is defined
+    - by_ssh_host_keyscan.stdout_lines | reject('match', '^#') | list | length > 0
   tags: [apply]

--- a/ansible/roles/monitoring/vars/Debian.yml
+++ b/ansible/roles/monitoring/vars/Debian.yml
@@ -5,8 +5,9 @@ monitoring_node_env_path: /etc/default/prometheus-node-exporter
 
 # Dedicated by_ssh remote user. Created by the monitoring role when
 # monitoring_by_ssh_pubkey is set; the icinga2 daemon on mon logs in as
-# this user to run by_ssh checks. Per-OS shell path differs.
-monitoring_user_shell: /usr/sbin/nologin
+# this user to run by_ssh checks. The account needs a real shell because
+# OpenSSH executes by_ssh commands via the user's shell (`$SHELL -c ...`).
+monitoring_user_shell: /bin/sh
 monitoring_user_home: /var/lib/monitoring
 monitoring_user_privesc_template: sudoers-monitoring.j2
 monitoring_user_privesc_dest: /etc/sudoers.d/monitoring

--- a/configs/mon/icinga2/services/rtr-checks.conf
+++ b/configs/mon/icinga2/services/rtr-checks.conf
@@ -4,15 +4,10 @@
 // Catches the same failure class as #18 (NAT64 outage) earlier and from
 // a different angle than the dataplane probe (`nat64-ipv4-reachability`).
 //
-// All three use the by_ssh CheckCommand from mon → rtr. rtr currently uses
-// the legacy root-based by_ssh path (root has the icinga2 pubkey authorized
-// per rtr.yml: monitoring_by_ssh_user=root), so each service must set
-// vars.by_ssh_logname = "root" explicitly. Without that, check_by_ssh runs
-// as the local nagios user and fails before the remote command executes.
-// Migration to the dedicated `monitoring` user is deferred until rtr's
-// apt-cache failure (blocks the monitoring role's node_exporter task) is
-// resolved. cr1.* already use the `monitoring` user — see
-// configs/mon/icinga2/services/cr-bogon-egress.conf.
+// All three use the by_ssh CheckCommand from mon → rtr. rtr uses the
+// dedicated `monitoring` by_ssh user provisioned by ansible/roles/monitoring.
+// Privileged checks must go through the scoped sudoers rule, which only allows
+// `/usr/local/lib/nagios/plugins/*`.
 //
 // Filed by issue #20. The host.name match changed from "rtr.ovh1" to "rtr"
 // in PR for issue #21 (monitoring_register migration).
@@ -23,7 +18,7 @@ apply Service "rtr-ipv4-gateway-arp" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ping -c2 -W2 -I enX4 193.70.32.254 >/dev/null"
-  vars.by_ssh_logname = "root"
+  vars.by_ssh_logname = "monitoring"
   notes = "rtr's WAN default gateway is reachable on the underlay interface (catches enX4 down, ARP failure)."
 
   assign where host.name == "rtr"
@@ -35,7 +30,7 @@ apply Service "rtr-ipv4-default-route" {
   retry_interval = 30s
 
   vars.by_ssh_command = "ip -4 route show default | grep -q '193.70.32.254'"
-  vars.by_ssh_logname = "root"
+  vars.by_ssh_logname = "monitoring"
   notes = "rtr has the expected v4 default route via OVH gateway 193.70.32.254 (catches FRR or systemd-networkd misconfig)."
 
   assign where host.name == "rtr"
@@ -47,11 +42,10 @@ apply Service "rtr-jool-success-delta" {
   retry_interval = 1m
 
   // Wrapper script tracks the JSTAT_SUCCESS counter over time. Deployed
-  // via the monitoring role at /usr/local/lib/nagios/plugins/. rtr's
-  // by_ssh user is still root, so no sudo wrap needed yet — that lands
-  // alongside the rtr migration once apt-cache works.
-  vars.by_ssh_command = "/usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
-  vars.by_ssh_logname = "root"
+  // via the monitoring role at /usr/local/lib/nagios/plugins/. Jool stats
+  // need root, so run the plugin through the scoped sudoers rule.
+  vars.by_ssh_command = "sudo /usr/local/lib/nagios/plugins/check_jool_success_delta.sh"
+  vars.by_ssh_logname = "monitoring"
   notes = "JSTAT_SUCCESS counter should advance between checks — flat counter signals NAT64 pipeline broken (jool down, pool4/pool6 mismatch, VRF leak missing)."
 
   assign where host.name == "rtr"

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -156,21 +156,17 @@ daemon left stale by a botched reload still gets reconverged on a re-run.
 ## Monitoring user — dedicated `monitoring` system account on by_ssh hosts
 
 The `monitoring` role provisions a dedicated `monitoring` system user
-(nologin shell, home under `/var/lib/monitoring` on Linux,
-`/var/db/monitoring` on FreeBSD) on any host where
-`monitoring_by_ssh_pubkey` is set. mon's icinga2 daemon SSHes in as this
-user for `by_ssh` checks; the pubkey is dropped into
-`~monitoring/.ssh/authorized_keys`. Human SSH (`svag`, `root`) is
-untouched.
+(home under `/var/lib/monitoring` on Linux, `/var/db/monitoring` on FreeBSD)
+on any host where `monitoring_by_ssh_pubkey` is set. The account uses a real
+shell because OpenSSH executes remote commands via `$SHELL -c ...`; access is
+still key-only and source-restricted. mon's icinga2 daemon SSHes in as this user
+for `by_ssh` checks; the pubkey is dropped into
+`~monitoring/.ssh/authorized_keys`. Human SSH (`svag`, `root`) is untouched.
 
 Privileged checks (FRR vtysh, jool stats) need root. A scoped
 sudoers (Linux) / doas (FreeBSD) drop allows `monitoring` to invoke
 exactly `/usr/local/lib/nagios/plugins/*` as root, nothing else. In
 Icinga, those `vars.by_ssh_command` strings prepend `sudo`.
-
-Exception: rtr still sets `monitoring_by_ssh_user: root` while its legacy
-checks run without sudo. rtr service definitions must therefore set
-`vars.by_ssh_logname = "root"` explicitly until it is migrated.
 
 The first connection from icinga2 to a new by_ssh target fails with
 *"Host key verification failed"* until mon's nagios-user known_hosts file


### PR DESCRIPTION
## Summary
- remove rtr's temporary root by_ssh override
- switch rtr Icinga by_ssh services to the dedicated `monitoring` user
- run the Jool privileged check through scoped sudo (`/usr/local/lib/nagios/plugins/*`)
- give Debian monitoring users a real shell so OpenSSH can execute remote commands
- codify removal of the legacy root by_ssh authorization for rtr
- fix by_ssh known_hosts population to loop over actual `ssh-keyscan` key lines only

## Live rollout already completed
- provisioned `monitoring` on rtr with mon's Icinga pubkey restricted to mon's IPv6
- installed `/etc/sudoers.d/monitoring` scoped to `/usr/local/lib/nagios/plugins/*`
- removed mon's Icinga pubkey from `root@rtr`
- deployed updated `rtr-checks.conf` and reloaded Icinga
- cleaned duplicate rtr entries in mon's nagios known_hosts left by the older raw-keyscan task

## Verification
- `git diff --check`
- `ansible-playbook playbooks/monitoring.yml --syntax-check --limit rtr`
- `ansible-playbook playbooks/icinga2.yml --syntax-check --limit mon`
- `ansible-playbook playbooks/monitoring.yml --tags validate --skip-tags snapshot --connection=local --limit rtr`
- `ansible-lint roles/monitoring playbooks/monitoring.yml` (passes; pre-existing schema warnings only)
- live manual by_ssh checks from mon as `monitoring`: default route, gateway ARP, Jool success delta all OK
- live `monitoring.yml --tags apply --limit rtr` final run: `changed=0`
- live Icinga: rtr host OK and no non-OK rtr services
