### PR TITLE
Fix runner Vault token sink permissions

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -237,11 +237,11 @@ jobs:
           fi
 
           token_file="/run/vault-agent/github-runner.token"
-          if [ -r "$token_file" ]; then
-            vault_token="$(cat "$token_file")"
-          else
-            vault_token="$(sudo cat "$token_file")"
+          if [ ! -r "$token_file" ]; then
+            echo "::error::${token_file} is not readable by the runner user; re-apply playbooks/ci.yml to refresh Vault Agent token sink permissions"
+            exit 1
           fi
+          vault_token="$(cat "$token_file")"
 
           export VAULT_ADDR="${VAULT_ADDR:-http://[2a0c:b641:b50:2::c0]:8200}"
           export VAULT_TOKEN="$vault_token"

--- a/ansible/roles/github_runner/tasks/main.yml
+++ b/ansible/roles/github_runner/tasks/main.yml
@@ -653,6 +653,11 @@
     vault_agent_name: github-runner
     vault_agent_role_id: "{{ github_runner_vault_role_id }}"
     vault_agent_secret_id: "{{ github_runner_vault_secret_id }}"
+    vault_agent_service_group: "{{ github_runner_group }}"
+    vault_agent_run_dir_group: "{{ github_runner_group }}"
+    vault_agent_run_dir_mode: "2750"
+    vault_agent_token_sink_group: "{{ github_runner_group }}"
+    vault_agent_token_sink_mode: "0640"
     vault_agent_templates:
       - src: github-runner.env.ctmpl.j2
         name: github-runner.env.ctmpl

--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -5,14 +5,19 @@ vault_agent_name: noc-agent
 # Caddy so a proxy outage does not break the secrets plane.
 vault_agent_vault_addr: "http://[{{ peers.vault.ipv6 }}]:8200"
 vault_agent_vault_tls_skip_verify: false
+vault_agent_service_group: root
 vault_agent_config_dir: "/etc/vault-agent.d"
 vault_agent_run_dir: "/run/vault-agent"
+vault_agent_run_dir_group: root
+vault_agent_run_dir_mode: "0750"
 vault_agent_role_id: ""
 vault_agent_secret_id: ""
 vault_agent_secret_id_response_wrapping_path: ""
 vault_agent_role_id_file: "{{ vault_agent_config_dir }}/{{ vault_agent_name }}-role-id"
 vault_agent_secret_id_file: "{{ vault_agent_config_dir }}/{{ vault_agent_name }}-secret-id"
 vault_agent_token_sink: "{{ vault_agent_run_dir }}/{{ vault_agent_name }}.token"
+vault_agent_token_sink_group: root
+vault_agent_token_sink_mode: "0600"
 vault_agent_template_dir: "{{ vault_agent_config_dir }}/templates"
 vault_agent_env_destination: /opt/noc-agent/.env
 vault_agent_google_subject_token_destination: /run/noc-agent/google-subject.jwt

--- a/ansible/roles/vault_agent/tasks/main.yml
+++ b/ansible/roles/vault_agent/tasks/main.yml
@@ -45,7 +45,7 @@
     {{ [
          {'path': vault_agent_config_dir, 'mode': '0750'},
          {'path': vault_agent_template_dir, 'mode': '0750'},
-         {'path': vault_agent_run_dir, 'mode': '0750'},
+         {'path': vault_agent_run_dir, 'group': vault_agent_run_dir_group, 'mode': vault_agent_run_dir_mode},
        ] + vault_agent_extra_dirs }}
   tags: [apply]
 
@@ -144,6 +144,18 @@
     enabled: true
     daemon_reload: true
   when:
+    - vault_agent_role_id | length > 0 or vault_agent_existing_role_id.stat.exists
+    - vault_agent_secret_id | length > 0 or vault_agent_existing_secret_id.stat.exists or vault_agent_existing_token_sink.stat.exists
+  tags: [apply]
+
+- name: Ensure Vault Agent token sink permissions
+  file:
+    path: "{{ vault_agent_token_sink }}"
+    owner: root
+    group: "{{ vault_agent_token_sink_group }}"
+    mode: "{{ vault_agent_token_sink_mode }}"
+  when:
+    - vault_agent_token_sink_group != "root" or vault_agent_token_sink_mode != "0600"
     - vault_agent_role_id | length > 0 or vault_agent_existing_role_id.stat.exists
     - vault_agent_secret_id | length > 0 or vault_agent_existing_secret_id.stat.exists or vault_agent_existing_token_sink.stat.exists
   tags: [apply]

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -33,7 +33,7 @@ auto_auth {
   sink "file" {
     config = {
       path = "{{ vault_agent_token_sink }}"
-      mode = 0600
+      mode = {{ vault_agent_token_sink_mode }}
     }
   }
 }

--- a/ansible/roles/vault_agent/templates/vault-agent.service.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.service.j2
@@ -9,7 +9,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=root
-Group=root
+Group={{ vault_agent_service_group }}
 {# Recreate the consumer's volatile (/run) dirs on boot — tmpfs is wiped.
    Persistent dirs (e.g. /etc/*) are handled by the role's file task. #}
 {% for d in vault_agent_extra_dirs if d.path.startswith('/run/') %}
@@ -22,7 +22,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
 RuntimeDirectory=vault-agent
-RuntimeDirectoryMode=0750
+RuntimeDirectoryMode={{ vault_agent_run_dir_mode }}
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHome=yes

--- a/tests/iac/mock_inventory.yml
+++ b/tests/iac/mock_inventory.yml
@@ -55,6 +55,7 @@ vault_agent_role_id_file: /etc/vault-agent.d/hyrule-cloud-role-id
 vault_agent_secret_id_file: /etc/vault-agent.d/hyrule-cloud-secret-id
 vault_agent_secret_id_response_wrapping_path: auth/approle/role/hyrule-cloud/secret-id
 vault_agent_token_sink: /run/vault-agent/hyrule-cloud.token
+vault_agent_token_sink_mode: "0600"
 vault_agent_template_dir: /etc/vault-agent.d/templates
 vault_agent_templates:
   - name: hyrule-cloud.env.ctmpl

--- a/tests/iac/test_mock_render.py
+++ b/tests/iac/test_mock_render.py
@@ -27,6 +27,15 @@ class MockRenderTest(unittest.TestCase):
         rendered = self.render(REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2")
         self.assertIn('secret_id_response_wrapping_path = "auth/approle/role/hyrule-cloud/secret-id"', rendered)
         self.assertIn("remove_secret_id_file_after_reading = true", rendered)
+        self.assertIn("mode = 0600", rendered)
+
+    def test_vault_agent_config_renders_custom_token_sink_mode(self):
+        context = deepcopy(MOCK)
+        context["vault_agent_token_sink_mode"] = "0640"
+
+        rendered = self.render(REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2", context)
+
+        self.assertIn("mode = 0640", rendered)
 
     def test_vault_agent_config_escapes_reload_command_quotes(self):
         context = deepcopy(MOCK)

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -108,7 +108,9 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
             'vault write -wrap-ttl=10m -field=wrapping_token -f auth/approle/role/hyrule-cloud/secret-id',
             workflow,
         )
+        self.assertIn("is not readable by the runner user", workflow)
         self.assertIn("VAULT_HYRULE_CLOUD_WRAPPED_SECRET_ID", workflow)
+        self.assertNotIn("sudo cat", workflow)
 
         self.assertIn('path "auth/approle/role/hyrule-cloud/role-id"', runner_policy)
         self.assertIn('path "auth/approle/role/hyrule-cloud/secret-id"', runner_policy)
@@ -118,6 +120,36 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertNotIn("kv/data/hyrule-cloud", runner_policy)
         self.assertNotIn("XCPNG_XO_TOKEN", runner_template)
         self.assertNotIn("VAULT_HYRULE_CLOUD_SECRET_ID", runner_template)
+
+    def test_github_runner_vault_token_sink_is_runner_readable(self):
+        defaults = yaml.safe_load((REPO / "ansible/roles/vault_agent/defaults/main.yml").read_text())
+        vault_tasks = yaml.safe_load((REPO / "ansible/roles/vault_agent/tasks/main.yml").read_text())
+        vault_template = (REPO / "ansible/roles/vault_agent/templates/vault-agent.hcl.j2").read_text()
+        service_template = (REPO / "ansible/roles/vault_agent/templates/vault-agent.service.j2").read_text()
+        runner_tasks = yaml.safe_load((REPO / "ansible/roles/github_runner/tasks/main.yml").read_text())
+
+        self.assertEqual(defaults["vault_agent_service_group"], "root")
+        self.assertEqual(defaults["vault_agent_token_sink_group"], "root")
+        self.assertEqual(defaults["vault_agent_token_sink_mode"], "0600")
+        self.assertEqual(defaults["vault_agent_run_dir_group"], "root")
+        self.assertEqual(defaults["vault_agent_run_dir_mode"], "0750")
+        self.assertIn("mode = {{ vault_agent_token_sink_mode }}", vault_template)
+        self.assertIn("Group={{ vault_agent_service_group }}", service_template)
+        self.assertIn("RuntimeDirectoryMode={{ vault_agent_run_dir_mode }}", service_template)
+
+        token_permission_task = _task_by_name(vault_tasks, "Ensure Vault Agent token sink permissions")
+        self.assertIsNotNone(token_permission_task)
+        self.assertEqual(token_permission_task["file"]["group"], "{{ vault_agent_token_sink_group }}")
+        self.assertEqual(token_permission_task["file"]["mode"], "{{ vault_agent_token_sink_mode }}")
+
+        runner_vault_task = _task_by_name(runner_tasks, "Set up Vault Agent for runner secret delivery")
+        self.assertIsNotNone(runner_vault_task)
+        runner_vars = runner_vault_task["vars"]
+        self.assertEqual(runner_vars["vault_agent_service_group"], "{{ github_runner_group }}")
+        self.assertEqual(runner_vars["vault_agent_run_dir_group"], "{{ github_runner_group }}")
+        self.assertEqual(runner_vars["vault_agent_run_dir_mode"], "2750")
+        self.assertEqual(runner_vars["vault_agent_token_sink_group"], "{{ github_runner_group }}")
+        self.assertEqual(runner_vars["vault_agent_token_sink_mode"], "0640")
 
     def test_app_roles_restart_deterministically_on_apply(self):
         for role in ("hyrule_cloud", "hyrule_web"):


### PR DESCRIPTION
## Summary
- make Vault Agent token sink group/mode configurable while preserving root-only defaults
- run the github-runner Vault Agent as root:runner and write its token sink as root:runner 0640
- remove the sudo fallback from apply.yml cloud bootstrap and fail clearly if the token is unreadable
- add render/contract coverage for default and custom token sink modes

## Live remediation
Applied playbooks/ci.yml from this branch to ci. Verified vault-agent-github-runner now runs with Group=runner, /run/vault-agent is root:runner 2750, /run/vault-agent/github-runner.token is root:runner 0640, and runner can read it without sudo.

## Validation
- uv run pytest tests/iac/test_vault_and_runner_contracts.py tests/iac/test_mock_render.py -q
- scripts/ci/iac-static.sh
- ansible-playbook playbooks/ci.yml --tags apply -e github_runner_apply=true --limit ci
