### PR TITLE
[codex] Keep NAT64 VRF leak active

### DIFF
--- a/ansible/generated/rtr/nat64-vrf-leak.service
+++ b/ansible/generated/rtr/nat64-vrf-leak.service
@@ -1,0 +1,39 @@
+# /etc/systemd/system/nat64-vrf-leak.service
+# Leak the NAT64 prefix between overlay VRF (table 200) and default VRF so
+# Jool (default-VRF-only) can translate traffic for overlay clients.
+#
+# Forward: overlay -> default VRF so Jool's netfilter hook sees the packet.
+# Return:  Jool's reply -> overlay VRF to reach the client. The explicit
+# destination rules are intentionally narrower than the allocation-wide
+# source NAT64 rule; they prevent default-VRF route lookups from sending
+# translated SYN-ACKs for infra/customer VMs out the underlay.
+# Route in table 200 gives overlay clients a next-hop for 64:ff9b::/96.
+[Unit]
+Description=NAT64 VRF route leak rules
+After=systemd-networkd.service
+Before=jool.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# ExecStartPre lines tolerate missing rules on first boot (the leading '-').
+ExecStartPre=-/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
+ExecStartPre=-/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStartPre=-/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
+ExecStartPre=-/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
+ExecStartPre=-/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
+ExecStart=/usr/sbin/ip -6 route add 64:ff9b::/96 via 2001:41d0:303:48a::1 dev enX4 table 200
+ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901
+ExecStart=/usr/sbin/ip -6 rule add from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
+ExecStart=/usr/sbin/ip -6 rule add from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
+# ExecStop also tolerates already-missing rules. Failed cleanup must not block
+# a later restart from reinstalling the full route leak.
+ExecStop=-/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
+ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
+ExecStop=-/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
+ExecStop=-/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/firewall/handlers/main.yml
+++ b/ansible/roles/firewall/handlers/main.yml
@@ -14,13 +14,18 @@
   systemd:
     name: jool
     state: restarted
+    no_block: false
   when: inventory_hostname == 'rtr'
   listen: reload nftables
 
-- name: restart nat64-vrf-leak
+# Keep this handler after the synchronous Jool restart. Jool service restarts
+# stop nat64-vrf-leak because the unit is ordered Before=jool.service; restoring
+# the leak last reinstalls return-routing rules for overlay clients.
+- name: restart nat64-vrf-leak after jool
   systemd:
     name: nat64-vrf-leak
     state: restarted
+    no_block: false
   when: inventory_hostname == 'rtr'
   listen: reload nftables
 

--- a/ansible/roles/firewall/handlers/main.yml
+++ b/ansible/roles/firewall/handlers/main.yml
@@ -10,16 +10,16 @@
     state: reloaded
   listen: reload nftables
 
-- name: restart nat64-vrf-leak
+- name: restart jool
   systemd:
-    name: nat64-vrf-leak
+    name: jool
     state: restarted
   when: inventory_hostname == 'rtr'
   listen: reload nftables
 
-- name: restart jool
+- name: restart nat64-vrf-leak
   systemd:
-    name: jool
+    name: nat64-vrf-leak
     state: restarted
   when: inventory_hostname == 'rtr'
   listen: reload nftables

--- a/ansible/roles/firewall/tasks/nftables.yml
+++ b/ansible/roles/firewall/tasks/nftables.yml
@@ -1,4 +1,35 @@
 ---
+- name: Stage nat64-vrf-leak unit to controller (review artifact)
+  delegate_to: localhost
+  become: false
+  copy:
+    src: "{{ playbook_dir }}/../../configs/rtr/jool/nat64-vrf-leak.service"
+    dest: "{{ firewall_generated_dir }}/{{ inventory_hostname }}/nat64-vrf-leak.service"
+    mode: "0644"
+  when: inventory_hostname == "rtr"
+  tags: [validate, diff, apply]
+
+- name: Install nat64-vrf-leak unit on rtr
+  copy:
+    src: "{{ playbook_dir }}/../../configs/rtr/jool/nat64-vrf-leak.service"
+    dest: /etc/systemd/system/nat64-vrf-leak.service
+    mode: "0644"
+  when:
+    - inventory_hostname == "rtr"
+    - firewall_apply | default(false) | bool
+  notify: reload nftables
+  tags: [apply]
+
+- name: Enable nat64-vrf-leak unit on rtr
+  systemd:
+    name: nat64-vrf-leak
+    enabled: true
+    daemon_reload: true
+  when:
+    - inventory_hostname == "rtr"
+    - firewall_apply | default(false) | bool
+  tags: [apply]
+
 - name: Render nftables config to controller (review artifact)
   delegate_to: localhost
   become: false

--- a/configs/rtr/jool/nat64-vrf-leak.service
+++ b/configs/rtr/jool/nat64-vrf-leak.service
@@ -3,7 +3,10 @@
 # Jool (default-VRF-only) can translate traffic for overlay clients.
 #
 # Forward: overlay -> default VRF so Jool's netfilter hook sees the packet.
-# Return:  Jool's reply (src 64:ff9b::) -> overlay VRF to reach the client.
+# Return:  Jool's reply -> overlay VRF to reach the client. The explicit
+# destination rules are intentionally narrower than the allocation-wide
+# source NAT64 rule; they prevent default-VRF route lookups from sending
+# translated SYN-ACKs for infra/customer VMs out the underlay.
 # Route in table 200 gives overlay clients a next-hop for 64:ff9b::/96.
 [Unit]
 Description=NAT64 VRF route leak rules
@@ -15,12 +18,18 @@ Type=oneshot
 RemainAfterExit=yes
 # ExecStartPre lines tolerate missing rules on first boot (the leading '-').
 ExecStartPre=-/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
+ExecStartPre=-/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStartPre=-/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
 ExecStartPre=-/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
 ExecStartPre=-/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
 ExecStart=/usr/sbin/ip -6 route add 64:ff9b::/96 via 2001:41d0:303:48a::1 dev enX4 table 200
+ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901
 ExecStart=/usr/sbin/ip -6 rule add from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
 ExecStart=/usr/sbin/ip -6 rule add from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
 ExecStop=/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
+ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
 ExecStop=/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
 ExecStop=/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
 

--- a/configs/rtr/jool/nat64-vrf-leak.service
+++ b/configs/rtr/jool/nat64-vrf-leak.service
@@ -27,11 +27,13 @@ ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900
 ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901
 ExecStart=/usr/sbin/ip -6 rule add from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
 ExecStart=/usr/sbin/ip -6 rule add from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
-ExecStop=/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
-ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
-ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
-ExecStop=/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
-ExecStop=/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
+# ExecStop also tolerates already-missing rules. Failed cleanup must not block
+# a later restart from reinstalling the full route leak.
+ExecStop=-/usr/sbin/ip -6 route del 64:ff9b::/96 table 200
+ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900
+ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901
+ExecStop=-/usr/sbin/ip -6 rule del from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
+ExecStop=-/usr/sbin/ip -6 rule del from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -61,7 +61,11 @@ This:
 5. Schedules a 3-minute `at` watchdog that reverts to the backup if the play
    doesn't cancel it.
 6. Atomically moves the new config into place and triggers the reload handler.
-7. On rtr, the handler also restarts `nat64-vrf-leak` and `jool` (in that order). The IPv4 DNAT VRF leak lives in `10-enX2.network` as routing-policy rules and needs no per-reload restart.
+7. On `rtr`, the handler restarts `jool` first, then restarts
+   `nat64-vrf-leak`. This order matters: restarting Jool can stop the leak
+   unit because `nat64-vrf-leak.service` is ordered `Before=jool.service`, so
+   the leak must be restored last. The IPv4 DNAT VRF leak lives in
+   `10-enX2.network` as routing-policy rules and needs no per-reload restart.
 8. Cancels the watchdog only if the play completes cleanly.
 
 `serial: 1` is set on the firewall play, so a bad rule blocks the next host.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -229,15 +229,23 @@ The overlay network is IPv6-only. NAT64 + DNS64 provides IPv4 reachability for o
     - Enable the stock `jool.service` shipped by `jool-tools` (it runs
       `jool file handle /etc/jool/jool.conf` on start).
 23. Deploy `configs/rtr/jool/nat64-vrf-leak.service` → `/etc/systemd/system/`
-    and `systemctl enable --now nat64-vrf-leak`. It installs both VRF leak
-    rules plus a table-200 route for the NAT64 prefix:
+    and `systemctl enable --now nat64-vrf-leak`. It installs the NAT64 VRF
+    leak rules plus a table-200 route for the NAT64 prefix:
     ```
     # Forward: overlay clients → Jool in default VRF (so Jool's netfilter
     # hook sees the packet; without this rule overlay traffic never reaches
     # Jool and all NAT64 checks time out)
     ip -6 rule add from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
-    # Return: Jool reply (src 64:ff9b::...) → overlay VRF so it reaches the VM
+
+    # Return: Jool replies to infrastructure and customer VMs → overlay VRF.
+    # These destination rules prevent default-VRF route lookup from sending
+    # translated replies out the underlay.
+    ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900
+    ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901
+
+    # Return: allocation-wide NAT64 replies → overlay VRF.
     ip -6 rule add from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
+
     # Route in overlay VRF giving clients a next-hop for the NAT64 prefix
     ip -6 route add 64:ff9b::/96 via 2001:41d0:303:48a::1 dev enX4 table 200
     ```

--- a/docs/rtr-vrf.md
+++ b/docs/rtr-vrf.md
@@ -88,6 +88,8 @@ VRF. Overlay clients reach Jool via the IPv6 leak rules installed by
 [`nat64-vrf-leak.service`](../configs/rtr/jool/nat64-vrf-leak.service):
 
 ```
+ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900
+ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901
 ip -6 rule add from 2a0c:b641:b50::/44 to 64:ff9b::/96 lookup main prio 1000
 ip -6 rule add from 64:ff9b::/96 to 2a0c:b641:b50::/44 lookup 200 prio 1001
 ip -6 route add 64:ff9b::/96 via 2001:41d0:303:48a::1 dev enX4 table 200
@@ -95,8 +97,9 @@ ip -6 route add 64:ff9b::/96 via 2001:41d0:303:48a::1 dev enX4 table 200
 
 This is a different shape than the v4 DNAT leak — Jool needs the
 forward packet in default VRF (so its netfilter hook fires) and the
-synthesised reply needs to escape back to overlay. See [CLAUDE.md
-NAT64 section](../CLAUDE.md) for the full picture.
+synthesised reply needs to escape back to overlay. The explicit destination
+rules for `2a0c:b641:b51::/48` and `2a0c:b641:b50:2::/64` keep translated
+replies for infrastructure and customer VMs from being routed out the underlay.
 
 ## Boot-order traps
 

--- a/tests/iac/test_rtr_nat64_contracts.py
+++ b/tests/iac/test_rtr_nat64_contracts.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class RtrNat64ContractsTest(unittest.TestCase):
+    def test_nat64_vrf_leak_routes_returns_to_overlay_clients(self):
+        unit = (REPO / "configs/rtr/jool/nat64-vrf-leak.service").read_text()
+
+        self.assertIn("RemainAfterExit=yes", unit)
+        self.assertIn(
+            "ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b51::/48 lookup 200 prio 900",
+            unit,
+        )
+        self.assertIn(
+            "ExecStart=/usr/sbin/ip -6 rule add to 2a0c:b641:b50:2::/64 lookup 200 prio 901",
+            unit,
+        )
+        self.assertIn(
+            "ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900",
+            unit,
+        )
+        self.assertIn(
+            "ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901",
+            unit,
+        )
+
+    def test_firewall_handler_restores_nat64_leak_after_jool_restart(self):
+        handlers = yaml.safe_load(
+            (REPO / "ansible/roles/firewall/handlers/main.yml").read_text()
+        )
+        names = [handler.get("name") for handler in handlers]
+
+        self.assertIn("restart jool", names)
+        self.assertIn("restart nat64-vrf-leak", names)
+        self.assertLess(names.index("restart jool"), names.index("restart nat64-vrf-leak"))
+
+        nat64_handler = next(
+            handler for handler in handlers if handler.get("name") == "restart nat64-vrf-leak"
+        )
+        self.assertEqual(nat64_handler["systemd"]["state"], "restarted")
+        self.assertEqual(nat64_handler["listen"], "reload nftables")

--- a/tests/iac/test_rtr_nat64_contracts.py
+++ b/tests/iac/test_rtr_nat64_contracts.py
@@ -21,13 +21,16 @@ class RtrNat64ContractsTest(unittest.TestCase):
             unit,
         )
         self.assertIn(
-            "ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900",
+            "ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b51::/48 lookup 200 prio 900",
             unit,
         )
         self.assertIn(
-            "ExecStop=/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901",
+            "ExecStop=-/usr/sbin/ip -6 rule del to 2a0c:b641:b50:2::/64 lookup 200 prio 901",
             unit,
         )
+        for line in unit.splitlines():
+            if line.startswith("ExecStop="):
+                self.assertTrue(line.startswith("ExecStop=-"), line)
 
     def test_firewall_handler_restores_nat64_leak_after_jool_restart(self):
         handlers = yaml.safe_load(
@@ -36,11 +39,44 @@ class RtrNat64ContractsTest(unittest.TestCase):
         names = [handler.get("name") for handler in handlers]
 
         self.assertIn("restart jool", names)
-        self.assertIn("restart nat64-vrf-leak", names)
-        self.assertLess(names.index("restart jool"), names.index("restart nat64-vrf-leak"))
+        self.assertIn("restart nat64-vrf-leak after jool", names)
+        self.assertLess(names.index("restart jool"), names.index("restart nat64-vrf-leak after jool"))
 
+        jool_handler = next(handler for handler in handlers if handler.get("name") == "restart jool")
         nat64_handler = next(
-            handler for handler in handlers if handler.get("name") == "restart nat64-vrf-leak"
+            handler for handler in handlers if handler.get("name") == "restart nat64-vrf-leak after jool"
         )
+        self.assertEqual(jool_handler["systemd"]["state"], "restarted")
+        self.assertFalse(jool_handler["systemd"]["no_block"])
         self.assertEqual(nat64_handler["systemd"]["state"], "restarted")
+        self.assertFalse(nat64_handler["systemd"]["no_block"])
+        self.assertEqual(jool_handler["listen"], "reload nftables")
         self.assertEqual(nat64_handler["listen"], "reload nftables")
+
+    def test_firewall_role_deploys_nat64_vrf_leak_unit_from_source(self):
+        tasks = yaml.safe_load((REPO / "ansible/roles/firewall/tasks/nftables.yml").read_text())
+        task_by_name = {task.get("name"): task for task in tasks}
+
+        review_task = task_by_name["Stage nat64-vrf-leak unit to controller (review artifact)"]
+        self.assertEqual(
+            review_task["copy"]["src"],
+            "{{ playbook_dir }}/../../configs/rtr/jool/nat64-vrf-leak.service",
+        )
+        self.assertEqual(
+            review_task["copy"]["dest"],
+            "{{ firewall_generated_dir }}/{{ inventory_hostname }}/nat64-vrf-leak.service",
+        )
+        self.assertEqual(review_task["when"], 'inventory_hostname == "rtr"')
+
+        install_task = task_by_name["Install nat64-vrf-leak unit on rtr"]
+        self.assertEqual(
+            install_task["copy"]["src"],
+            "{{ playbook_dir }}/../../configs/rtr/jool/nat64-vrf-leak.service",
+        )
+        self.assertEqual(install_task["copy"]["dest"], "/etc/systemd/system/nat64-vrf-leak.service")
+        self.assertEqual(install_task["notify"], "reload nftables")
+
+        enable_task = task_by_name["Enable nat64-vrf-leak unit on rtr"]
+        self.assertEqual(enable_task["systemd"]["name"], "nat64-vrf-leak")
+        self.assertTrue(enable_task["systemd"]["enabled"])
+        self.assertTrue(enable_task["systemd"]["daemon_reload"])


### PR DESCRIPTION
## Summary

Restore and persist NAT64 return routing for overlay infrastructure and customer VM subnets.

- Add explicit return-routing policy rules for `2a0c:b641:b51::/48` and `2a0c:b641:b50:2::/64`.
- Make `nat64-vrf-leak.service` cleanup idempotent with tolerant `ExecStop=-...` commands.
- Deploy the committed `nat64-vrf-leak.service` through the rtr firewall role and stage it as a generated review artifact.
- Restart Jool synchronously before restoring `nat64-vrf-leak`, so firewall applies do not leave NAT64 return routing inactive.
- Add IaC tests for route-leak rules, handler order, synchronous restart behavior, and unit deployment source.
- Update NAT64 docs so the documented route leak matches production behavior.

## Context

After the NOC deploy, both self-hosted GitHub runners went offline even though systemd showed the runner services as active. Runner logs timed out against `broker.actions.githubusercontent.com`.

On `rtr`, NAT64 SYNs left via `enX4` and SYN-ACKs returned from GitHub, but translated replies never reached `ci-pr`. The leak service had been stopped during a Jool restart, and default-VRF lookup sent overlay destinations toward the underlay instead of back to the overlay VRF.

## Review Fixes

- **Operational footgun:** `ExecStop` now tolerates missing route/rule entries so a failed or partial start cannot block a later restart.
- **Handler ordering risk:** handlers explicitly keep synchronous `jool` restart before `nat64-vrf-leak` restart, with tests covering order and `no_block: false`.
- **Deploy gate gap:** the firewall role now copies the committed unit into `/etc/systemd/system/` and stages it in `ansible/generated/rtr/` for review/dry-run visibility.

## Validation

- `uv run pytest tests/iac/test_rtr_nat64_contracts.py -q`
- `uv run pytest tests/iac -q`
- `scripts/ci/iac-static.sh`
- Live temporary rtr policy rules restored NAT64: `ci-pr` can reach `https://broker.actions.githubusercontent.com` over DNS64/NAT64 and both GitHub runners are online.

## Rollback

Revert this PR and run the rtr firewall apply path again. If immediate live rollback is required, remove the temporary policy rules with `ip -6 rule del` for priorities `900` and `901`, then restart `jool` and `nat64-vrf-leak`.
