### PR TITLE
Automate cloud Vault bootstrap during applies

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -226,6 +226,45 @@ jobs:
             echo "\`${apply_var}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Mint hyrule-cloud Vault bootstrap
+        if: ${{ !inputs.dry_run && inputs.playbook == 'cloud' }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${VAULT_HYRULE_CLOUD_ROLE_ID:-}" ] && { [ -n "${VAULT_HYRULE_CLOUD_WRAPPED_SECRET_ID:-}" ] || [ -n "${VAULT_HYRULE_CLOUD_SECRET_ID:-}" ]; }; then
+            echo "hyrule-cloud Vault bootstrap already provided by environment"
+            exit 0
+          fi
+
+          token_file="/run/vault-agent/github-runner.token"
+          if [ -r "$token_file" ]; then
+            vault_token="$(cat "$token_file")"
+          else
+            vault_token="$(sudo cat "$token_file")"
+          fi
+
+          export VAULT_ADDR="${VAULT_ADDR:-http://[2a0c:b641:b50:2::c0]:8200}"
+          export VAULT_TOKEN="$vault_token"
+
+          role_id="$(vault read -field=role_id auth/approle/role/hyrule-cloud/role-id)"
+          wrapped_secret_id="$(vault write -wrap-ttl=10m -field=wrapping_token -f auth/approle/role/hyrule-cloud/secret-id)"
+
+          if [ -z "$role_id" ] || [ -z "$wrapped_secret_id" ]; then
+            echo "::error::failed to mint hyrule-cloud Vault bootstrap credentials"
+            exit 1
+          fi
+
+          echo "::add-mask::$role_id"
+          echo "::add-mask::$wrapped_secret_id"
+          printf 'VAULT_HYRULE_CLOUD_ROLE_ID=%s\n' "$role_id" >> "$GITHUB_ENV"
+          printf 'VAULT_HYRULE_CLOUD_WRAPPED_SECRET_ID=%s\n' "$wrapped_secret_id" >> "$GITHUB_ENV"
+
+          {
+            echo "## hyrule-cloud Vault bootstrap"
+            echo
+            echo "Minted response-wrapped AppRole SecretID for this apply run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # -e ansible_user=ci: the runner connects as the dedicated `ci` deploy
       # user on every host (created + NOPASSWD-root by the ci_runner_key role)
       # and escalates with sudo — never root, never the operator's svag. An

--- a/ansible/roles/hyrule_web/tasks/health.yml
+++ b/ansible/roles/hyrule_web/tasks/health.yml
@@ -1,10 +1,18 @@
 ---
-# Flush handlers so the systemd-active assert and the HTTP probe see the
-# *post-restart* state, not the pre-restart state. Without flush_handlers,
-# Ansible runs handlers at end-of-play and these checks would race the restart.
+# Flush handlers first so any `reload systemd` (changed unit file) runs before
+# we restart. Then restart UNCONDITIONALLY: the deploy must guarantee the
+# running process is on the requested ref, but a retry where the checkout SHA
+# was already current, or a code-only deploy, notifies no restart handler and
+# leaves the old process running.
 
-- name: Flush handlers before health check
+- name: Flush handlers (reload systemd if the unit changed) before restart
   ansible.builtin.meta: flush_handlers
+
+- name: Restart hyrule-web (deterministic on every apply)
+  ansible.builtin.systemd:
+    name: "{{ hyrule_web_service_name }}"
+    state: restarted
+    enabled: true
 
 - name: Check hyrule-web systemd state
   ansible.builtin.systemd:

--- a/configs/vault/policies/github-runner.hcl
+++ b/configs/vault/policies/github-runner.hcl
@@ -14,3 +14,15 @@ path "kv/data/ci-runner" {
 path "kv/metadata/ci-runner" {
   capabilities = ["read"]
 }
+
+# Production cloud applies run on the trusted ci runner and need to bootstrap
+# the api VM's target-side Vault Agent. The runner may mint only a short-lived,
+# response-wrapped SecretID for the hyrule-cloud AppRole; it still cannot read
+# kv/hyrule-cloud runtime secrets.
+path "auth/approle/role/hyrule-cloud/role-id" {
+  capabilities = ["read"]
+}
+
+path "auth/approle/role/hyrule-cloud/secret-id" {
+  capabilities = ["update"]
+}

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -95,6 +95,38 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertIn('user_args=()', workflow)
         self.assertNotIn('${{ inputs.playbook }}_apply=true', workflow)
 
+    def test_cloud_apply_mints_wrapped_vault_bootstrap(self):
+        workflow = (REPO / ".github/workflows/apply.yml").read_text()
+        runner_policy = (REPO / "configs/vault/policies/github-runner.hcl").read_text()
+        runner_template = (REPO / "ansible/roles/vault_agent/templates/github-runner.env.ctmpl.j2").read_text()
+
+        self.assertIn("Mint hyrule-cloud Vault bootstrap", workflow)
+        self.assertIn("inputs.playbook == 'cloud'", workflow)
+        self.assertIn("!inputs.dry_run", workflow)
+        self.assertIn('vault read -field=role_id auth/approle/role/hyrule-cloud/role-id', workflow)
+        self.assertIn(
+            'vault write -wrap-ttl=10m -field=wrapping_token -f auth/approle/role/hyrule-cloud/secret-id',
+            workflow,
+        )
+        self.assertIn("VAULT_HYRULE_CLOUD_WRAPPED_SECRET_ID", workflow)
+
+        self.assertIn('path "auth/approle/role/hyrule-cloud/role-id"', runner_policy)
+        self.assertIn('path "auth/approle/role/hyrule-cloud/secret-id"', runner_policy)
+        self.assertIn('capabilities = ["read"]', runner_policy)
+        self.assertIn('capabilities = ["update"]', runner_policy)
+
+        self.assertNotIn("kv/data/hyrule-cloud", runner_policy)
+        self.assertNotIn("XCPNG_XO_TOKEN", runner_template)
+        self.assertNotIn("VAULT_HYRULE_CLOUD_SECRET_ID", runner_template)
+
+    def test_app_roles_restart_deterministically_on_apply(self):
+        for role in ("hyrule_cloud", "hyrule_web"):
+            health_tasks = yaml.safe_load((REPO / "ansible/roles" / role / "tasks/health.yml").read_text())
+            restart_task = _task_by_name(health_tasks, f"Restart {role.replace('_', '-')} (deterministic on every apply)")
+
+            self.assertIsNotNone(restart_task, role)
+            self.assertEqual(restart_task["ansible.builtin.systemd"]["state"], "restarted")
+
     def test_noc_action_signing_secret_has_no_empty_fallback(self):
         vault_template = (REPO / "ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2").read_text()
         noc_env = (REPO / "configs/noc-agent.env.j2").read_text()


### PR DESCRIPTION
## Summary
- allow the trusted ci runner Vault policy to mint only response-wrapped hyrule-cloud AppRole SecretIDs
- have apply.yml mint a short-lived wrapped SecretID for non-dry-run cloud applies when one was not provided
- restart hyrule-web deterministically on every apply so code-only deploys actually update the running process
- add contract tests for cloud bootstrap and deterministic app restarts

## Operational note
I applied the updated github-runner Vault policy live with: vault policy write github-runner configs/vault/policies/github-runner.hcl

I also completed a one-time cloud bootstrap/deploy from the workstation using a response-wrapped SecretID.

## Validation
- uv run pytest tests/iac/test_vault_and_runner_contracts.py -q
- scripts/ci/iac-static.sh
- manual cloud apply: passed, /opt/hyrule-cloud at 5384a96bd9dbe381eb2bce192099de6f07bd27b4
- web service manually restarted after existing successful apply; /opt/hyrule-web at 45d7bb6964c686188a49da032de785be55e95a56