### PR TITLE
[promotion] Promote NOC Agent OpenRouter health fix

### DIFF
--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,7 +5,7 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
-noc_agent_version: 746cb5aff239f21a0492d0a4af210076ffd40a41
+noc_agent_version: 21e9fdb720423d355c1be45108e057a51a5901a9
 hyrule_mcp_version: d95e94766cc3608b38066bd50bc938c284b47bee
 
 firewall_extra_rules:


### PR DESCRIPTION
## Promotion

App PRs:
- `AS215932/noc-agent#15` -> `21e9fdb720423d355c1be45108e057a51a5901a9`

Pinned versions:
- `noc_agent_version`: `21e9fdb720423d355c1be45108e057a51a5901a9`
- `hyrule_mcp_version`: unchanged, `d95e94766cc3608b38066bd50bc938c284b47bee`
- `hyrule_cloud_version`: unchanged
- `hyrule_web_version`: unchanged

Deploy impact:
- Affected playbooks: `noc.yml`
- Expected service restarts: `noc-agent`, `noc-agent-bot`
- Operator-visible behavior: `/health/model` should stop degrading when an OpenRouter key with a small daily limit still has healthy remaining quota.

Rollback:
- Previous `noc_agent_version`: `746cb5aff239f21a0492d0a4af210076ffd40a41`
- Previous `hyrule_mcp_version`: `d95e94766cc3608b38066bd50bc938c284b47bee`
- Previous `hyrule_cloud_version`: unchanged
- Previous `hyrule_web_version`: unchanged

Validation:
- [x] App CI is green for every promoted SHA.
- [x] `uv run pytest tests/iac -q` passes.
- [x] `scripts/ci/iac-static.sh` passes.
- [ ] `apply.yml` dry-run completed for `playbook=noc`, `limit=noc`.
- [ ] Production `apply.yml` completed.
- [ ] Icinga pre/post snapshot diff reviewed.
