### PR TITLE
Name apply runs by target

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -1,5 +1,6 @@
 ---
 name: apply
+run-name: ${{ inputs.dry_run == true && 'Dry-run' || 'Apply' }} playbook ${{ inputs.playbook }} to target(s) ${{ inputs.limit }}
 
 # Manual gated deployment. Run with:
 #   gh workflow run apply.yml -F playbook=firewall -F limit=cr1-de1 -F dry_run=true
@@ -91,6 +92,7 @@ concurrency:
 
 jobs:
   apply:
+    name: ${{ inputs.dry_run == true && 'Dry-run' || 'Apply' }} playbook ${{ inputs.playbook }} to target(s) ${{ inputs.limit }}
     runs-on: [self-hosted, linux, x64, hyrule-infra]
     # Real applies pause on the protected `production` environment. Dry-runs
     # must stay ungated so promotion PR validation can be automated.

--- a/tests/iac/test_apply_workflow.py
+++ b/tests/iac/test_apply_workflow.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class ApplyWorkflowTest(unittest.TestCase):
+    def test_apply_run_and_job_names_include_target(self):
+        workflow = yaml.safe_load((REPO / ".github/workflows/apply.yml").read_text())
+
+        expected = "${{ inputs.dry_run == true && 'Dry-run' || 'Apply' }} playbook ${{ inputs.playbook }} to target(s) ${{ inputs.limit }}"
+        self.assertEqual(workflow["run-name"], expected)
+        self.assertEqual(workflow["jobs"]["apply"]["name"], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dynamic run name for apply.yml: `Apply <playbook> to <limit>` or `Dry-run <playbook> to <limit>`
- add the same dynamic name to the apply job so job lists are readable too
- add a static IaC test to keep the naming in place

## Validation
- `uv run pytest tests/iac/test_apply_workflow.py -q`
- workflow YAML parse check
- `scripts/ci/iac-static.sh`