### PR TITLE
Serialize app promotion deploy applies

### DIFF
--- a/.github/workflows/app-promotion-deploy.yml
+++ b/.github/workflows/app-promotion-deploy.yml
@@ -53,6 +53,7 @@ jobs:
     if: ${{ needs.detect.outputs.has_changes == 'true' }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
     uses: ./.github/workflows/apply.yml
     with:

--- a/tests/iac/test_app_promotion_deploy.py
+++ b/tests/iac/test_app_promotion_deploy.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class AppPromotionDeployTest(unittest.TestCase):
+    def test_apply_matrix_is_serialized(self):
+        workflow = yaml.safe_load(
+            (REPO / ".github/workflows/app-promotion-deploy.yml").read_text()
+        )
+
+        strategy = workflow["jobs"]["apply"]["strategy"]
+        self.assertEqual(strategy["fail-fast"], False)
+        self.assertEqual(strategy["max-parallel"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- serialize app-promotion-deploy matrix applies with `max-parallel: 1`
- prevents matrix legs from evicting each other from the shared `production-infra` concurrency group
- add a static IaC test covering the serialization guard

## Validation
- `uv run pytest tests/iac/test_app_promotion_deploy.py -q`
- workflow YAML parse check
- `scripts/ci/iac-static.sh`

## Operational note
The missed web deploy from #185 was triggered directly via `apply.yml`: https://github.com/AS215932/network-operations/actions/runs/27351432988