### PR TITLE
Fix app promotion apply gates

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -192,6 +192,40 @@ jobs:
             echo "| \`${key}\` | \`${repo}\` | \`${current}\` | ${compare} |" >> "$GITHUB_STEP_SUMMARY"
           done
 
+      - name: Resolve apply gate variable
+        env:
+          PLAYBOOK: ${{ inputs.playbook }}
+        run: |
+          set -euo pipefail
+
+          playbook="$PLAYBOOK"
+          case "$playbook" in
+            cloud)
+              apply_var="hyrule_cloud_apply=true"
+              expected_apply_var="hyrule_cloud_apply=true"
+              ;;
+            web)
+              apply_var="hyrule_web_apply=true"
+              expected_apply_var="hyrule_web_apply=true"
+              ;;
+            *)
+              apply_var="${playbook//-/_}_apply=true"
+              expected_apply_var="${playbook//-/_}_apply=true"
+              ;;
+          esac
+
+          if [ "$apply_var" != "$expected_apply_var" ]; then
+            echo "::error::${playbook} resolved apply gate ${apply_var}, expected ${expected_apply_var}"
+            exit 1
+          fi
+
+          printf 'APPLY_VAR=%s\n' "$apply_var" >> "$GITHUB_ENV"
+          {
+            echo "## Apply gate"
+            echo
+            echo "\`${apply_var}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # -e ansible_user=ci: the runner connects as the dedicated `ci` deploy
       # user on every host (created + NOPASSWD-root by the ci_runner_key role)
       # and escalates with sudo — never root, never the operator's svag. An
@@ -232,7 +266,6 @@ jobs:
           BOOTSTRAP_CI_RUNNER_KEY: ${{ inputs.bootstrap_ci_runner_key }}
         run: |
           playbook="$PLAYBOOK"
-          apply_var="${playbook//-/_}_apply=true"
           user_args=(-e ansible_user=ci)
           limit_args=()
           if [ -n "$LIMIT" ]; then
@@ -244,7 +277,7 @@ jobs:
           ansible-playbook "playbooks/${playbook}.yml" \
             --tags apply \
             "${user_args[@]}" \
-            -e "${apply_var}" \
+            -e "${APPLY_VAR}" \
             "${limit_args[@]}"
 
       - name: Post-deploy Icinga snapshot

--- a/.github/workflows/render-check.yml
+++ b/.github/workflows/render-check.yml
@@ -9,12 +9,6 @@ name: render-check
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'ansible/**'
-      - 'configs/**'
-      - 'docs/network-flows.md'
-      - 'scripts/ci/render-all.sh'
-      - '.github/workflows/render-check.yml'
   push:
     branches: [main]
     paths:

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -50,6 +50,16 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
             self.assertIn("hyrule-infra", text, name)
             self.assertNotIn("hyrule-public-pr", text, name)
 
+    def test_required_render_check_reports_on_every_pull_request(self):
+        workflow = yaml.safe_load((REPO / ".github/workflows/render-check.yml").read_text())
+        pull_request = workflow.get("on", workflow.get(True))["pull_request"]
+
+        self.assertNotIn(
+            "paths",
+            pull_request,
+            "render is a required branch-protection context, so it must not be skipped by PR path filters",
+        )
+
     def test_apply_workflow_can_gate_ci_runner_key_bootstrap(self):
         workflow = (REPO / ".github/workflows/apply.yml").read_text()
 
@@ -57,7 +67,26 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn("bootstrap_ci_runner_key:", workflow)
         self.assertIn("Connect as inventory users for first-time ci-runner-key bootstrap", workflow)
         self.assertIn("CI_KEY_PATH: /var/lib/github-runner/.ssh/id_ci", workflow)
-        self.assertIn('apply_var="${playbook//-/_}_apply=true"', workflow)
+        self.assertRegex(
+            workflow,
+            r"""case "\$playbook" in
+\s+cloud\)
+\s+apply_var="hyrule_cloud_apply=true"
+\s+expected_apply_var="hyrule_cloud_apply=true"
+\s+;;
+\s+web\)
+\s+apply_var="hyrule_web_apply=true"
+\s+expected_apply_var="hyrule_web_apply=true"
+\s+;;
+\s+\*\)
+\s+apply_var="\$\{playbook//-/_\}_apply=true"
+\s+expected_apply_var="\$\{playbook//-/_\}_apply=true"
+\s+;;
+\s+esac""",
+        )
+        self.assertIn('printf \'APPLY_VAR=%s\\n\' "$apply_var" >> "$GITHUB_ENV"', workflow)
+        self.assertIn('-e "${APPLY_VAR}"', workflow)
+        self.assertNotIn('-e "${apply_var}"', workflow)
         self.assertIn('user_args=(-e ansible_user=ci)', workflow)
         self.assertIn(
             'if [ "$playbook" = "ci-runner-key" ] && [ "$BOOTSTRAP_CI_RUNNER_KEY" = "true" ]; then',


### PR DESCRIPTION
## Summary
- map apply.yml playbook=cloud to hyrule_cloud_apply=true
- map apply.yml playbook=web to hyrule_web_apply=true
- keep existing playbook-name apply gates for all other playbooks
- add regression coverage for the cloud/web app deploy gate mapping

## Why
The #172 app-promotion deploy jobs for cloud/web reported success while skipping the actual mutating role tasks. The workflow passed cloud_apply=true/web_apply=true, but the roles are gated on hyrule_cloud_apply/hyrule_web_apply.

## Validation
- uv run pytest tests/iac/test_vault_and_runner_contracts.py -q
- scripts/ci/iac-static.sh
- ansible-playbook playbooks/cloud.yml --tags apply --limit api -e hyrule_cloud_apply=true --list-tasks
- ansible-playbook playbooks/web.yml --tags apply --limit web -e hyrule_web_apply=true --list-tasks