### PR TITLE
fix: escape Vault Agent reload commands

### DIFF
--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -87,8 +87,8 @@
         vault_agent_env_destination: /opt/noc-agent/.env
         vault_agent_google_subject_token_destination: "{{ noc_agent_google_subject_token_path }}"
         vault_agent_env_reload_command: >-
-          /bin/grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env &&
-          /bin/grep -Eq "^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env &&
+          /bin/grep -Eq ^NOC_APPROVAL_SIGNING_SECRET=................................ /opt/noc-agent/.env &&
+          /bin/grep -Eq ^HYRULE_MCP_ACTION_SIGNING_SECRET=................................ /opt/noc-agent/.env &&
           /bin/systemctl restart xo-mcp.service &&
           /bin/systemctl restart noc-agent.service &&
           /bin/systemctl restart noc-agent-bot.service

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -43,7 +43,8 @@ template {
   source      = "{{ vault_agent_template_dir }}/{{ t.name }}"
   destination = "{{ t.destination }}"
   perms       = 0640
-  command     = "/bin/sh -c 'chgrp {{ t.group }} {{ t.destination }} && chmod 0640 {{ t.destination }} && {{ t.reload_command }}'"
+{% set render_command = "/bin/sh -c 'chgrp " ~ t.group ~ " " ~ t.destination ~ " && chmod 0640 " ~ t.destination ~ " && " ~ t.reload_command ~ "'" %}
+  command     = {{ render_command | to_json }}
 
   wait {
     min = "2s"

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -1,4 +1,6 @@
+import json
 import unittest
+from copy import deepcopy
 from pathlib import Path
 
 import yaml
@@ -10,19 +12,33 @@ MOCK = yaml.safe_load((REPO / "tests/iac/mock_inventory.yml").read_text())
 
 
 class MockRenderTest(unittest.TestCase):
-    def render(self, template):
+    def render(self, template, context=None):
+        context = MOCK if context is None else context
         env = Environment(
             loader=FileSystemLoader(str(template.parent)),
             undefined=StrictUndefined,
             keep_trailing_newline=True,
         )
         env.filters["bool"] = bool
-        return env.get_template(template.name).render(**MOCK)
+        env.filters["to_json"] = json.dumps
+        return env.get_template(template.name).render(**context)
 
     def test_vault_agent_config_renders_with_wrapped_secretid(self):
         rendered = self.render(REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2")
         self.assertIn('secret_id_response_wrapping_path = "auth/approle/role/hyrule-cloud/secret-id"', rendered)
         self.assertIn("remove_secret_id_file_after_reading = true", rendered)
+
+    def test_vault_agent_config_escapes_reload_command_quotes(self):
+        context = deepcopy(MOCK)
+        context["vault_agent_templates"][0]["reload_command"] = (
+            '/bin/grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$" /opt/noc-agent/.env && '
+            "/bin/systemctl restart noc-agent.service"
+        )
+
+        rendered = self.render(REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2", context)
+
+        self.assertIn(r"\"^NOC_APPROVAL_SIGNING_SECRET=.{32,}$\"", rendered)
+        self.assertNotIn('grep -Eq "^NOC_APPROVAL_SIGNING_SECRET=.{32,}$"', rendered)
 
     def test_hyrule_cloud_vault_render_hook_renders_required_keys(self):
         rendered = self.render(REPO / "ansible/roles/hyrule_cloud/templates/vault-render-hook.sh.j2")


### PR DESCRIPTION
## Summary
- JSON-escape Vault Agent template reload commands before embedding them in HCL
- Add a regression test for reload commands containing quoted grep regexes

## Why
The NOC deploy rendered an invalid /etc/vault-agent.d/noc-agent.hcl because the new reload command included unescaped double quotes. Vault Agent then failed with:

`error loading configuration from /etc/vault-agent.d/noc-agent.hcl: At 37:118: illegal char`

## Validation
- `python3 -m unittest tests.iac.test_mock_render tests.iac.test_vault_and_runner_contracts`
- `scripts/ci/iac-static.sh`

## Follow-up operator step
Seed `kv/noc-agent` with `noc_approval_signing_secret`; the NOC AppRole is read-only and cannot perform that patch.