### PR TITLE
[codex] Wire NOC action authorization environment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/promotion.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promotion.md
@@ -1,0 +1,28 @@
+## Promotion
+
+App PRs:
+- `AS215932/<repo>#<number>` -> `<40-char-sha>`
+
+Pinned versions:
+- `noc_agent_version`: unchanged or `<40-char-sha>`
+- `hyrule_mcp_version`: unchanged or `<40-char-sha>`
+- `hyrule_cloud_version`: unchanged or `<40-char-sha>`
+- `hyrule_web_version`: unchanged or `<40-char-sha>`
+
+Deploy impact:
+- Affected playbooks:
+- Expected service restarts:
+- Operator-visible behavior:
+
+Rollback:
+- Previous `noc_agent_version`:
+- Previous `hyrule_mcp_version`:
+- Previous `hyrule_cloud_version`:
+- Previous `hyrule_web_version`:
+
+Validation:
+- [ ] App CI is green for every promoted SHA.
+- [ ] `scripts/ci/iac-static.sh` passes.
+- [ ] `apply.yml` dry-run completed for each affected playbook.
+- [ ] Production `apply.yml` completed.
+- [ ] Icinga pre/post snapshot diff reviewed.

--- a/.github/workflows/app-promotion-deploy.yml
+++ b/.github/workflows/app-promotion-deploy.yml
@@ -1,0 +1,62 @@
+---
+name: app-promotion-deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ansible/inventory/host_vars/noc.yml
+      - ansible/inventory/host_vars/api.yml
+      - ansible/inventory/host_vars/web.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: production-app-promotion
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - id: detect
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only HEAD^ HEAD -- ansible/inventory/host_vars/noc.yml ansible/inventory/host_vars/api.yml ansible/inventory/host_vars/web.yml)"
+          python3 - "$changed" <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import sys
+
+          changed = set(sys.argv[1].splitlines())
+          matrix = []
+          if "ansible/inventory/host_vars/noc.yml" in changed:
+              matrix.append({"playbook": "noc", "limit": "noc"})
+          if "ansible/inventory/host_vars/api.yml" in changed:
+              matrix.append({"playbook": "cloud", "limit": "api"})
+          if "ansible/inventory/host_vars/web.yml" in changed:
+              matrix.append({"playbook": "web", "limit": "web"})
+          print(f"matrix={json.dumps({'include': matrix})}")
+          print(f"has_changes={'true' if matrix else 'false'}")
+          PY
+
+  apply:
+    needs: detect
+    if: ${{ needs.detect.outputs.has_changes == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    uses: ./.github/workflows/apply.yml
+    with:
+      playbook: ${{ matrix.playbook }}
+      limit: ${{ matrix.limit }}
+      dry_run: false
+      pr_number: ""

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -92,9 +92,9 @@ concurrency:
 jobs:
   apply:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
-    # `production` is an environment with a required reviewer rule.
-    # The job pauses until the reviewer approves.
-    environment: production
+    # Real applies pause on the protected `production` environment. Dry-runs
+    # must stay ungated so promotion PR validation can be automated.
+    environment: ${{ inputs.dry_run && 'dry-run' || 'production' }}
     timeout-minutes: 30
     env:
       ANSIBLE_FORCE_COLOR: "true"

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -22,6 +22,8 @@ on:
           - monitoring
           - icinga2
           - logs
+          - cloud
+          - web
           - noc
           - vault
           - ci
@@ -54,10 +56,38 @@ on:
         type: boolean
         required: true
         default: false
+  workflow_call:
+    inputs:
+      playbook:
+        description: Playbook to apply (matches ansible/playbooks/<name>.yml)
+        type: string
+        required: true
+      limit:
+        description: Ansible --limit pattern (host or group)
+        type: string
+        required: true
+      dry_run:
+        description: Dry-run only (render + check, no apply)
+        type: boolean
+        required: true
+      pr_number:
+        description: PR number to post the diff to (optional)
+        type: string
+        required: false
+        default: ""
+      bootstrap_ci_runner_key:
+        description: Connect as inventory users for first-time ci-runner-key bootstrap
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  group: production-infra
+  cancel-in-progress: false
 
 jobs:
   apply:
@@ -77,6 +107,8 @@ jobs:
       CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Runner deploy preflight
         run: scripts/ci/deploy-preflight.sh --runner
@@ -102,6 +134,61 @@ jobs:
           else
             echo "::warning::/etc/github-runner/secrets.env not found — apply may fail on env-var lookups"
           fi
+
+      - name: Summarize app version pins
+        if: ${{ contains(fromJSON('["noc","cloud","web"]'), inputs.playbook) }}
+        run: |
+          set -euo pipefail
+
+          case "${{ inputs.playbook }}" in
+            noc)
+              host_vars="ansible/inventory/host_vars/noc.yml"
+              entries="noc_agent_version|AS215932/noc-agent hyrule_mcp_version|AS215932/hyrule-mcp"
+              ;;
+            cloud)
+              host_vars="ansible/inventory/host_vars/api.yml"
+              entries="hyrule_cloud_version|AS215932/hyrule-cloud"
+              ;;
+            web)
+              host_vars="ansible/inventory/host_vars/web.yml"
+              entries="hyrule_web_version|AS215932/hyrule-web"
+              ;;
+          esac
+
+          extract_pin() {
+            local key="$1"
+            local file="$2"
+            sed -nE "s/^${key}:[[:space:]]*['\"]?([0-9a-fA-F]{40})['\"]?[[:space:]]*$/\1/p" "$file" | head -1
+          }
+
+          {
+            echo "## App version pins"
+            echo
+            echo "| Variable | Repository | SHA | Compare |"
+            echo "| --- | --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for entry in $entries; do
+            key="${entry%%|*}"
+            repo="${entry##*|}"
+            current="$(extract_pin "$key" "$host_vars")"
+            previous=""
+            if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+              tmp="$(mktemp)"
+              if git show "HEAD^:${host_vars}" > "$tmp" 2>/dev/null; then
+                previous="$(extract_pin "$key" "$tmp")"
+              fi
+              rm -f "$tmp"
+            fi
+
+            if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
+              compare="[${previous:0:7}...${current:0:7}](https://github.com/${repo}/compare/${previous}...${current})"
+            else
+              compare="unchanged"
+            fi
+
+            echo "| \`${key}\` | \`${repo}\` | \`${current}\` | ${compare} |" >> "$GITHUB_STEP_SUMMARY"
+          done
 
       # -e ansible_user=ci: the runner connects as the dedicated `ci` deploy
       # user on every host (created + NOPASSWD-root by the ci_runner_key role)

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -137,10 +137,12 @@ jobs:
 
       - name: Summarize app version pins
         if: ${{ contains(fromJSON('["noc","cloud","web"]'), inputs.playbook) }}
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
         run: |
           set -euo pipefail
 
-          case "${{ inputs.playbook }}" in
+          case "$PLAYBOOK" in
             noc)
               host_vars="ansible/inventory/host_vars/noc.yml"
               entries="noc_agent_version|AS215932/noc-agent hyrule_mcp_version|AS215932/hyrule-mcp"
@@ -196,8 +198,10 @@ jobs:
       # extra-var so it overrides per-host ansible_user (rtr/xoa=root, etc.).
       - name: Pre-deploy Icinga snapshot
         working-directory: ansible
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
         run: |
-          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+          ansible-playbook "playbooks/${PLAYBOOK}.yml" \
             --tags snapshot \
             -e ansible_user=ci \
             -e snapshot_phase=pre
@@ -205,41 +209,61 @@ jobs:
       - name: Render-only (dry run)
         if: ${{ inputs.dry_run }}
         working-directory: ansible
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
+          LIMIT: ${{ inputs.limit }}
         run: |
-          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+          limit_args=()
+          if [ -n "$LIMIT" ]; then
+            limit_args=(--limit "$LIMIT")
+          fi
+          ansible-playbook "playbooks/${PLAYBOOK}.yml" \
             --tags validate \
             --connection=local \
             --skip-tags=snapshot \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${limit_args[@]}"
 
       - name: Apply
         if: ${{ !inputs.dry_run }}
         working-directory: ansible
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
+          LIMIT: ${{ inputs.limit }}
+          BOOTSTRAP_CI_RUNNER_KEY: ${{ inputs.bootstrap_ci_runner_key }}
         run: |
-          playbook="${{ inputs.playbook }}"
+          playbook="$PLAYBOOK"
           apply_var="${playbook//-/_}_apply=true"
           user_args=(-e ansible_user=ci)
-          if [ "${playbook}" = "ci-runner-key" ] && [ "${{ inputs.bootstrap_ci_runner_key }}" = "true" ]; then
+          limit_args=()
+          if [ -n "$LIMIT" ]; then
+            limit_args=(--limit "$LIMIT")
+          fi
+          if [ "$playbook" = "ci-runner-key" ] && [ "$BOOTSTRAP_CI_RUNNER_KEY" = "true" ]; then
             user_args=()
           fi
           ansible-playbook "playbooks/${playbook}.yml" \
             --tags apply \
             "${user_args[@]}" \
             -e "${apply_var}" \
-            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }}
+            "${limit_args[@]}"
 
       - name: Post-deploy Icinga snapshot
         if: ${{ !inputs.dry_run }}
         working-directory: ansible
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
         run: |
-          ansible-playbook "playbooks/${{ inputs.playbook }}.yml" \
+          ansible-playbook "playbooks/${PLAYBOOK}.yml" \
             --tags snapshot \
             -e ansible_user=ci \
             -e snapshot_phase=post
 
       - name: Post-deploy Goss validation
         if: ${{ !inputs.dry_run }}
-        run: scripts/ci/goss-validate.sh "${{ inputs.playbook }}" "${{ inputs.limit }}"
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
+          LIMIT: ${{ inputs.limit }}
+        run: scripts/ci/goss-validate.sh "$PLAYBOOK" "$LIMIT"
 
       - name: Capture snapshot diff
         if: ${{ !inputs.dry_run }}
@@ -280,9 +304,11 @@ jobs:
         if: ${{ !inputs.dry_run && inputs.pr_number != '' && steps.diff.outputs.diff != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          gh pr comment "${{ inputs.pr_number }}" \
-            --repo "${{ github.repository }}" \
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPOSITORY" \
             --body-file /tmp/diff.md
 
       - name: Upload snapshots as artifact

--- a/.github/workflows/promote-apps.yml
+++ b/.github/workflows/promote-apps.yml
@@ -1,0 +1,93 @@
+---
+name: promote-apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: Promotion PR title
+        type: string
+        required: true
+        default: Promote app SHAs
+      noc_agent_sha:
+        description: Optional AS215932/noc-agent commit SHA
+        type: string
+        required: false
+        default: ""
+      hyrule_mcp_sha:
+        description: Optional AS215932/hyrule-mcp commit SHA
+        type: string
+        required: false
+        default: ""
+      hyrule_cloud_sha:
+        description: Optional AS215932/hyrule-cloud commit SHA
+        type: string
+        required: false
+        default: ""
+      hyrule_web_sha:
+        description: Optional AS215932/hyrule-web commit SHA
+        type: string
+        required: false
+        default: ""
+      impact:
+        description: Short deploy impact note
+        type: string
+        required: false
+        default: Automated app SHA promotion.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: promote-apps
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Update app pins
+        run: |
+          scripts/ci/promote-app-pins.py \
+            --title "${{ inputs.title }}" \
+            --impact "${{ inputs.impact }}" \
+            --noc-agent-sha "${{ inputs.noc_agent_sha }}" \
+            --hyrule-mcp-sha "${{ inputs.hyrule_mcp_sha }}" \
+            --hyrule-cloud-sha "${{ inputs.hyrule_cloud_sha }}" \
+            --hyrule-web-sha "${{ inputs.hyrule_web_sha }}" \
+            --body-file /tmp/promotion-body.md
+
+      - name: Validate pins
+        run: scripts/ci/iac-static.sh
+
+      - name: Commit promotion branch
+        env:
+          BRANCH: promotion/app-sha-pins
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add ansible/inventory/host_vars/noc.yml ansible/inventory/host_vars/api.yml ansible/inventory/host_vars/web.yml
+          git commit -m "${{ inputs.title }}"
+          git push --force-with-lease origin "$BRANCH"
+
+      - name: Open or update promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: promotion/app-sha-pins
+        run: |
+          set -euo pipefail
+          existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "${{ inputs.title }}" --body-file /tmp/promotion-body.md
+            echo "Updated PR #$existing" >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr create --base main --head "$BRANCH" --title "${{ inputs.title }}" --body-file /tmp/promotion-body.md
+          fi

--- a/.github/workflows/promote-apps.yml
+++ b/.github/workflows/promote-apps.yml
@@ -53,14 +53,21 @@ jobs:
           ref: main
 
       - name: Update app pins
+        env:
+          PROMOTION_TITLE: ${{ inputs.title }}
+          PROMOTION_IMPACT: ${{ inputs.impact }}
+          NOC_AGENT_SHA: ${{ inputs.noc_agent_sha }}
+          HYRULE_MCP_SHA: ${{ inputs.hyrule_mcp_sha }}
+          HYRULE_CLOUD_SHA: ${{ inputs.hyrule_cloud_sha }}
+          HYRULE_WEB_SHA: ${{ inputs.hyrule_web_sha }}
         run: |
           scripts/ci/promote-app-pins.py \
-            --title "${{ inputs.title }}" \
-            --impact "${{ inputs.impact }}" \
-            --noc-agent-sha "${{ inputs.noc_agent_sha }}" \
-            --hyrule-mcp-sha "${{ inputs.hyrule_mcp_sha }}" \
-            --hyrule-cloud-sha "${{ inputs.hyrule_cloud_sha }}" \
-            --hyrule-web-sha "${{ inputs.hyrule_web_sha }}" \
+            --title "$PROMOTION_TITLE" \
+            --impact "$PROMOTION_IMPACT" \
+            --noc-agent-sha "$NOC_AGENT_SHA" \
+            --hyrule-mcp-sha "$HYRULE_MCP_SHA" \
+            --hyrule-cloud-sha "$HYRULE_CLOUD_SHA" \
+            --hyrule-web-sha "$HYRULE_WEB_SHA" \
             --body-file /tmp/promotion-body.md
 
       - name: Validate pins
@@ -69,25 +76,27 @@ jobs:
       - name: Commit promotion branch
         env:
           BRANCH: promotion/app-sha-pins
+          COMMIT_MESSAGE: ${{ inputs.title }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add ansible/inventory/host_vars/noc.yml ansible/inventory/host_vars/api.yml ansible/inventory/host_vars/web.yml
-          git commit -m "${{ inputs.title }}"
+          git commit -m "$COMMIT_MESSAGE"
           git push --force-with-lease origin "$BRANCH"
 
       - name: Open or update promotion PR
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: promotion/app-sha-pins
+          PR_TITLE: ${{ inputs.title }}
         run: |
           set -euo pipefail
           existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --title "${{ inputs.title }}" --body-file /tmp/promotion-body.md
+            gh pr edit "$existing" --title "$PR_TITLE" --body-file /tmp/promotion-body.md
             echo "Updated PR #$existing" >> "$GITHUB_STEP_SUMMARY"
           else
-            gh pr create --base main --head "$BRANCH" --title "${{ inputs.title }}" --body-file /tmp/promotion-body.md
+            gh pr create --base main --head "$BRANCH" --title "$PR_TITLE" --body-file /tmp/promotion-body.md
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ ovh.conf
 openprovider.conf
 secrets.local.sh
 __pycache__/
+.tmp/
 
 # Rendered Knot configs embed the TSIG secret (key.secret). Everything else
 # under ansible/generated/ is intentionally tracked (render-check diffs it),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,28 @@
 # AS215932 Infrastructure Agent Guide
 
+## Deployment Rules - Read Before Touching App Pins
+
+- Production deploys for `noc-agent`, `hyrule-mcp`, `hyrule-cloud`, and
+  `hyrule-web` are controlled from this repository, not from app repos.
+- App repositories may merge code, but they must not be treated as production
+  deployment records.
+- Production app versions are the pinned 40-character SHAs in:
+  - `ansible/inventory/host_vars/noc.yml`
+  - `ansible/inventory/host_vars/api.yml`
+  - `ansible/inventory/host_vars/web.yml`
+- Normal promotion path:
+  1. Merge app PRs after app CI is green.
+  2. Run the `promote-apps` workflow in this repo with the merged app SHAs.
+  3. Review and merge the generated promotion PR.
+  4. Let `app-promotion-deploy` start automatically from `main`.
+  5. The only intended manual step is approving the `production` environment
+     gate before `apply.yml` touches live hosts.
+- Do not manually edit app pins unless the automation is unavailable. If you
+  must, use the promotion PR template and keep rollback SHAs in the PR body.
+- `apply.yml` runs only when explicitly dispatched or called by another
+  workflow. After this automation, app pin changes merged to `main` cause
+  `app-promotion-deploy` to call `apply.yml` automatically.
+
 ## Domain Policy
 
 - `hyrule.host` is customer-facing Hyrule Cloud/product identity. Use it for the product site, public Hyrule Cloud API, and customer VM subdomains.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # AS215932 Network Operations
 
+## Production Deploys: Read This First
+
+This repository is the production deployment record for `noc-agent`,
+`hyrule-mcp`, `hyrule-cloud`, and `hyrule-web`. App repos do not deploy
+production on merge.
+
+Use **Actions -> promote-apps** with the merged app commit SHAs. That workflow
+opens or updates the promotion PR that pins exact SHAs in inventory. After the
+promotion PR merges, **app-promotion-deploy** automatically calls `apply.yml`
+for the affected playbooks and waits at the GitHub `production` environment
+approval gate. The human operator's normal job is to review the promotion PR,
+merge it, approve the production gate, and review the Icinga snapshot diff.
+
+Full runbook: [docs/ci/deploy-runbook.md](docs/ci/deploy-runbook.md).
+
 Public operations repository for **AS215932** (Hyrule/Servify) - building a complete Internet Service Provider from scratch.
 
 ## About

--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -1,6 +1,8 @@
 ---
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
+hyrule_cloud_version: 1907cf99fe8d9c9c8b7ff825363fd33f63cb667a
+
 firewall_extra_rules:
   # API upstreams and backend health checks.
   - { proto: tcp, dport: 8402, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.web.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-cloud API from proxy/web/mon" }

--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -1,7 +1,7 @@
 ---
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
-hyrule_cloud_version: 1907cf99fe8d9c9c8b7ff825363fd33f63cb667a
+hyrule_cloud_version: 5384a96bd9dbe381eb2bce192099de6f07bd27b4
 
 firewall_extra_rules:
   # API upstreams and backend health checks.

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,6 +5,9 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
+noc_agent_version: 63d6c9b995b453b2ca92c21759ce6729cdda1ce5
+hyrule_mcp_version: bbe5e4d7271b888581f86016234326b8cd60dd22
+
 firewall_extra_rules:
   # Webhooks from Alertmanager + Icinga2 on mon.
   - { proto: tcp, dport: 8000, src: "{{ peers.mon.ipv6 }}", comment: "noc-agent webhook from mon (Alertmanager + Icinga)" }

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,8 +5,8 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
-noc_agent_version: 63d6c9b995b453b2ca92c21759ce6729cdda1ce5
-hyrule_mcp_version: bbe5e4d7271b888581f86016234326b8cd60dd22
+noc_agent_version: d0b61e651f323c206fd1b603d83d1320b3c01797
+hyrule_mcp_version: d95e94766cc3608b38066bd50bc938c284b47bee
 
 firewall_extra_rules:
   # Webhooks from Alertmanager + Icinga2 on mon.

--- a/ansible/inventory/host_vars/web.yml
+++ b/ansible/inventory/host_vars/web.yml
@@ -1,6 +1,8 @@
 ---
 # web — hyrule-web (uvicorn :8080 hyrule.host) + nginx (:8081 as215932.net).
 
+hyrule_web_version: 45d7bb6964c686188a49da032de785be55e95a56
+
 firewall_extra_rules:
   - { proto: tcp, dport: 8080, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-web upstream from proxy/mon" }
   - { proto: tcp, dport: 8081, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "as215932.net upstream from proxy/mon" }

--- a/ansible/playbooks/cloud.yml
+++ b/ansible/playbooks/cloud.yml
@@ -8,12 +8,10 @@
 # Apply (live deploy):
 #   ansible-playbook playbooks/cloud.yml --tags apply \
 #     -e hyrule_cloud_apply=true \
-#     -e hyrule_cloud_version=<sha-or-ref> \
 #     --limit api
 #
-# The deploy.yml workflow in AS215932/hyrule-cloud invokes the apply variant
-# with hyrule_cloud_version=${{ github.sha }} so production deploys are pinned
-# to the exact commit that passed CI.
+# Production deploys use hyrule_cloud_version from inventory host_vars. Promote
+# a new app commit by updating the pinned SHA in network-operations.
 #
 # Wave 2 prerequisite: the toy `accounts` and `crypto_intents` tables created
 # via hand-applied db_patch{1,2,3}.py scripts must be dropped before Wave 2's

--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -27,6 +27,17 @@
   gather_facts: true
   become: true
   pre_tasks:
+    - name: Require NOC approval signing secret
+      assert:
+        that:
+          - noc_approval_signing_secret | length >= 32
+        fail_msg: >-
+          NOC_APPROVAL_SIGNING_SECRET must be set to at least 32 characters
+          before deploying NOC write-action approval support.
+      when: noc_agent_secret_backend == 'env'
+      no_log: true
+      tags: [validate, apply]
+
     - name: Pre-deploy Icinga snapshot
       include_role:
         name: firewall
@@ -75,7 +86,9 @@
         vault_agent_secret_id: "{{ lookup('env', 'VAULT_NOC_AGENT_SECRET_ID') | default('', true) }}"
         vault_agent_env_destination: /opt/noc-agent/.env
         vault_agent_google_subject_token_destination: "{{ noc_agent_google_subject_token_path }}"
-        vault_agent_reload_command: >-
+        vault_agent_env_reload_command: >-
+          /bin/grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env &&
+          /bin/grep -Eq "^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env &&
           /bin/systemctl restart xo-mcp.service &&
           /bin/systemctl restart noc-agent.service &&
           /bin/systemctl restart noc-agent-bot.service

--- a/ansible/playbooks/web.yml
+++ b/ansible/playbooks/web.yml
@@ -8,12 +8,10 @@
 # Apply (live deploy):
 #   ansible-playbook playbooks/web.yml --tags apply \
 #     -e hyrule_web_apply=true \
-#     -e hyrule_web_version=<sha-or-ref> \
 #     --limit web
 #
-# The deploy.yml workflow in AS215932/hyrule-web invokes the apply variant
-# with hyrule_web_version=${{ github.sha }} so production deploys are pinned
-# to the exact commit that passed CI.
+# Production deploys use hyrule_web_version from inventory host_vars. Promote
+# a new app commit by updating the pinned SHA in network-operations.
 
 - name: hyrule-web — apply
   hosts: web

--- a/ansible/roles/hyrule_cloud/tasks/validate.yml
+++ b/ansible/roles/hyrule_cloud/tasks/validate.yml
@@ -3,15 +3,15 @@
 # possible, and they make `--tags validate` a real safety net rather than
 # a no-op rubber stamp.
 
-- name: Assert hyrule_cloud_version is set to a non-empty ref
+- name: Assert hyrule_cloud_version is pinned to a commit SHA
   ansible.builtin.assert:
     that:
       - hyrule_cloud_version is defined
-      - hyrule_cloud_version | length > 0
+      - hyrule_cloud_version is match('^[0-9a-fA-F]{40}$')
     fail_msg: >-
-      hyrule_cloud_version must be set to a branch, tag, or commit SHA.
-      The deploy workflow normally passes the triggering commit SHA;
-      for local runs pass -e hyrule_cloud_version=main (or a SHA for rollback).
+      hyrule_cloud_version must be set to a 40-character commit SHA. Production
+      deploys are promoted through network-operations by pinning the exact app
+      commit; for rollback, promote the previous SHA or pass it explicitly.
 
 - name: Stat reusable configs on the controller (hyrule-cloud.service)
   ansible.builtin.stat:

--- a/ansible/roles/hyrule_web/tasks/validate.yml
+++ b/ansible/roles/hyrule_web/tasks/validate.yml
@@ -3,15 +3,15 @@
 # possible, and they make `--tags validate` a real safety net rather than
 # a no-op rubber stamp.
 
-- name: Assert hyrule_web_version is set to a non-empty ref
+- name: Assert hyrule_web_version is pinned to a commit SHA
   ansible.builtin.assert:
     that:
       - hyrule_web_version is defined
-      - hyrule_web_version | length > 0
+      - hyrule_web_version is match('^[0-9a-fA-F]{40}$')
     fail_msg: >-
-      hyrule_web_version must be set to a branch, tag, or commit SHA.
-      The deploy workflow normally passes the triggering commit SHA;
-      for local runs pass -e hyrule_web_version=main (or a SHA for rollback).
+      hyrule_web_version must be set to a 40-character commit SHA. Production
+      deploys are promoted through network-operations by pinning the exact app
+      commit; for rollback, promote the previous SHA or pass it explicitly.
 
 - name: Stat reusable configs on the controller (hyrule-web.service)
   ansible.builtin.stat:

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -14,7 +14,7 @@ DISCORD_ALLOWED_GUILD_IDS={{ or .Data.data.discord_allowed_guild_ids "" }}
 DISCORD_ALLOWED_CHANNEL_IDS={{ or .Data.data.discord_allowed_channel_ids "" }}
 DISCORD_ALLOWED_ROLE_IDS={{ or .Data.data.discord_allowed_role_ids "" }}
 NOC_CONTROL_TOKEN={{ or .Data.data.noc_control_token "" }}
-NOC_APPROVAL_SIGNING_SECRET={{ or .Data.data.noc_approval_signing_secret "" }}
+NOC_APPROVAL_SIGNING_SECRET={{ .Data.data.noc_approval_signing_secret }}
 MAIL_IMAP_PASSWORD={{ .Data.data.mail_imap_password }}
 XO_TOKEN={{ .Data.data.xo_token }}
 ICINGA_API_USER={{ .Data.data.icinga_api_user }}
@@ -52,7 +52,7 @@ PROMETHEUS_URL=http://[{{ peers.mon.ipv6 }}]:9090
 HYRULE_MCP_HOSTS_CONFIG=/etc/hyrule-mcp/hosts.yml
 HYRULE_MCP_ENABLE_ACTIONS=1
 {% raw %}{{ with secret "kv/data/noc-agent" -}}
-HYRULE_MCP_ACTION_SIGNING_SECRET={{ or .Data.data.noc_approval_signing_secret "" }}
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ .Data.data.noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ or .Data.data.noc_action_allowed_hosts "noc,mon,cr1-nl1,cr1-de1" }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ or .Data.data.noc_action_allowed_services "node_exporter,noc-agent,noc-agent-bot,hyrule-mcp" }}
 {{- end }}{% endraw %}

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -51,3 +51,8 @@ XO_MCP_ENABLE_ACTIONS=0
 PROMETHEUS_URL=http://[{{ peers.mon.ipv6 }}]:9090
 HYRULE_MCP_HOSTS_CONFIG=/etc/hyrule-mcp/hosts.yml
 HYRULE_MCP_ENABLE_ACTIONS=1
+{% raw %}{{ with secret "kv/data/noc-agent" -}}
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ or .Data.data.noc_approval_signing_secret "" }}
+HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ or .Data.data.noc_action_allowed_hosts "noc,mon,cr1-nl1,cr1-de1" }}
+HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ or .Data.data.noc_action_allowed_services "node_exporter,noc-agent,noc-agent-bot,hyrule-mcp" }}
+{{- end }}{% endraw %}

--- a/configs/hyrule-mcp.env.j2
+++ b/configs/hyrule-mcp.env.j2
@@ -17,6 +17,6 @@ ICINGA_API_PASSWORD={{ icinga_api_password }}
 # Action tools are registered for the deterministic approval executor. The
 # triage agent still receives only read-only toolsets.
 HYRULE_MCP_ENABLE_ACTIONS=1
-HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret | default('') }}
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}

--- a/configs/hyrule-mcp.env.j2
+++ b/configs/hyrule-mcp.env.j2
@@ -17,3 +17,6 @@ ICINGA_API_PASSWORD={{ icinga_api_password }}
 # Action tools are registered for the deterministic approval executor. The
 # triage agent still receives only read-only toolsets.
 HYRULE_MCP_ENABLE_ACTIONS=1
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret | default('') }}
+HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
+HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}

--- a/configs/hyrule-mcp.service
+++ b/configs/hyrule-mcp.service
@@ -14,6 +14,7 @@ EnvironmentFile=/opt/noc-agent/.env
 Environment=HYRULE_MCP_TRANSPORT=http
 Environment=HYRULE_MCP_BIND=127.0.0.1
 Environment=HYRULE_MCP_PORT=8765
+ExecStartPre=/bin/grep -Eq "^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env
 ExecStart=/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py
 Restart=always
 RestartSec=5

--- a/configs/noc-agent-bot.service
+++ b/configs/noc-agent-bot.service
@@ -13,6 +13,8 @@ Group=noc-agent
 WorkingDirectory=/opt/noc-agent
 EnvironmentFile=/opt/noc-agent/.env
 Environment=PYTHONPATH=/opt/noc-agent
+ExecStartPre=/bin/grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env
+ExecStartPre=/bin/grep -Eq "^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env
 ExecStart=/opt/noc-agent/.venv/bin/noc-agent-bot
 Restart=always
 RestartSec=5

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -33,7 +33,7 @@ DISCORD_ALLOWED_GUILD_IDS={{ noc_discord_allowed_guild_ids | default('') }}
 DISCORD_ALLOWED_CHANNEL_IDS={{ noc_discord_allowed_channel_ids | default('') }}
 DISCORD_ALLOWED_ROLE_IDS={{ noc_discord_allowed_role_ids | default('') }}
 NOC_CONTROL_TOKEN={{ noc_control_token | default('') }}
-NOC_APPROVAL_SIGNING_SECRET={{ noc_approval_signing_secret | default('') }}
+NOC_APPROVAL_SIGNING_SECRET={{ noc_approval_signing_secret }}
 NOC_CONTROL_URL=http://127.0.0.1:8000
 NOC_REDIS_URL=redis://127.0.0.1:6379/0
 
@@ -67,6 +67,6 @@ ICINGA_API_PASSWORD={{ icinga_api_password }}
 # Action tools are registered for the deterministic approval executor. The
 # triage agent still receives only read-only toolsets.
 HYRULE_MCP_ENABLE_ACTIONS=1
-HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret | default('') }}
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -67,3 +67,6 @@ ICINGA_API_PASSWORD={{ icinga_api_password }}
 # Action tools are registered for the deterministic approval executor. The
 # triage agent still receives only read-only toolsets.
 HYRULE_MCP_ENABLE_ACTIONS=1
+HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret | default('') }}
+HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
+HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}

--- a/configs/noc-agent.service
+++ b/configs/noc-agent.service
@@ -13,6 +13,8 @@ Group=noc-agent
 WorkingDirectory=/opt/noc-agent
 EnvironmentFile=/opt/noc-agent/.env
 Environment=PYTHONPATH=/opt/noc-agent
+ExecStartPre=/bin/grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env
+ExecStartPre=/bin/grep -Eq "^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env
 ExecStart=/opt/noc-agent/.venv/bin/uvicorn app.main:app \
     --host :: \
     --port 8000 \

--- a/docs/ci/deploy-runbook.md
+++ b/docs/ci/deploy-runbook.md
@@ -2,20 +2,61 @@
 
 How to ship a change from "PR merged" to "live on production." Production is
 the next environment after `main` — there is no staging VM, by design (the
-approved plan trades fidelity for a smaller blast surface). Safety lives in
-two layers:
+approved plan trades fidelity for a smaller blast surface). For app-backed
+services, production deploys are promoted through `network-operations` by
+pinning exact app commit SHAs. Safety lives in three layers:
 
-1. **Render-check** before merge — the diff between `ansible/generated/` and
+1. **App CI** before promotion — the exact app commit has passed its required
+   lint, type, and test checks.
+2. **Render-check** before merge — the diff between `ansible/generated/` and
    what render produces is empty.
-2. **Icinga snapshot bracket** around apply — what was broken before and what
+3. **Icinga snapshot bracket** around apply — what was broken before and what
    is broken after, captured as artifacts on the workflow run.
+
+## App promotion model
+
+`hyrule-noc-agent`, `hyrule-mcp`, `hyrule-cloud`, and `hyrule-web` do not own
+normal production applies. Their repositories produce reviewed commits with
+green CI. `network-operations` owns production by pinning those commits in
+inventory:
+
+- `ansible/inventory/host_vars/noc.yml`: `noc_agent_version`,
+  `hyrule_mcp_version`
+- `ansible/inventory/host_vars/api.yml`: `hyrule_cloud_version`
+- `ansible/inventory/host_vars/web.yml`: `hyrule_web_version`
+
+Use the promotion PR template for coordinated deploys. Merge app PRs first,
+update the promotion PR to the exact merged app SHAs, run a dry-run from the
+promotion branch, then merge and apply from `network-operations/main`.
+
+The normal automated path is:
+
+1. Merge app PRs after app CI is green.
+2. Run **Actions -> promote-apps** in this repository and paste the merged app
+   SHAs into the relevant inputs.
+3. Review the generated promotion PR. It updates the app pins and records
+   compare links plus rollback SHAs.
+4. Merge the promotion PR after checks pass.
+5. **app-promotion-deploy** starts automatically on the `main` push when an app
+   pin file changed. It calls `apply.yml` for the affected playbook(s).
+6. Approve the GitHub `production` environment gate. This is the intended
+   manual deploy step.
+7. Review the workflow summary: app pins, compare links, and Icinga snapshot
+   diff.
+
+`apply.yml` itself is not a push-triggered workflow. It runs when either:
+
+- an operator manually starts it with `workflow_dispatch`, or
+- another workflow calls it through `workflow_call` (for app promotions, this is
+  `app-promotion-deploy` after a SHA-pin PR merges).
 
 ## When to ship
 
-After your PR merges to `main`. Most days that's also the same day, but
-deploys happen one at a time. If two operators merge back-to-back, ship
-sequentially (each apply's post-snapshot is the next apply's pre-snapshot
-baseline).
+For pure infrastructure changes, ship after the `network-operations` PR merges
+to `main`. For app-backed services, ship only after the app PRs are merged and
+the `network-operations` promotion PR pins their exact SHAs. Deploys happen one
+at a time. If two operators merge back-to-back, ship sequentially (each apply's
+post-snapshot is the next apply's pre-snapshot baseline).
 
 Do not ship during the documented merge-freeze windows (see `MEMORY.md` for
 any active freezes).
@@ -24,8 +65,8 @@ any active freezes).
 
 ```bash
 gh workflow run apply.yml \
-  -F playbook=firewall \
-  -F limit=cr1-de1 \
+  -F playbook=noc \
+  -F limit=noc \
   -F dry_run=false \
   -F pr_number=42         # optional — auto-comments the diff onto the PR
 ```
@@ -68,6 +109,17 @@ expected response is:
    reload; that just makes the next deploy harder.
 2. **If the apply failed mid-flight**: roll back the change with another PR,
    re-dispatch.
+
+## App rollback
+
+Prefer rollback by PR: revert the app version pin in `network-operations` to
+the previous known-good SHA, merge the rollback promotion PR, then run
+`apply.yml` for the affected playbook.
+
+During an active outage, an operator may pass an explicit old SHA through
+Ansible extra-vars from a trusted shell, then follow up with a PR that records
+the deployed pin. Extra-vars are an emergency escape hatch, not the normal
+promotion path.
 
 ## Manual deploy (bypass CI)
 

--- a/scripts/ci/promote-app-pins.py
+++ b/scripts/ci/promote-app-pins.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Update production app SHA pins and write a promotion PR body."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+PIN_TARGETS = {
+    "noc_agent_version": ("ansible/inventory/host_vars/noc.yml", "AS215932/noc-agent", "noc"),
+    "hyrule_mcp_version": ("ansible/inventory/host_vars/noc.yml", "AS215932/hyrule-mcp", "noc"),
+    "hyrule_cloud_version": ("ansible/inventory/host_vars/api.yml", "AS215932/hyrule-cloud", "cloud"),
+    "hyrule_web_version": ("ansible/inventory/host_vars/web.yml", "AS215932/hyrule-web", "web"),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--noc-agent-sha", default="")
+    parser.add_argument("--hyrule-mcp-sha", default="")
+    parser.add_argument("--hyrule-cloud-sha", default="")
+    parser.add_argument("--hyrule-web-sha", default="")
+    parser.add_argument("--title", default="Promote app SHAs")
+    parser.add_argument("--impact", default="Automated app SHA promotion.")
+    parser.add_argument("--body-file", default="")
+    args = parser.parse_args()
+
+    requested = {
+        "noc_agent_version": args.noc_agent_sha.strip(),
+        "hyrule_mcp_version": args.hyrule_mcp_sha.strip(),
+        "hyrule_cloud_version": args.hyrule_cloud_sha.strip(),
+        "hyrule_web_version": args.hyrule_web_sha.strip(),
+    }
+    requested = {key: value for key, value in requested.items() if value}
+    if not requested:
+        raise SystemExit("no app SHA inputs provided")
+
+    for key, sha in requested.items():
+        if not SHA_RE.match(sha):
+            raise SystemExit(f"{key} must be a 40-character commit SHA, got {sha!r}")
+
+    changes: list[tuple[str, str, str, str, str]] = []
+    for key, new_sha in requested.items():
+        rel_path, repo, playbook = PIN_TARGETS[key]
+        path = REPO / rel_path
+        old_sha = update_pin(path, key, new_sha)
+        changes.append((key, repo, playbook, old_sha, new_sha))
+
+    if args.body_file:
+        Path(args.body_file).write_text(render_body(args.title, args.impact, changes))
+
+    for key, _repo, _playbook, old_sha, new_sha in changes:
+        print(f"{key}: {old_sha} -> {new_sha}")
+    return 0
+
+
+def update_pin(path: Path, key: str, new_sha: str) -> str:
+    text = path.read_text()
+    pattern = re.compile(rf"^({re.escape(key)}:\s*)([0-9a-fA-F]{{40}})(\s*)$", re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        raise SystemExit(f"{path.relative_to(REPO)} does not contain {key} with a SHA value")
+    old_sha = match.group(2)
+    path.write_text(pattern.sub(rf"\g<1>{new_sha}\g<3>", text, count=1))
+    return old_sha
+
+
+def render_body(title: str, impact: str, changes: list[tuple[str, str, str, str, str]]) -> str:
+    affected = sorted({playbook for _key, _repo, playbook, old, new in changes if old != new})
+    lines = [
+        "## Promotion",
+        "",
+        f"Title: {title}",
+        "",
+        "App PRs:",
+        "- Automated promotion workflow; see linked app commits below.",
+        "",
+        "Pinned versions:",
+    ]
+    for key, repo, _playbook, old_sha, new_sha in changes:
+        compare = f"https://github.com/{repo}/compare/{old_sha}...{new_sha}"
+        lines.append(f"- `{key}`: `{new_sha}` ({compare})")
+
+    lines.extend(
+        [
+            "",
+            "Deploy impact:",
+            f"- Affected playbooks: {', '.join(affected) if affected else 'none'}",
+            f"- {impact}",
+            "",
+            "Rollback:",
+        ]
+    )
+    for key, _repo, _playbook, old_sha, _new_sha in changes:
+        lines.append(f"- Previous `{key}`: `{old_sha}`")
+
+    lines.extend(
+        [
+            "",
+            "Validation:",
+            "- [ ] App CI is green for every promoted SHA.",
+            "- [ ] `scripts/ci/iac-static.sh` passes.",
+            "- [ ] Promotion PR checks are green.",
+            "- [ ] Production environment gate approved after merge.",
+            "- [ ] Icinga pre/post snapshot diff reviewed.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vault-put-noc-agent-secrets.sh
+++ b/scripts/vault-put-noc-agent-secrets.sh
@@ -22,8 +22,9 @@ vault token lookup >/dev/null 2>&1 || {
 : "${XO_TOKEN:?XO_TOKEN is required}"
 : "${ICINGA_API_USER:?ICINGA_API_USER is required}"
 : "${ICINGA_API_PASSWORD:?ICINGA_API_PASSWORD is required}"
+: "${NOC_APPROVAL_SIGNING_SECRET:?NOC_APPROVAL_SIGNING_SECRET is required}"
 
-vault kv put kv/noc-agent \
+vault_args=(
   gemini_api_key="${GEMINI_API_KEY}" \
   anthropic_api_key="${ANTHROPIC_API_KEY:-}" \
   openai_api_key="${OPENAI_API_KEY:-}" \
@@ -34,12 +35,21 @@ vault kv put kv/noc-agent \
   discord_allowed_channel_ids="${NOC_DISCORD_ALLOWED_CHANNEL_IDS:-}" \
   discord_allowed_role_ids="${NOC_DISCORD_ALLOWED_ROLE_IDS:-}" \
   noc_control_token="${NOC_CONTROL_TOKEN:-}" \
-  noc_approval_signing_secret="${NOC_APPROVAL_SIGNING_SECRET:-}" \
-  noc_action_allowed_hosts="${NOC_ACTION_ALLOWED_HOSTS:-noc,mon,cr1-nl1,cr1-de1}" \
-  noc_action_allowed_services="${NOC_ACTION_ALLOWED_SERVICES:-node_exporter,noc-agent,noc-agent-bot,hyrule-mcp}" \
+  noc_approval_signing_secret="${NOC_APPROVAL_SIGNING_SECRET}" \
   mail_imap_password="${MAIL_NOC_PASSWORD}" \
   xo_token="${XO_TOKEN}" \
   icinga_api_user="${ICINGA_API_USER}" \
   icinga_api_password="${ICINGA_API_PASSWORD}"
+)
+
+if [ -n "${NOC_ACTION_ALLOWED_HOSTS:-}" ]; then
+  vault_args+=(noc_action_allowed_hosts="${NOC_ACTION_ALLOWED_HOSTS}")
+fi
+
+if [ -n "${NOC_ACTION_ALLOWED_SERVICES:-}" ]; then
+  vault_args+=(noc_action_allowed_services="${NOC_ACTION_ALLOWED_SERVICES}")
+fi
+
+vault kv put kv/noc-agent "${vault_args[@]}"
 
 echo "Wrote kv/noc-agent."

--- a/scripts/vault-put-noc-agent-secrets.sh
+++ b/scripts/vault-put-noc-agent-secrets.sh
@@ -35,6 +35,8 @@ vault kv put kv/noc-agent \
   discord_allowed_role_ids="${NOC_DISCORD_ALLOWED_ROLE_IDS:-}" \
   noc_control_token="${NOC_CONTROL_TOKEN:-}" \
   noc_approval_signing_secret="${NOC_APPROVAL_SIGNING_SECRET:-}" \
+  noc_action_allowed_hosts="${NOC_ACTION_ALLOWED_HOSTS:-noc,mon,cr1-nl1,cr1-de1}" \
+  noc_action_allowed_services="${NOC_ACTION_ALLOWED_SERVICES:-node_exporter,noc-agent,noc-agent-bot,hyrule-mcp}" \
   mail_imap_password="${MAIL_NOC_PASSWORD}" \
   xo_token="${XO_TOKEN}" \
   icinga_api_user="${ICINGA_API_USER}" \

--- a/tests/iac/test_app_version_pins.py
+++ b/tests/iac/test_app_version_pins.py
@@ -1,0 +1,34 @@
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class ProductionAppVersionPinsTest(unittest.TestCase):
+    def test_production_app_versions_are_full_commit_shas(self):
+        cases = {
+            "ansible/inventory/host_vars/noc.yml": ("noc_agent_version", "hyrule_mcp_version"),
+            "ansible/inventory/host_vars/api.yml": ("hyrule_cloud_version",),
+            "ansible/inventory/host_vars/web.yml": ("hyrule_web_version",),
+        }
+
+        for rel_path, keys in cases.items():
+            with self.subTest(path=rel_path):
+                values = yaml.safe_load((REPO / rel_path).read_text()) or {}
+                for key in keys:
+                    value = str(values.get(key, ""))
+                    self.assertRegex(
+                        value,
+                        SHA_RE,
+                        f"{rel_path}:{key} must be pinned to a 40-character commit SHA",
+                    )
+                    self.assertNotIn(value, {"main", "master", "HEAD"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -60,11 +60,32 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn('apply_var="${playbook//-/_}_apply=true"', workflow)
         self.assertIn('user_args=(-e ansible_user=ci)', workflow)
         self.assertIn(
-            'if [ "${playbook}" = "ci-runner-key" ] && [ "${{ inputs.bootstrap_ci_runner_key }}" = "true" ]; then',
+            'if [ "$playbook" = "ci-runner-key" ] && [ "$BOOTSTRAP_CI_RUNNER_KEY" = "true" ]; then',
             workflow,
         )
         self.assertIn('user_args=()', workflow)
         self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
+
+    def test_noc_action_signing_secret_has_no_empty_fallback(self):
+        vault_template = (REPO / "ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2").read_text()
+        noc_env = (REPO / "configs/noc-agent.env.j2").read_text()
+        mcp_env = (REPO / "configs/hyrule-mcp.env.j2").read_text()
+        vault_put = (REPO / "scripts/vault-put-noc-agent-secrets.sh").read_text()
+        noc_service = (REPO / "configs/noc-agent.service").read_text()
+        bot_service = (REPO / "configs/noc-agent-bot.service").read_text()
+        mcp_service = (REPO / "configs/hyrule-mcp.service").read_text()
+
+        for text in (vault_template, noc_env, mcp_env):
+            self.assertNotIn('noc_approval_signing_secret ""', text)
+            self.assertNotIn("noc_approval_signing_secret | default('')", text)
+
+        self.assertIn("NOC_APPROVAL_SIGNING_SECRET is required", vault_put)
+        self.assertNotIn("NOC_ACTION_ALLOWED_HOSTS:-noc,mon,cr1-nl1,cr1-de1", vault_put)
+        self.assertNotIn("NOC_ACTION_ALLOWED_SERVICES:-node_exporter,noc-agent,noc-agent-bot,hyrule-mcp", vault_put)
+        for text in (noc_service, bot_service):
+            self.assertIn('^NOC_APPROVAL_SIGNING_SECRET=.{32,}$', text)
+        for text in (noc_service, bot_service, mcp_service):
+            self.assertIn('^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$', text)
 
     def test_freebsd_playbooks_can_opt_into_become(self):
         freebsd_vars = yaml.safe_load((REPO / "ansible/inventory/group_vars/freebsd.yml").read_text())


### PR DESCRIPTION
## Promotion

Title: Promote control-plane app SHAs

App PRs:
- Automated promotion workflow; see linked app commits below.

Pinned versions:
- `noc_agent_version`: `d0b61e651f323c206fd1b603d83d1320b3c01797` (https://github.com/AS215932/noc-agent/compare/63d6c9b995b453b2ca92c21759ce6729cdda1ce5...d0b61e651f323c206fd1b603d83d1320b3c01797)
- `hyrule_mcp_version`: `d95e94766cc3608b38066bd50bc938c284b47bee` (https://github.com/AS215932/hyrule-mcp/compare/bbe5e4d7271b888581f86016234326b8cd60dd22...d95e94766cc3608b38066bd50bc938c284b47bee)
- `hyrule_cloud_version`: `5384a96bd9dbe381eb2bce192099de6f07bd27b4` (https://github.com/AS215932/hyrule-cloud/compare/1907cf99fe8d9c9c8b7ff825363fd33f63cb667a...5384a96bd9dbe381eb2bce192099de6f07bd27b4)

Deploy impact:
- Affected playbooks: cloud, noc
- Promotes merged noc-agent, hyrule-mcp, and hyrule-cloud changes. hyrule-web remains pinned until PR #22 receives approval and merges.

Rollback:
- Previous `noc_agent_version`: `63d6c9b995b453b2ca92c21759ce6729cdda1ce5`
- Previous `hyrule_mcp_version`: `bbe5e4d7271b888581f86016234326b8cd60dd22`
- Previous `hyrule_cloud_version`: `1907cf99fe8d9c9c8b7ff825363fd33f63cb667a`

Validation:
- [ ] App CI is green for every promoted SHA.
- [ ] `scripts/ci/iac-static.sh` passes.
- [ ] Promotion PR checks are green.
- [ ] Production environment gate approved after merge.
- [ ] Icinga pre/post snapshot diff reviewed.
