### PR TITLE
[codex] Promote NOC Agent and restore OpenRouter model defaults

### DIFF
--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,7 +5,7 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
-noc_agent_version: d0b61e651f323c206fd1b603d83d1320b3c01797
+noc_agent_version: 746cb5aff239f21a0492d0a4af210076ffd40a41
 hyrule_mcp_version: d95e94766cc3608b38066bd50bc938c284b47bee
 
 firewall_extra_rules:

--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -57,6 +57,8 @@
       tags: [snapshot, always]
   vars:
     gemini_api_key: "{{ lookup('env', 'GEMINI_API_KEY') }}"
+    openrouter_api_key: "{{ lookup('env', 'OPENROUTER_API_KEY') | default('', true) }}"
+    openrouter_management_api_key: "{{ lookup('env', 'OPENROUTER_MANAGEMENT_API_KEY') | default('', true) }}"
     noc_discord_webhook: "{{ lookup('env', 'NOC_DISCORD_WEBHOOK') }}"
     icinga_api_user: "{{ lookup('env', 'ICINGA_API_USER') }}"
     icinga_api_password: "{{ lookup('env', 'ICINGA_API_PASSWORD') }}"

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -4,6 +4,8 @@
 {% raw %}{{ with secret "kv/data/noc-agent" -}}
 GEMINI_API_KEY={{ .Data.data.gemini_api_key }}
 GOOGLE_API_KEY={{ .Data.data.gemini_api_key }}
+OPENROUTER_API_KEY={{ or .Data.data.openrouter_api_key "" }}
+OPENROUTER_MANAGEMENT_API_KEY={{ or .Data.data.openrouter_management_api_key "" }}
 ANTHROPIC_API_KEY={{ or .Data.data.anthropic_api_key "" }}
 OPENAI_API_KEY={{ or .Data.data.openai_api_key "" }}
 
@@ -21,8 +23,12 @@ ICINGA_API_USER={{ .Data.data.icinga_api_user }}
 ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
 {{- end }}{% endraw %}
 
-AGENT_MODEL={{ noc_agent_model | default('google-gla:gemini-3.1-pro-preview') }}
-AGENT_FALLBACK_MODELS={{ noc_agent_fallback_models | default('google-gla:gemini-2.5-flash') }}
+{% if noc_agent_model is defined and noc_agent_model | length > 0 %}
+AGENT_MODEL={{ noc_agent_model }}
+{% endif %}
+{% if noc_agent_fallback_models is defined and noc_agent_fallback_models | length > 0 %}
+AGENT_FALLBACK_MODELS={{ noc_agent_fallback_models }}
+{% endif %}
 
 GEMINI_QUOTA_PROJECT_ID={{ gemini_quota_project_id | default('project-73d4ac43-0c8a-4ec0-ac5') }}
 GEMINI_QUOTA_METRIC={{ gemini_quota_metric | default('generativelanguage.googleapis.com/generate_requests_per_model_per_day') }}

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -9,8 +9,14 @@ GEMINI_API_KEY={{ gemini_api_key }}
 # PydanticAI's Google provider looks for GOOGLE_API_KEY; keep GEMINI_API_KEY
 # for existing operators/scripts and expose the provider-native alias too.
 GOOGLE_API_KEY={{ gemini_api_key }}
-AGENT_MODEL={{ noc_agent_model | default('google-gla:gemini-3.1-pro-preview') }}
-AGENT_FALLBACK_MODELS={{ noc_agent_fallback_models | default('google-gla:gemini-2.5-flash') }}
+OPENROUTER_API_KEY={{ openrouter_api_key | default('') }}
+OPENROUTER_MANAGEMENT_API_KEY={{ openrouter_management_api_key | default('') }}
+{% if noc_agent_model is defined and noc_agent_model | length > 0 %}
+AGENT_MODEL={{ noc_agent_model }}
+{% endif %}
+{% if noc_agent_fallback_models is defined and noc_agent_fallback_models | length > 0 %}
+AGENT_FALLBACK_MODELS={{ noc_agent_fallback_models }}
+{% endif %}
 ANTHROPIC_API_KEY={{ anthropic_api_key | default('') }}
 OPENAI_API_KEY={{ openai_api_key | default('') }}
 

--- a/scripts/vault-put-noc-agent-secrets.sh
+++ b/scripts/vault-put-noc-agent-secrets.sh
@@ -16,6 +16,7 @@ vault token lookup >/dev/null 2>&1 || {
   echo "Set VAULT_TOKEN to a token allowed to write kv/noc-agent, or run vault login" >&2
   exit 1
 }
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY is required}"
 : "${GEMINI_API_KEY:?GEMINI_API_KEY is required}"
 : "${NOC_DISCORD_WEBHOOK:?NOC_DISCORD_WEBHOOK is required}"
 : "${MAIL_NOC_PASSWORD:?MAIL_NOC_PASSWORD is required}"
@@ -26,6 +27,8 @@ vault token lookup >/dev/null 2>&1 || {
 
 vault_args=(
   gemini_api_key="${GEMINI_API_KEY}" \
+  openrouter_api_key="${OPENROUTER_API_KEY}" \
+  openrouter_management_api_key="${OPENROUTER_MANAGEMENT_API_KEY:-}" \
   anthropic_api_key="${ANTHROPIC_API_KEY:-}" \
   openai_api_key="${OPENAI_API_KEY:-}" \
   discord_webhook_url="${NOC_DISCORD_WEBHOOK}" \

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -180,6 +180,23 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         for text in (noc_service, bot_service, mcp_service):
             self.assertIn('^HYRULE_MCP_ACTION_SIGNING_SECRET=.{32,}$', text)
 
+    def test_noc_agent_model_defaults_come_from_toml_not_env(self):
+        vault_template = (REPO / "ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2").read_text()
+        noc_env = (REPO / "configs/noc-agent.env.j2").read_text()
+        vault_put = (REPO / "scripts/vault-put-noc-agent-secrets.sh").read_text()
+        playbook = (REPO / "ansible/playbooks/noc.yml").read_text()
+
+        for text in (vault_template, noc_env):
+            self.assertNotIn("google-gla:gemini-3.1-pro-preview", text)
+            self.assertNotIn("google-gla:gemini-2.5-flash", text)
+            self.assertIn("OPENROUTER_API_KEY", text)
+            self.assertIn("OPENROUTER_MANAGEMENT_API_KEY", text)
+
+        self.assertIn("OPENROUTER_API_KEY is required", vault_put)
+        self.assertIn('openrouter_api_key="${OPENROUTER_API_KEY}"', vault_put)
+        self.assertIn("openrouter_api_key", playbook)
+        self.assertIn("openrouter_management_api_key", playbook)
+
     def test_freebsd_playbooks_can_opt_into_become(self):
         freebsd_vars = yaml.safe_load((REPO / "ansible/inventory/group_vars/freebsd.yml").read_text())
 


### PR DESCRIPTION
## Promotion

App PRs:
- `AS215932/noc-agent#14` -> `746cb5aff239f21a0492d0a4af210076ffd40a41`

Pinned versions:
- `noc_agent_version`: `746cb5aff239f21a0492d0a4af210076ffd40a41`
- `hyrule_mcp_version`: unchanged (`d95e94766cc3608b38066bd50bc938c284b47bee`)
- `hyrule_cloud_version`: unchanged (`5384a96bd9dbe381eb2bce192099de6f07bd27b4`)
- `hyrule_web_version`: unchanged (`45d7bb6964c686188a49da032de785be55e95a56`)

Deploy impact:
- Affected playbooks: `noc`
- Expected service restarts: `noc-agent`, `noc-agent-bot`, `xo-mcp` through the Vault Agent render hook when the NOC env is re-rendered.
- Operator-visible behavior:
  - `/health/mcp` should recover from a timed-out MCP client by reconnecting instead of leaving a worker wedged until service restart.
  - `/health/model` should stop being forced to `google-gla:gemini-3.1-pro-preview` by the rendered environment. The TOML default OpenRouter model becomes authoritative unless `noc_agent_model` is explicitly set.

Model config note:
- Root cause: `/opt/noc-agent/config/noc-agent.toml` already specified OpenRouter, but the rendered `.env` still emitted `AGENT_MODEL=google-gla:gemini-3.1-pro-preview`, and env overrides TOML.
- This PR removes the Gemini default env override and renders `OPENROUTER_API_KEY` / `OPENROUTER_MANAGEMENT_API_KEY` from `kv/noc-agent`.
- Production still needs `openrouter_api_key` present in `kv/noc-agent`; I did not find it in the runner secret env.

Rollback:
- Previous `noc_agent_version`: `d0b61e651f323c206fd1b603d83d1320b3c01797`
- Previous `hyrule_mcp_version`: `d95e94766cc3608b38066bd50bc938c284b47bee`
- Previous `hyrule_cloud_version`: `5384a96bd9dbe381eb2bce192099de6f07bd27b4`
- Previous `hyrule_web_version`: `45d7bb6964c686188a49da032de785be55e95a56`

Validation:
- [x] App CI is green for every promoted SHA.
- [x] `uv run pytest tests/iac/test_vault_and_runner_contracts.py -q` passes.
- [x] `scripts/ci/iac-static.sh` passes.
- [x] `apply.yml` dry-run completed for each affected playbook. Run: `27169065589`.
- [ ] Production `apply.yml` completed.
- [ ] Icinga pre/post snapshot diff reviewed.
