### PR TITLE
Promote app SHAs

### DIFF
--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -1,7 +1,7 @@
 ---
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
-hyrule_cloud_version: 5384a96bd9dbe381eb2bce192099de6f07bd27b4
+hyrule_cloud_version: df222b386625b46843a76ac6139fb0e4bc38a15a
 
 firewall_extra_rules:
   # API upstreams and backend health checks.

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,8 +5,8 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
-noc_agent_version: 21e9fdb720423d355c1be45108e057a51a5901a9
-hyrule_mcp_version: d95e94766cc3608b38066bd50bc938c284b47bee
+noc_agent_version: c2ae3a9a59d2e6e9600b14c9b33350a029e65faf
+hyrule_mcp_version: 78b97ee626d665160b9bd3c3741589392655a00e
 
 firewall_extra_rules:
   # Webhooks from Alertmanager + Icinga2 on mon.

--- a/ansible/inventory/host_vars/web.yml
+++ b/ansible/inventory/host_vars/web.yml
@@ -1,7 +1,7 @@
 ---
 # web — hyrule-web (uvicorn :8080 hyrule.host) + nginx (:8081 as215932.net).
 
-hyrule_web_version: 45d7bb6964c686188a49da032de785be55e95a56
+hyrule_web_version: 7720f083320d03eb5c62bfdd8be329b6fe82d7e2
 
 firewall_extra_rules:
   - { proto: tcp, dport: 8080, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-web upstream from proxy/mon" }


### PR DESCRIPTION
## Promotion

Title: Promote app SHAs

App PRs:
- Automated promotion workflow; see linked app commits below.

Pinned versions:
- `noc_agent_version`: `c2ae3a9a59d2e6e9600b14c9b33350a029e65faf` (https://github.com/AS215932/noc-agent/compare/21e9fdb720423d355c1be45108e057a51a5901a9...c2ae3a9a59d2e6e9600b14c9b33350a029e65faf)
- `hyrule_mcp_version`: `78b97ee626d665160b9bd3c3741589392655a00e` (https://github.com/AS215932/hyrule-mcp/compare/d95e94766cc3608b38066bd50bc938c284b47bee...78b97ee626d665160b9bd3c3741589392655a00e)
- `hyrule_cloud_version`: `df222b386625b46843a76ac6139fb0e4bc38a15a` (https://github.com/AS215932/hyrule-cloud/compare/df222b386625b46843a76ac6139fb0e4bc38a15a...df222b386625b46843a76ac6139fb0e4bc38a15a)
- `hyrule_web_version`: `7720f083320d03eb5c62bfdd8be329b6fe82d7e2` (https://github.com/AS215932/hyrule-web/compare/7720f083320d03eb5c62bfdd8be329b6fe82d7e2...7720f083320d03eb5c62bfdd8be329b6fe82d7e2)

Deploy impact:
- Affected playbooks: noc
- Promote merged promotion-bot rollout commits for noc-agent, hyrule-mcp, hyrule-cloud, and hyrule-web.

Rollback:
- Previous `noc_agent_version`: `21e9fdb720423d355c1be45108e057a51a5901a9`
- Previous `hyrule_mcp_version`: `d95e94766cc3608b38066bd50bc938c284b47bee`
- Previous `hyrule_cloud_version`: `df222b386625b46843a76ac6139fb0e4bc38a15a`
- Previous `hyrule_web_version`: `7720f083320d03eb5c62bfdd8be329b6fe82d7e2`

Validation:
- [ ] App CI is green for every promoted SHA.
- [ ] `scripts/ci/iac-static.sh` passes.
- [ ] Promotion PR checks are green.
- [ ] Production environment gate approved after merge.
- [ ] Icinga pre/post snapshot diff reviewed.
