### PR TITLE
[codex] Automate app promotion dispatches

### DIFF
--- a/.github/workflows/promote-apps.yml
+++ b/.github/workflows/promote-apps.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Resolve promotion request
         id: resolve

--- a/.github/workflows/promote-apps.yml
+++ b/.github/workflows/promote-apps.yml
@@ -2,6 +2,8 @@
 name: promote-apps
 
 on:
+  repository_dispatch:
+    types: [app-promote]
   workflow_dispatch:
     inputs:
       title:
@@ -52,14 +54,87 @@ jobs:
         with:
           ref: main
 
+      - name: Resolve promotion request
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REPOSITORY: ${{ github.event.client_payload.repository }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          DISPATCH_TITLE: ${{ github.event.client_payload.title }}
+          DISPATCH_IMPACT: ${{ github.event.client_payload.impact }}
+          INPUT_TITLE: ${{ inputs.title }}
+          INPUT_IMPACT: ${{ inputs.impact }}
+          INPUT_NOC_AGENT_SHA: ${{ inputs.noc_agent_sha }}
+          INPUT_HYRULE_MCP_SHA: ${{ inputs.hyrule_mcp_sha }}
+          INPUT_HYRULE_CLOUD_SHA: ${{ inputs.hyrule_cloud_sha }}
+          INPUT_HYRULE_WEB_SHA: ${{ inputs.hyrule_web_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="${INPUT_TITLE:-Promote app SHAs}"
+          impact="${INPUT_IMPACT:-Automated app SHA promotion.}"
+          noc_agent_sha="${INPUT_NOC_AGENT_SHA:-}"
+          hyrule_mcp_sha="${INPUT_HYRULE_MCP_SHA:-}"
+          hyrule_cloud_sha="${INPUT_HYRULE_CLOUD_SHA:-}"
+          hyrule_web_sha="${INPUT_HYRULE_WEB_SHA:-}"
+
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            repo="${DISPATCH_REPOSITORY:-}"
+            sha="${DISPATCH_SHA:-}"
+            sha="${sha,,}"
+
+            if ! [[ "$sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::repository_dispatch payload sha must be a 40-character commit SHA"
+              exit 1
+            fi
+
+            case "$repo" in
+              AS215932/noc-agent)
+                noc_agent_sha="$sha"
+                ;;
+              AS215932/hyrule-mcp)
+                hyrule_mcp_sha="$sha"
+                ;;
+              AS215932/hyrule-cloud)
+                hyrule_cloud_sha="$sha"
+                ;;
+              AS215932/hyrule-web)
+                hyrule_web_sha="$sha"
+                ;;
+              *)
+                echo "::error::unsupported promotion source repository: ${repo:-<missing>}"
+                exit 1
+                ;;
+            esac
+
+            canonical="$(gh api "repos/${repo}/commits/${sha}" --jq .sha)"
+            if [ "$canonical" != "$sha" ]; then
+              echo "::error::commit ${sha} was not found in ${repo}"
+              exit 1
+            fi
+
+            title="${DISPATCH_TITLE:-Promote ${repo#AS215932/} ${sha:0:7}}"
+            impact="${DISPATCH_IMPACT:-Automated promotion request from ${repo}@${sha}.}"
+          fi
+
+          {
+            printf 'title=%s\n' "$title"
+            printf 'impact=%s\n' "$impact"
+            printf 'noc_agent_sha=%s\n' "$noc_agent_sha"
+            printf 'hyrule_mcp_sha=%s\n' "$hyrule_mcp_sha"
+            printf 'hyrule_cloud_sha=%s\n' "$hyrule_cloud_sha"
+            printf 'hyrule_web_sha=%s\n' "$hyrule_web_sha"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Update app pins
         env:
-          PROMOTION_TITLE: ${{ inputs.title }}
-          PROMOTION_IMPACT: ${{ inputs.impact }}
-          NOC_AGENT_SHA: ${{ inputs.noc_agent_sha }}
-          HYRULE_MCP_SHA: ${{ inputs.hyrule_mcp_sha }}
-          HYRULE_CLOUD_SHA: ${{ inputs.hyrule_cloud_sha }}
-          HYRULE_WEB_SHA: ${{ inputs.hyrule_web_sha }}
+          PROMOTION_TITLE: ${{ steps.resolve.outputs.title }}
+          PROMOTION_IMPACT: ${{ steps.resolve.outputs.impact }}
+          NOC_AGENT_SHA: ${{ steps.resolve.outputs.noc_agent_sha }}
+          HYRULE_MCP_SHA: ${{ steps.resolve.outputs.hyrule_mcp_sha }}
+          HYRULE_CLOUD_SHA: ${{ steps.resolve.outputs.hyrule_cloud_sha }}
+          HYRULE_WEB_SHA: ${{ steps.resolve.outputs.hyrule_web_sha }}
         run: |
           scripts/ci/promote-app-pins.py \
             --title "$PROMOTION_TITLE" \
@@ -73,10 +148,22 @@ jobs:
       - name: Validate pins
         run: scripts/ci/iac-static.sh
 
+      - name: Check promotion diff
+        id: diff
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- ansible/inventory/host_vars/noc.yml ansible/inventory/host_vars/api.yml ansible/inventory/host_vars/web.yml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No app pin changes requested; promotion PR not needed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Commit promotion branch
+        if: steps.diff.outputs.changed == 'true'
         env:
           BRANCH: promotion/app-sha-pins
-          COMMIT_MESSAGE: ${{ inputs.title }}
+          COMMIT_MESSAGE: ${{ steps.resolve.outputs.title }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -87,10 +174,11 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
 
       - name: Open or update promotion PR
+        if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: promotion/app-sha-pins
-          PR_TITLE: ${{ inputs.title }}
+          PR_TITLE: ${{ steps.resolve.outputs.title }}
         run: |
           set -euo pipefail
           existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ This repository is the production deployment record for `noc-agent`,
 `hyrule-mcp`, `hyrule-cloud`, and `hyrule-web`. App repos do not deploy
 production on merge.
 
-Use **Actions -> promote-apps** with the merged app commit SHAs. That workflow
-opens or updates the promotion PR that pins exact SHAs in inventory. After the
-promotion PR merges, **app-promotion-deploy** automatically calls `apply.yml`
-for the affected playbooks and waits at the GitHub `production` environment
-approval gate. The human operator's normal job is to review the promotion PR,
-merge it, approve the production gate, and review the Icinga snapshot diff.
+After an app repo's `ci` workflow succeeds on `main`, its
+**request-promotion** workflow asks this repo to open or update the promotion PR
+that pins exact SHAs in inventory. **Actions -> promote-apps** remains the
+manual fallback when a promotion request needs to be replayed or coordinated by
+hand. After the promotion PR merges, **app-promotion-deploy** automatically
+calls `apply.yml` for the affected playbooks and waits at the GitHub
+`production` environment approval gate. The human operator's normal job is to
+review the promotion PR, merge it, approve the production gate, and review the
+Icinga snapshot diff.
 
 Full runbook: [docs/ci/deploy-runbook.md](docs/ci/deploy-runbook.md).
 

--- a/docs/ci/deploy-runbook.md
+++ b/docs/ci/deploy-runbook.md
@@ -26,23 +26,32 @@ inventory:
 - `ansible/inventory/host_vars/web.yml`: `hyrule_web_version`
 
 Use the promotion PR template for coordinated deploys. Merge app PRs first,
-update the promotion PR to the exact merged app SHAs, run a dry-run from the
-promotion branch, then merge and apply from `network-operations/main`.
+then let the app repo request or manually update a promotion PR with the exact
+merged app SHAs. Production deploys only happen from `network-operations/main`
+after the promotion PR merges and the GitHub `production` environment gate is
+approved.
 
 The normal automated path is:
 
 1. Merge app PRs after app CI is green.
-2. Run **Actions -> promote-apps** in this repository and paste the merged app
-   SHAs into the relevant inputs.
-3. Review the generated promotion PR. It updates the app pins and records
-   compare links plus rollback SHAs.
-4. Merge the promotion PR after checks pass.
-5. **app-promotion-deploy** starts automatically on the `main` push when an app
+2. The app repo's **request-promotion** workflow runs after its `ci` workflow
+   succeeds on `main`. It uses the AS215932 Promotion Bot GitHub App to send
+   `repository_dispatch` to this repository.
+3. **promote-apps** opens or updates the promotion PR with app pins, compare
+   links, and rollback SHAs.
+4. Review the generated promotion PR.
+5. Merge the promotion PR after checks pass.
+6. **app-promotion-deploy** starts automatically on the `main` push when an app
    pin file changed. It calls `apply.yml` for the affected playbook(s).
-6. Approve the GitHub `production` environment gate. This is the intended
+7. Approve the GitHub `production` environment gate. This is the intended
    manual deploy step.
-7. Review the workflow summary: app pins, compare links, and Icinga snapshot
+8. Review the workflow summary: app pins, compare links, and Icinga snapshot
    diff.
+
+Manual fallback: run **Actions -> promote-apps** in this repository and paste
+the merged app SHAs into the relevant inputs. Use this when a dispatch failed,
+when a coordinated promotion should pin multiple app repos at once, or when an
+operator intentionally wants to replay a promotion request.
 
 `apply.yml` itself is not a push-triggered workflow. It runs when either:
 

--- a/tests/iac/test_app_promotion_bot.py
+++ b/tests/iac/test_app_promotion_bot.py
@@ -7,16 +7,22 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 
 
+def workflow_triggers(workflow: dict) -> dict:
+    return workflow.get("on", workflow.get(True, {}))
+
+
 class AppPromotionBotTest(unittest.TestCase):
     def test_promote_apps_accepts_repository_dispatch(self):
         workflow = yaml.safe_load((REPO / ".github/workflows/promote-apps.yml").read_text())
 
-        triggers = workflow[True]
+        triggers = workflow_triggers(workflow)
         self.assertIn("repository_dispatch", triggers)
         self.assertEqual(triggers["repository_dispatch"]["types"], ["app-promote"])
 
     def test_promote_apps_maps_known_repositories_to_pin_inputs(self):
         workflow_text = (REPO / ".github/workflows/promote-apps.yml").read_text()
+
+        self.assertIn("ref: ${{ github.sha }}", workflow_text)
 
         expected_cases = {
             "AS215932/noc-agent)": 'noc_agent_sha="$sha"',

--- a/tests/iac/test_app_promotion_bot.py
+++ b/tests/iac/test_app_promotion_bot.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class AppPromotionBotTest(unittest.TestCase):
+    def test_promote_apps_accepts_repository_dispatch(self):
+        workflow = yaml.safe_load((REPO / ".github/workflows/promote-apps.yml").read_text())
+
+        triggers = workflow[True]
+        self.assertIn("repository_dispatch", triggers)
+        self.assertEqual(triggers["repository_dispatch"]["types"], ["app-promote"])
+
+    def test_promote_apps_maps_known_repositories_to_pin_inputs(self):
+        workflow_text = (REPO / ".github/workflows/promote-apps.yml").read_text()
+
+        expected_cases = {
+            "AS215932/noc-agent)": 'noc_agent_sha="$sha"',
+            "AS215932/hyrule-mcp)": 'hyrule_mcp_sha="$sha"',
+            "AS215932/hyrule-cloud)": 'hyrule_cloud_sha="$sha"',
+            "AS215932/hyrule-web)": 'hyrule_web_sha="$sha"',
+        }
+        for repo_case, pin_assignment in expected_cases.items():
+            with self.subTest(repo_case=repo_case):
+                self.assertIn(repo_case, workflow_text)
+                self.assertIn(pin_assignment, workflow_text)
+
+        self.assertIn("unsupported promotion source repository", workflow_text)
+        self.assertIn('gh api "repos/${repo}/commits/${sha}" --jq .sha', workflow_text)
+        self.assertIn("repository_dispatch payload sha must be a 40-character commit SHA", workflow_text)


### PR DESCRIPTION
## Summary
- accept app promotion requests via repository_dispatch
- map known app repos to production SHA pins and validate commit SHAs
- skip PR creation when the requested pin is already current
- document the automatic promotion flow

## Validation
- uv run pytest tests/iac/test_app_promotion_bot.py -q
- uv run pytest tests/iac -q
- scripts/ci/iac-static.sh
- YAML parse check for updated workflows