### PR TITLE
Fix runner monitoring coverage

### DIFF
--- a/ansible/generated/ci-pr/icinga_host.conf
+++ b/ansible/generated/ci-pr/icinga_host.conf
@@ -11,6 +11,7 @@ object Host "ci-pr" {
   vars.os = "Debian"
   vars.role = "ci"
   vars.ssh_port = 22
+  vars.github_runner = true
 
   vars.prom_instance_node = "[2a0c:b641:b51::c1]:9100"
 

--- a/ansible/generated/ci/icinga_host.conf
+++ b/ansible/generated/ci/icinga_host.conf
@@ -11,6 +11,7 @@ object Host "ci" {
   vars.os = "Debian"
   vars.role = "ci"
   vars.ssh_port = 22
+  vars.github_runner = true
 
   vars.prom_instance_node = "[2a0c:b641:b50:2::d0]:9100"
 

--- a/ansible/inventory/host_vars/ci-pr.yml
+++ b/ansible/inventory/host_vars/ci-pr.yml
@@ -59,6 +59,8 @@ firewall_forward_extra_raw_nft: |
 # --- Monitoring: register on mon (Icinga host + node_exporter scrape) ---
 monitoring_register: true
 monitoring_role: ci
+monitoring_check_vars:
+  github_runner: true
 
 # --- Logs: OFF. Pushing to the log VM (customer->infra) is dropped by the
 # customer isolation; shipping would require weakening that boundary. The logs

--- a/ansible/inventory/host_vars/ci.yml
+++ b/ansible/inventory/host_vars/ci.yml
@@ -23,6 +23,8 @@ firewall_extra_rules:
 # (Prometheus query on node_systemd_unit_state) — no by_ssh trust plumbing needed.
 monitoring_register: true
 monitoring_role: ci
+monitoring_check_vars:
+  github_runner: true
 
 # Logs — ship journald to log VM.
 logs_register: true

--- a/configs/mon/icinga2/services/github-runner.conf
+++ b/configs/mon/icinga2/services/github-runner.conf
@@ -33,8 +33,7 @@ apply Service "github-runner" {
   vars.prom_instance = host.vars.prom_instance_node
   vars.systemd_unit = "github-runner.service"
 
-  // ci is the only runner today; key on a host var when a second one lands.
-  assign where host.name == "ci"
+  assign where host.vars.github_runner && host.vars.prom_instance_node
 }
 
 // Crash/restart-loop detection. The active-state check above samples every 2m
@@ -77,5 +76,5 @@ apply Service "github-runner-restart-loop" {
   vars.prom_instance = host.vars.prom_instance_node
   vars.systemd_unit = "github-runner.service"
 
-  assign where host.name == "ci"
+  assign where host.vars.github_runner && host.vars.prom_instance_node
 }

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -32,9 +32,15 @@ scrape_configs:
           - "[2a0c:b641:b50:2::a0]:9100"   # noc
           - "[2a0c:b641:b50:2::b0]:9100"   # log
           - "[2a0c:b641:b50:2::c0]:9100"   # vault
+          - "[2a0c:b641:b50:2::d0]:9100"   # ci (privileged runner)
         labels:
           site: ovh1
           role: infra
+      - targets:
+          - "[2a0c:b641:b51::c1]:9100"     # ci-pr (unprivileged PR runner, customer-isolated)
+        labels:
+          site: ovh1
+          role: ci-pr
       - targets:
           - "[2a0c:b641:b50:2::80]:9100"   # irc
         labels:

--- a/tests/iac/test_monitoring_runner_contracts.py
+++ b/tests/iac/test_monitoring_runner_contracts.py
@@ -1,0 +1,56 @@
+"""Monitoring contracts for the two self-hosted GitHub Actions runners."""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _prometheus_targets():
+    cfg = yaml.safe_load((REPO / "configs/mon/prometheus.yml").read_text())
+    targets = set()
+    labels_by_target = {}
+    for job in cfg["scrape_configs"]:
+        for static in job.get("static_configs", []):
+            labels = static.get("labels", {})
+            for target in static.get("targets", []):
+                targets.add(target)
+                labels_by_target[target] = labels
+    return targets, labels_by_target
+
+
+class MonitoringRunnerContractsTest(unittest.TestCase):
+    def test_prometheus_scrapes_both_github_runner_hosts(self):
+        targets, labels = _prometheus_targets()
+
+        expected = {
+            "[2a0c:b641:b50:2::d0]:9100": "infra",  # ci
+            "[2a0c:b641:b51::c1]:9100": "ci-pr",   # unprivileged PR runner
+        }
+        for target, role in expected.items():
+            with self.subTest(target=target):
+                self.assertIn(target, targets)
+                self.assertEqual(labels[target].get("role"), role)
+
+    def test_icinga_runner_checks_are_host_var_driven(self):
+        service_cfg = (REPO / "configs/mon/icinga2/services/github-runner.conf").read_text()
+        self.assertIn(
+            "assign where host.vars.github_runner && host.vars.prom_instance_node",
+            service_cfg,
+        )
+        self.assertNotIn('assign where host.name == "ci"', service_cfg)
+
+        for host in ("ci", "ci-pr"):
+            with self.subTest(host=host):
+                host_vars = yaml.safe_load(
+                    (REPO / f"ansible/inventory/host_vars/{host}.yml").read_text()
+                )
+                self.assertTrue(host_vars["monitoring_check_vars"]["github_runner"])
+                rendered = (REPO / f"ansible/generated/{host}/icinga_host.conf").read_text()
+                self.assertIn("vars.github_runner = true", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore Prometheus scrape coverage for both self-hosted GitHub Actions runners (`ci` and `ci-pr`)
- mark both runner hosts with `vars.github_runner` and apply Icinga runner service checks from that host var
- add regression coverage so runner scrape targets and Icinga assignments do not drift again

## Live validation

- Applied Prometheus config on `mon` and reloaded Prometheus
- Re-applied monitoring role to `ci` / `ci-pr`
- Deployed updated Icinga runner service config and reloaded Icinga
- Forced rechecks; runner-related Icinga UNKNOWNs cleared

Remaining live Icinga problem is unrelated: `rtr!disk disk /` warning (~15% free).

## Tests

- `python -m pytest tests/iac -q`
- `scripts/ci/iac-static.sh`
- `scripts/ci/deploy-preflight.sh --repo-only`
- `git diff --check`

Related follow-up: #181 tracks missing `icinga-snapshot` env credentials on `mon`.
