### PR TITLE
Engineering Loop v2: architecture spec, roadmap, templates, and initial skills tree

### DIFF
--- a/.github/workflows/iac-tests.yml
+++ b/.github/workflows/iac-tests.yml
@@ -11,30 +11,16 @@ name: iac-tests
 # runner. Tiers 1-2 spin up Batfish / Containerlab (heavy lab infra + Docker) on
 # the privileged ci runner and only run on a trusted trigger — never automatically
 # on an arbitrary PR. The `iac-gate` job is the single REQUIRED status context:
-# it always reports, so a PR that touches none of the path-filtered IaC files
-# (where this whole workflow is skipped) is treated as passing, while an IaC PR
-# only passes when the required tiers succeed and the lab tiers are
+# this workflow always starts, a cheap `changes` job decides whether IaC paths
+# changed, and `iac-gate` reports for both docs-only and IaC PRs. IaC PRs only
+# pass when the required tiers succeed and the lab tiers are
 # success-or-skipped (never failed). See docs/netops/testing-strategy.md.
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - '.github/workflows/iac-tests.yml'
-      - '.pre-commit-config.yaml'
-      - 'ansible/**'
-      - 'configs/**'
-      - 'scripts/ci/**'
-      - 'tests/**'
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/iac-tests.yml'
-      - '.pre-commit-config.yaml'
-      - 'ansible/**'
-      - 'configs/**'
-      - 'scripts/ci/**'
-      - 'tests/**'
   workflow_dispatch:
 
 permissions:
@@ -42,9 +28,82 @@ permissions:
   pull-requests: read
 
 jobs:
+  changes:
+    name: Detect IaC changes
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    timeout-minutes: 5
+    outputs:
+      iac_changed: ${{ steps.diff.outputs.iac_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect IaC-relevant paths
+        id: diff
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: running IaC tests."
+            echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            base="${PR_BASE_SHA}"
+            head="${PR_HEAD_SHA}"
+          elif [ "${EVENT_NAME}" = "push" ]; then
+            base="${PUSH_BEFORE}"
+            head="${HEAD_SHA}"
+          else
+            echo "Unsupported event ${EVENT_NAME}: running IaC tests."
+            echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ]; then
+            echo "No usable base SHA: running IaC tests."
+            echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            if ! diff_base="$(git merge-base "${base}" "${head}")"; then
+              echo "Could not determine merge base: running IaC tests."
+              echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          else
+            diff_base="${base}"
+          fi
+
+          if ! changed_paths="$(git diff --name-only "${diff_base}" "${head}")"; then
+            echo "Could not determine changed paths: running IaC tests."
+            echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Changed paths:"
+          printf '%s\n' "${changed_paths}"
+
+          if printf '%s\n' "${changed_paths}" | grep -Eq '^(\.github/workflows/iac-tests\.yml|\.pre-commit-config\.yaml|ansible/|configs/|scripts/ci/|tests/)'; then
+            echo "iac_changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "iac_changed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   # ---- Tier 0: static, unprivileged, required ---------------------------
   static-iac:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    needs: changes
+    if: ${{ needs.changes.outputs.iac_changed == 'true' }}
     timeout-minutes: 10
     env:
       ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles
@@ -64,7 +123,8 @@ jobs:
 
   ansible-idempotency:
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    needs: static-iac
+    needs: [changes, static-iac]
+    if: ${{ needs.changes.outputs.iac_changed == 'true' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -75,8 +135,8 @@ jobs:
   # ---- Tier 1: Batfish control-plane model (privileged, trusted-only) ---
   batfish:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
-    needs: static-iac
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_BATFISH_TESTS == 'true' }}
+    needs: [changes, static-iac]
+    if: ${{ needs.changes.outputs.iac_changed == 'true' && (github.event_name == 'workflow_dispatch' || vars.ENABLE_BATFISH_TESTS == 'true') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -103,8 +163,8 @@ jobs:
   # ---- Tier 2: Containerlab dynamic FRR (privileged, trusted-only) ------
   containerlab-frr:
     runs-on: [self-hosted, linux, x64, hyrule-infra]
-    needs: static-iac
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_CONTAINERLAB_TESTS == 'true' }}
+    needs: [changes, static-iac]
+    if: ${{ needs.changes.outputs.iac_changed == 'true' && (github.event_name == 'workflow_dispatch' || vars.ENABLE_CONTAINERLAB_TESTS == 'true') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -127,12 +187,14 @@ jobs:
   iac-gate:
     name: iac-gate
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    needs: [static-iac, ansible-idempotency, batfish, containerlab-frr]
+    needs: [changes, static-iac, ansible-idempotency, batfish, containerlab-frr]
     if: always()
     timeout-minutes: 5
     steps:
       - name: Evaluate tier results
         env:
+          CHANGES: ${{ needs.changes.result }}
+          IAC_CHANGED: ${{ needs.changes.outputs.iac_changed }}
           STATIC_IAC: ${{ needs.static-iac.result }}
           ANSIBLE_IDEMPOTENCY: ${{ needs.ansible-idempotency.result }}
           BATFISH: ${{ needs.batfish.result }}
@@ -140,20 +202,33 @@ jobs:
         run: |
           set -euo pipefail
           echo "Tier results:"
+          echo "  changes             = ${CHANGES}"
+          echo "  iac_changed         = ${IAC_CHANGED}"
           echo "  static-iac          = ${STATIC_IAC}"
           echo "  ansible-idempotency = ${ANSIBLE_IDEMPOTENCY}"
           echo "  batfish (trusted)   = ${BATFISH}"
           echo "  containerlab (trust)= ${CONTAINERLAB}"
           fail=0
-          # Required tiers must succeed.
-          for pair in "static-iac:${STATIC_IAC}" "ansible-idempotency:${ANSIBLE_IDEMPOTENCY}"; do
-            name="${pair%%:*}"; res="${pair##*:}"
-            if [ "${res}" != "success" ]; then
-              echo "::error::required tier ${name} did not pass (${res})"
-              fail=1
-            fi
-          done
-          # Trusted lab tiers may be skipped on PRs, but must never be failed.
+
+          if [ "${CHANGES}" != "success" ]; then
+            echo "::error::change detection did not pass (${CHANGES})"
+            fail=1
+          fi
+
+          if [ "${IAC_CHANGED}" = "true" ]; then
+            # Required tiers must succeed when IaC-relevant paths changed.
+            for pair in "static-iac:${STATIC_IAC}" "ansible-idempotency:${ANSIBLE_IDEMPOTENCY}"; do
+              name="${pair%%:*}"; res="${pair##*:}"
+              if [ "${res}" != "success" ]; then
+                echo "::error::required tier ${name} did not pass (${res})"
+                fail=1
+              fi
+            done
+          else
+            echo "No IaC-relevant changes; required tiers may be skipped."
+          fi
+
+          # Trusted lab tiers may be skipped on PRs, but must never fail.
           for pair in "batfish:${BATFISH}" "containerlab-frr:${CONTAINERLAB}"; do
             name="${pair%%:*}"; res="${pair##*:}"
             if [ "${res}" != "success" ] && [ "${res}" != "skipped" ]; then

--- a/docs/agentic-development-loop.md
+++ b/docs/agentic-development-loop.md
@@ -10,6 +10,20 @@ to alerts, investigates production, detects drift, recommends approved
 remediation, and verifies runtime recovery. Do not add development
 orchestration to `hyrule-noc-agent`.
 
+## v2 Direction
+
+This document describes the running v1 implementation and stays
+authoritative for current behavior. The approved v2 refactor — a real
+coding-agent backend inside the guarded worktree, task specs as sprint
+contracts, two-phase role participation (plan consult + post-diff
+judgment), a memory/reflection flywheel, issue/signal intake, and a
+headless operations lane — is specified in
+[docs/engineering-loop/v2-architecture.md](./engineering-loop/v2-architecture.md)
+with the phased plan in
+[docs/engineering-loop/v2-roadmap.md](./engineering-loop/v2-roadmap.md).
+The `skills/` tree at the repo root is the first v2 artifact; v1 keeps
+reading `docs/agent-loops/` until roadmap phase C rebinds prompt loading.
+
 ## Architecture Decision
 
 Use two separate loops:

--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -37,17 +37,17 @@ lists only `claude-for-github`, `claude`).
 ## The `iac-gate` deadlock guard (acceptance #7)
 
 `network-operations` requires **`iac-gate`**, not the individual Tier-0 jobs.
-`iac-tests.yml` is path-filtered (runs only when IaC files change), so a
-docs-only PR doesn't trigger it. GitHub treats a required check whose workflow
-is **skipped by path/branch filtering as passing**, so such a PR is not wedged.
-This is already proven on this repo: `render` (from the path-filtered
-`render-check.yml`) has long been required and docs-only PRs merge fine.
-`iac-gate` behaves identically. Always re-verify after changing required checks
-with a docs-only PR that touches none of the IaC paths — it must not show a
-stuck "Expected" check. (This very doc set was merged as that verification PR.)
+`iac-tests.yml` is not workflow-level path-filtered: GitHub does not create
+check runs for a workflow skipped by `paths`, so a required context from that
+workflow can remain stuck at "Expected" on a docs-only PR. Instead, the workflow
+always starts, an internal `changes` job decides whether IaC paths changed, and
+the `iac-gate` job reports either way. Always re-verify after changing required
+checks with a docs-only PR that touches none of the IaC paths: `iac-tests` must
+run, the tier jobs should be skipped, and `iac-gate` must report success.
 
-`iac-gate` itself (`if: always()`, `needs:` all tiers) passes only when the
-required tiers succeed and the trusted lab tiers are success-or-skipped — see
+`iac-gate` itself (`if: always()`, `needs:` the internal `changes` job plus all
+tiers) passes only when change detection succeeds, required tiers succeed for
+IaC changes, and the trusted lab tiers are success-or-skipped — see
 `docs/netops/testing-strategy.md`.
 
 ## Reproducing the protection

--- a/docs/engineering-loop/templates/pr-contract.md
+++ b/docs/engineering-loop/templates/pr-contract.md
@@ -1,0 +1,52 @@
+# PR contract template
+#
+# Rendered by the publish boundary (pr.py) from run state. Enforced, not
+# suggested: a loop-generated PR without these sections does not publish.
+
+## Intent
+
+<!-- 1–2 sentences: what and why. From the task spec. -->
+
+## Change class / risk
+
+- Change class: `<change_class>`
+- Risk tier: `<risk_level>`, customer impact `<customer_impact>`
+
+## AI transparency
+
+- Backend: `<backend>` (`<provider>/<model>`, tier `<tier>`)
+- Iterations: `<n>`, remediation rounds: `<n>`, cost: `<cost>`
+- Role judgments: `<role>: approve (provider/model)` per required role
+- Trace: `<loop_trace.json path / artifact link>`
+
+## Evidence
+
+<!-- Gate-by-gate results from the authoritative re-run, diff stats,
+     and for routing/firewall changes the lab (Batfish/Containerlab)
+     outcome. Evidence, not promises. -->
+
+## Human focus areas
+
+<!-- 1–2 named areas where machine verification is weakest and human
+     judgment is genuinely required (e.g. "transaction boundary in
+     services/intents.py", "prefix-list ordering"). -->
+
+## Rollout notes
+
+<!-- Deploy path and ordering, per docs/agentic-development-loop.md. -->
+
+## Rollback plan
+
+<!-- Deterministic command/workflow. -->
+
+## NOC handoff
+
+- expected alerts:
+- expected duration:
+- affected hosts/services:
+- rollback trigger:
+- operator command/workflow:
+
+## Post-deploy checks
+
+<!-- Health metrics + observation window for the break-glass handshake. -->

--- a/docs/engineering-loop/templates/task-spec.md
+++ b/docs/engineering-loop/templates/task-spec.md
@@ -1,0 +1,57 @@
+# Task spec template — tasks/<change-id>.md
+#
+# The sprint contract for one engineering-loop tranche. Frontmatter is the
+# machine-readable contract; the body is the human/agent-readable intent.
+# "Done" is defined here, before generation starts — evaluators grade the
+# diff against the acceptance criteria below, not against vibes.
+
+---
+change_id: EXAMPLE_CHANGE
+change_class: app_bugfix          # one of the v1 change classes
+risk_level: low                   # low | medium | high | critical
+customer_impact: none             # none | possible | expected
+repos:
+  hyrule-cloud:
+    allowed_paths: ["hyrule_cloud/", "tests/"]
+required_roles: []                # filled by the planner from the role matrix
+gates: []                         # filled from acceptance-gates.md per repo/class
+budget:
+  max_iterations: 20
+  max_wall_clock_minutes: 45
+  max_cost_usd: 5.00
+intake_source: "operator"         # operator | issue:<repo>#<n> | signal:<miner>
+---
+
+## Intent
+
+One or two sentences: what this tranche changes and why.
+
+## Acceptance criteria
+
+Testable statements only. Each criterion must be verifiable by a gate, a
+test, or direct inspection of the diff.
+
+1. ...
+2. ...
+
+## Done-conditions
+
+The run is complete when all acceptance criteria hold AND:
+
+- all gates in the frontmatter pass in the worktree;
+- the diff touches only `allowed_paths`;
+- every required role judgment is `approve`.
+
+## Non-goals
+
+What this tranche explicitly does not do (scope fence for the backend).
+
+## Role consult notes
+
+Appended by the plan-consult pass — one subsection per required role with
+the constraints that role demands of the diff.
+
+## Rollback sketch
+
+How this change is undone if it regresses after deploy (feeds the PR
+contract's rollback section and the NOC handoff).

--- a/docs/engineering-loop/v2-architecture.md
+++ b/docs/engineering-loop/v2-architecture.md
@@ -139,7 +139,10 @@ Execution rules:
   the backend environment. The backend gets the repo, its toolchain, and
   nothing else. Headless runs never execute on the privileged `ci` runner.
 - Budgets from the spec are hard limits: max iterations, max wall-clock, max
-  tokens/cost where the harness reports them. Exhaustion returns
+  tokens/cost where the harness reports them. When a harness reports no
+  cost/token figures, the loop enforces the iteration and wall-clock limits
+  alone and records the missing cost report in the trace — budget
+  enforcement is never silently skipped. Exhaustion returns
   `budget_exhausted` and routes to remediation/human sign-off, never to a
   silent retry.
 - `model-policy.yml` grows a `backends:` section so the same
@@ -282,7 +285,8 @@ Safety rails:
 
 - a run lock (one loop run at a time);
 - per-run and per-day budgets (tokens, cost, wall-clock, iterations);
-- kill criteria: no diff progress across N remediation rounds aborts the run;
+- kill criteria: an unchanged diff across 3 consecutive remediation rounds
+  (matching the role/gate retry circuit breaker) aborts the run;
 - a Discord webhook summary per run and an Icinga passive check
   ("loop ran / loop stuck / loop over budget");
 - never on the privileged `ci` runner — the backend executes generated code.

--- a/docs/engineering-loop/v2-architecture.md
+++ b/docs/engineering-loop/v2-architecture.md
@@ -1,0 +1,324 @@
+# Hyrule Engineering Loop v2 — Architecture
+
+Status: **approved design, pre-implementation**. This document is the
+canonical specification that the v2 refactor (roadmap phases B–G, see
+[v2-roadmap.md](./v2-roadmap.md)) is built against. The running v1
+implementation is documented in
+[docs/agentic-development-loop.md](../agentic-development-loop.md) and stays
+authoritative for current behavior until each phase lands.
+
+## Why v2
+
+v1 proved the control plane: classification, the six-senior-role matrix,
+gates, policy guards, worktree promotion, the human PR boundary, trace, and
+the NOC handoff. What it cannot yet do is *build real things* or *run
+unattended*:
+
+- The implementation writer is a **one-shot structured completion**
+  (`llm.py`). It receives truncated source context and must emit complete
+  file contents (`create`/`replace`) in a single response. It cannot explore
+  the repo, run a test, read an error, or iterate. That caps output quality
+  at docs scaffolding.
+- Role reviewers approve the **request text before any diff exists** — the
+  Network Architect never sees the FRR change it is approving.
+- There is no memory between runs, no intake beyond an operator prompt, no
+  scheduler, and no budget enforcement.
+
+The v2 inversion, grounded in current loop/harness-engineering practice
+(Osmani's loop-engineering / self-improving-agents / harness-engineering
+series, Anthropic's long-running harness design, Lance Martin's agent design
+patterns):
+
+> v1 simulated a coding agent inside LangGraph. v2 uses LangGraph to **drive
+> a real coding-agent harness** inside a guarded worktree, judges the
+> resulting diff, and learns from every run.
+
+Everything that made v1 safe is retained: the mutation boundary, policy
+guards, model-policy tiering, loop trace, NOC handoff, the break-glass
+rollback handshake, and the hard Engineering-Loop / NOC-Loop separation.
+
+## Decisions of record
+
+- v2 ultimately lives in a dedicated repo (`AS215932/engineering-loop`,
+  roadmap phase G). Until extraction, code keeps evolving in place in
+  `network-operations` so history transfers via `git subtree split`.
+- **Harness-agnostic**: loop state, prompts, skills, task specs, and gates
+  are plain files plus a CLI. Pi `/loop` remains the interactive entry
+  point; the same loop is drivable headless (`pi` non-interactive,
+  `claude -p`, systemd timer, CI).
+- **PR-only autonomy**: the loop may pick work, implement, verify, file
+  issues, and open draft PRs. Every merge and every production apply stays
+  human-gated. No auto-merge tier exists.
+
+## Top-level flow
+
+```text
+INTAKE (the heartbeat)
+  /loop <prompt> (Pi)            GitHub issues: loop:approved
+  signal miners (Icinga/Prometheus/drift/nightly CI, read-only) ──> triage
+        triage = scored candidates filed as issues labeled loop:candidate
+        a human relabels loop:candidate -> loop:approved
+            |
+            v
+PLAN  planner + role plan-consults
+        -> tasks/<change-id>.md  (sprint contract: acceptance criteria,
+           risk, required roles, gates, budget, allowed paths)
+            |
+            v
+RUN (one tranche, fresh context per run)
+  repo adapter: clean checkout -> branch-backed worktree
+  AgentBackend.execute(spec, worktree)        <- pi | claude -p | mock
+        iterative: explore, edit, run gates itself, react to failures
+  authoritative gate re-run                    <- loop re-runs gates itself
+  diff policy guard                            <- paths, secrets, size, scope
+  role evaluators judge the DIFF               <- per role matrix; read-only
+        findings + retry < 3  ──> back to AgentBackend with findings
+        retry == 3 or policy fail ──> human_signoff
+            |
+            v
+PACKAGE   PR contract + rollout/rollback notes + NOC handoff + trace
+            |
+            v
+HUMAN GATE   operator approves persisted state (Pi /loop, CLI)
+            |
+            v
+PUBLISH   push branch + draft PR (never merges)
+            |
+            v
+LEARN   reflection -> journal entry + proposed lessons / skill edits
+        memory/ is injected into the next run's planner and backend
+```
+
+## Components
+
+### 1. AgentBackend — the generation core
+
+New module `src/hyrule_engineering_loop/backend.py`.
+
+```python
+class AgentBackend(Protocol):
+    def execute(
+        self,
+        *,
+        task_spec: TaskSpec,          # parsed tasks/<change-id>.md
+        worktree: Path,               # branch-backed worktree, already created
+        constraints: BackendConstraints,  # budgets, tool scope, read_only
+    ) -> AgentRunResult: ...
+
+@dataclass
+class AgentRunResult:
+    diff: str                  # git diff captured from the worktree
+    changed_paths: list[str]
+    transcript_path: Path      # full harness transcript, kept out of trace
+    gate_evidence: list[GateResult]   # gates the agent ran itself (advisory)
+    iterations: int
+    wall_clock_seconds: float
+    cost: CostReport           # tokens / dollars where the harness reports them
+    status: Literal["completed", "budget_exhausted", "failed"]
+```
+
+Implementations:
+
+- `PiBackend` — non-interactive `pi` invocation in the worktree.
+- `ClaudeCodeBackend` — `claude -p --output-format json` with permission
+  flags pinned (no network-credentialed tools, repo-scoped filesystem).
+- `MockBackend` — deterministic; absorbs the v1 writer semantics
+  (`create`/`replace` whole-file mutations from `llm_mock_responses`) so the
+  existing phased test suites keep passing without API keys and without a
+  harness binary.
+
+Execution rules:
+
+- The backend runs **inside the promoted worktree** (worktree creation moves
+  *before* implementation). The v1 temp-workspace + whole-file mutation path
+  is retired from the live flow and survives only inside `MockBackend`.
+- Injected context: the task spec, the skill index (progressive disclosure —
+  full `SKILL.md` files are read on demand from the worktree), and the
+  target repo's `memory/lessons/<repo>.md`.
+- Environment hygiene: no production credentials, no Vault, no fleet SSH in
+  the backend environment. The backend gets the repo, its toolchain, and
+  nothing else. Headless runs never execute on the privileged `ci` runner.
+- Budgets from the spec are hard limits: max iterations, max wall-clock, max
+  tokens/cost where the harness reports them. Exhaustion returns
+  `budget_exhausted` and routes to remediation/human sign-off, never to a
+  silent retry.
+- `model-policy.yml` grows a `backends:` section so the same
+  tier/risk/retry escalation that selects models also selects the executor
+  (cheap harness+model combos for routine tranches, stronger for high risk).
+
+### 2. Task specs — sprint contracts
+
+`tasks/<change-id>.md`, template at
+[templates/task-spec.md](./templates/task-spec.md). YAML frontmatter carries
+the machine-readable contract (change_class, risk_level, customer_impact,
+repos + allowed paths, required roles, selected gates, budgets); the body
+carries intent, **testable acceptance criteria**, explicit done-conditions,
+non-goals, and a rollback sketch.
+
+A planner stage (model-routed like today's classifier) expands intake text
+into the spec. `/loop --plan` keeps feeding Pi Plan-Mode output into the
+same path. Evaluators later grade the diff *against the spec's criteria* —
+"done" is defined before generation starts, which is the structural defense
+against the agent declaring success.
+
+### 3. Two-phase role participation — all six roles preserved
+
+The v1 role matrix is kept verbatim (change class + risk selects required
+roles; `mixed`/high-risk requires all six; the graph cannot exit without
+every required approval). What changes is *when and what* a role reviews:
+
+1. **Plan consult (before implementation).** Each required role contributes
+   constraints and acceptance criteria into the task spec through its lens —
+   e.g. the Network Architect injects "WireGuard endpoints stay on
+   underlay; update `docs/network-flows.md`; rollback = revert + BGP session
+   re-check". This preserves v1's pre-implementation review value and is how
+   every role's perspective shapes the work before code exists.
+2. **Post-diff judgment (after gates).** Each required role rules on the
+   actual diff + gate evidence against the spec's criteria, returning a
+   structured verdict:
+
+```text
+verdict: approve | request_changes
+findings: [ {domain, severity, path?, message, suggested_remediation?} ]
+evidence_reviewed: [ ... ]      # what the role actually looked at
+```
+
+Generation vs judgment is the load-bearing distinction. Generation needs
+iteration, so it moves to the backend. Judgment over a bounded artifact
+(diff + evidence + criteria) is legitimately a structured call — **except**
+for high-risk roles, which run in **read-only agentic mode** (the same
+`AgentBackend` with `read_only=True`) so the architect can open full
+configs, grep `docs/network-flows.md`, or inspect Batfish output before
+ruling, instead of judging from one prompt of truncated context.
+
+Findings feed back to the backend as remediation context. The 3-strike
+retry counter per domain and the circuit breaker to `human_signoff` are
+unchanged from v1. Evaluation *depth* (model tier, agentic vs structured,
+evidence required) scales with risk; role *coverage* does not shrink.
+
+### 4. Gates — the loop re-verifies, never trusts
+
+The backend runs gates itself while iterating (that is what makes it
+effective), but its gate results are **advisory evidence only**. After the
+backend completes, the loop re-runs the authoritative gate set from the
+spec in the worktree: repo gates per `docs/agent-loops/acceptance-gates.md`
+(pytest/ruff/mypy, `npm run check`, Ansible validate renders), and for
+`routing_bgp_frr` / `firewall_policy` the existing tiered NetOps labs
+(`scripts/ci/iac-static.sh`, Batfish, Containerlab) on their normal trusted
+triggers. Gate failures parse into `validation_errors` exactly as today.
+
+### 5. Diff policy guard
+
+`policy.py` shifts from pre-validating proposed mutations to validating the
+**resulting `git diff`**: denied path globs, denied content patterns,
+max-changed-files, max-file-bytes — plus a new check that every changed path
+falls under the spec's allowed prefixes ("touch only what you're asked to
+touch"). Protected-branch, allowed-remote, and handoff-dir guards are
+unchanged. The changed-file cap doubles as the comprehension-debt control:
+tranches stay small enough for a human to genuinely review.
+
+### 6. Memory — the self-improvement flywheel
+
+New `memory/` tree:
+
+```text
+memory/
+  lessons/<repo>.md       # accumulated rules, AGENTS.md-style, human-curated
+  proposals/<change-id>.md  # loop-proposed lesson/skill edits, await human merge
+  journal/<change-id>.md  # per-run lab notes: attempts, failures, findings, cost
+```
+
+- A new `reflection` node runs after publish or human sign-off: it distills
+  the run (what failed, what the evaluators caught, what surprised the
+  backend) into a journal entry and, when warranted, a **proposed** lesson.
+- Humans merge proposals into `memory/lessons/` — human curation is
+  deliberate; the loop never edits its own rulebook directly.
+- Every lesson entry must trace to a specific failure (the ratchet). When a
+  failure class recurs, it graduates from a lesson into a deterministic gate
+  or policy rule, and the lesson is retired.
+- Lessons and the journal tail are injected into the planner and backend on
+  the next run touching that repo.
+
+### 7. Skills — workflows, not role essays
+
+`skills/<name>/SKILL.md` (see the `skills/` tree at the repo root):
+frontmatter with trigger conditions, workflow steps with **checkpoints that
+demand evidence**, an **anti-rationalization table**, and exit criteria.
+
+Initial set: the six senior-role skills, the implementation-tranche skill
+(the backend's working contract), and ISP-procedure skills that previously
+lived only as CLAUDE.md prose (firewall three-step, monitoring
+onboarding three-step). The loop injects skills itself (index up front, full
+text on demand), which keeps the system harness-agnostic instead of
+depending on any one CLI's native skill mechanism. v1's
+`docs/agent-loops/*.md` files remain until phase C rebinds prompt loading.
+
+### 8. Intake and triage — the heartbeat
+
+New `src/hyrule_engineering_loop/intake/`:
+
+- `github_issues.py` — scans org repos for actionable work. Queue
+  convention is labels: `loop:candidate` (machine-proposed, awaiting human
+  triage), `loop:approved` (eligible for autonomous runs). Issue bodies
+  follow the org's existing self-contained Context / Action items / Related
+  convention.
+- `signals.py` — read-only miners over Icinga and Prometheus (via
+  hyrule-mcp), nightly `drift-detection` artifacts, and `netops-nightly`
+  failures. Miners emit *candidate issues*, never direct runs, and dedupe
+  against open issues before filing. NetFlow joins later as another miner.
+
+The triage inbox is therefore the GitHub issue tracker itself — reviewable
+from anywhere, durable, and already monitored by humans.
+
+### 9. Operations lane — long-running mode
+
+`hyrule-engineering-loop daemon --once`: pick exactly one `loop:approved`
+item, run the full flow, end with a draft PR or a journaled failure, exit.
+A systemd timer (operator machine first; later a dedicated `loop` VM
+onboarded through the standard flows/firewall/monitoring three-steps) or a
+manually dispatched workflow provides the schedule.
+
+Safety rails:
+
+- a run lock (one loop run at a time);
+- per-run and per-day budgets (tokens, cost, wall-clock, iterations);
+- kill criteria: no diff progress across N remediation rounds aborts the run;
+- a Discord webhook summary per run and an Icinga passive check
+  ("loop ran / loop stuck / loop over budget");
+- never on the privileged `ci` runner — the backend executes generated code.
+
+### 10. PR contract
+
+`pr.py` renders a structured PR body from the run state
+([templates/pr-contract.md](./templates/pr-contract.md)): intent in two
+sentences, evidence (gate outputs, diff stats), risk tier + **AI
+transparency** (backend, models, iterations from the trace), one or two
+named human focus areas, and the rollout / rollback / NOC handoff sections
+that v1 documented as a suggestion. In v2 the template is enforced at the
+publish boundary, not suggested.
+
+## Boundaries that do not change
+
+- **NOC separation**: the Engineering Loop designs and builds; the NOC Loop
+  observes and remediates. The forbidden/allowed connection lists in
+  [docs/agentic-development-loop.md](../agentic-development-loop.md) carry
+  over verbatim, including the break-glass rollback handshake.
+- **Human gate**: `approval_decision: approved` on a persisted state
+  artifact remains the only path to push/PR. Draft PRs only. No auto-merge.
+- **Policy guards** stay fail-closed: any policy failure routes to
+  `human_signoff`, never around it.
+
+## State and artifact layout (target)
+
+```text
+.engineering-loop-state/<change-id>.json   # persisted GraphState (as today)
+tasks/<change-id>.md                       # sprint contract
+memory/{lessons,proposals,journal}/        # flywheel
+skills/<name>/SKILL.md                     # injected workflows
+handoff/{noc_handoff.json,loop_trace.json} # unchanged shapes, plus backend
+                                           # transcript path + cost report
+worktrees/<repo>-<change-id>/              # backend works here
+```
+
+`loop_trace.json` keeps its sanitized-summary discipline; backend
+transcripts are stored beside it but never inlined.

--- a/docs/engineering-loop/v2-roadmap.md
+++ b/docs/engineering-loop/v2-roadmap.md
@@ -1,0 +1,180 @@
+# Hyrule Engineering Loop v2 — Roadmap
+
+Phases B–G of the v2 refactor (phase A was the design itself — the
+[architecture spec](./v2-architecture.md), templates, and the initial
+`skills/` tree). Each phase is one reviewable PR with green gates and is
+dogfooded as a task spec when the loop is far enough along to build itself.
+
+Tracked as GitHub issues in `AS215932/network-operations`; this file is the
+ordered overview.
+
+## B — AgentBackend + worktree-first execution
+
+The generation core swap.
+
+Scope:
+
+- `src/hyrule_engineering_loop/backend.py`: `AgentBackend` protocol,
+  `AgentRunResult`, `BackendConstraints`, `CostReport`.
+- `MockBackend` absorbing v1 writer semantics (whole-file `create`/`replace`
+  from `llm_mock_responses`) so existing tests pass without keys/binaries.
+- `PiBackend` and `ClaudeCodeBackend` (non-interactive subprocess drivers,
+  environment-hygiene enforced: no Vault, no fleet SSH, repo-scoped).
+- Graph reorder: repo adapter + worktree creation move **before**
+  implementation; `delegate_implementation` node replaces
+  `implementation` + `workspace_writer`; the temp-workspace path is removed
+  from the live flow.
+- `policy.py` validates the resulting `git diff` (denied globs/content,
+  size caps, spec-allowed path prefixes) instead of proposed mutations.
+- `model-policy.yml` `backends:` section + selection logic in
+  `model_policy.py`.
+- `backend-canary` CLI command (docs-only live canary, successor of
+  `writer-canary`).
+
+Acceptance criteria:
+
+1. `uv run --group dev python -m pytest -q` green with no API keys and no
+   harness binaries installed (MockBackend everywhere).
+2. `backend-canary --dry-live` assembles spec/skills/lessons context and the
+   backend command line without executing a harness.
+3. A live `backend-canary` against a sibling repo produces a docs-only diff
+   in a branch-backed worktree, passes the diff policy guard, and stops
+   before approval/push.
+4. Policy guard rejects: a diff touching paths outside the spec allowlist, a
+   diff introducing a secret-pattern match, and a diff above the file cap —
+   each with structured `validation_errors`.
+5. Budget exhaustion in the backend returns `budget_exhausted` and routes to
+   human sign-off, observable in the trace.
+
+## C — Task specs + two-phase roles
+
+"Done" defined before generation; roles judge the artifact.
+
+Scope:
+
+- `tasks/<change-id>.md` parser (frontmatter + body sections per the
+  template); planner stage expands intake text into a spec; `/loop --plan`
+  feeds Plan-Mode output into the same path.
+- Role plan-consult pass writes role constraints/criteria into the spec.
+- Role nodes become post-diff judges: structured verdict schema
+  (`approve | request_changes` + findings), gate evidence attached.
+- Read-only agentic evaluation mode (backend with `read_only=True`) for
+  high/critical risk and for `routing_bgp_frr` / `firewall_policy` roles.
+- Remediation router feeds findings back to the backend; 3-strike circuit
+  breaker preserved.
+- Prompt loading rebinds from `docs/agent-loops/*.md` to `skills/*/SKILL.md`.
+
+Acceptance criteria:
+
+1. A run without a task spec is refused (except `run`/`dry-run` test paths).
+2. The spec records each required role's consult output; the trace shows
+   both consult and judgment events per role.
+3. A mocked failing judgment routes findings back to the backend and the
+   diff demonstrably changes on the retry (test fixture).
+4. Role matrix coverage is byte-identical to v1 for every change class
+   (regression-tested against `required_roles_for_state`).
+5. High-risk evaluators run read-only: a write attempt from evaluation mode
+   fails the run (test fixture).
+
+## D — Memory + reflection flywheel
+
+Scope:
+
+- `memory/{lessons,proposals,journal}/` tree + loaders.
+- `reflection` node after publish/sign-off: journal entry always; proposed
+  lesson when a failure pattern is detected.
+- Lessons + journal tail injected into planner and backend context for the
+  target repo.
+- `loop lessons` CLI + Pi `/loop lessons` to review/merge proposals
+  (merge itself is a human git action).
+
+Acceptance criteria:
+
+1. Every completed or signed-off run writes exactly one journal entry.
+2. A run that fails the same gate twice produces a lesson proposal that
+   names the gate and the failing pattern.
+3. Proposals never modify `memory/lessons/` directly (test: proposals dir
+   only).
+4. A lesson present for the target repo appears verbatim in the backend's
+   injected context (dry-live assembly test).
+
+## E — Intake + triage
+
+Scope:
+
+- `intake/github_issues.py`: org-repo scan, `loop:candidate` /
+  `loop:approved` label protocol, self-contained issue bodies, dedupe
+  against open issues.
+- `intake/signals.py`: read-only miners — Icinga unhandled-alert summary,
+  Prometheus rule breaches, nightly drift artifacts, `netops-nightly`
+  failures — each emitting candidate issues only.
+- Scoring/dedupe so the inbox stays low-noise.
+- Pi `/loop triage` to review the candidate queue.
+
+Acceptance criteria:
+
+1. Miners are read-only: no mutating MCP/gh calls outside issue creation.
+2. A signal already represented by an open issue files nothing.
+3. Candidate issues carry Context / Action items / Related sections and the
+   `loop:candidate` label; nothing self-promotes to `loop:approved`.
+4. `daemon --once` (phase F dependency) only consumes `loop:approved`.
+
+## F — Operations lane
+
+Scope:
+
+- `daemon --once`: pick one `loop:approved` item, full run, draft PR or
+  journaled failure, exit. Run lock; per-run and per-day budgets; kill
+  criteria (no diff progress across N remediation rounds).
+- Discord webhook run summary; Icinga passive check (`loop ran / stuck /
+  over budget`).
+- systemd service + timer units (operator machine first; a dedicated `loop`
+  VM later goes through the standard network-flows + firewall + monitoring
+  onboarding).
+- Never schedule on the privileged `ci` runner.
+
+Acceptance criteria:
+
+1. Two concurrent `daemon --once` invocations: the second exits immediately
+   on the lock.
+2. Budget exhaustion mid-run produces a draft-PR-less journaled failure and
+   a Discord summary, and the next run is unaffected.
+3. The Icinga passive check goes stale-alert when the timer stops firing.
+4. End-to-end: a seeded `loop:approved` docs issue becomes a draft PR with
+   the PR contract body, with no human input between timer fire and PR.
+
+## G — Extraction to AS215932/engineering-loop
+
+Scope:
+
+- `git subtree split` of: `src/hyrule_engineering_loop/`, loop test suites,
+  `docs/agent-loops/`, `docs/agentic-development-loop.md`,
+  `docs/engineering-loop/`, `skills/`, `integrations/pi/`,
+  `model-policy.yml`, `engineering-loop-policy.yml`, `pyproject.toml`/lock.
+- New repo CI: `pytest` + `ruff` + `mypy --strict` on the **unprivileged
+  `ci-pr` runner** (label `hyrule-public-pr`), branch protection with those
+  checks required.
+- `network-operations` keeps a pointer doc; Pi extension install docs
+  repoint; promotion/PR tooling configs updated for the new repo name.
+- Update the org CI/CD inventory (`docs/ci/org-cicd-inventory.md`).
+
+Acceptance criteria:
+
+1. History for migrated files is preserved in the new repo.
+2. New repo CI green on the unprivileged runner; repo added to the
+   `public-pr` runner group, not `hyrule-ci`.
+3. `network-operations` contains no loop runtime code afterwards; its CI
+   stays green (lint/render/iac-gate unaffected).
+4. A sibling-canary run from the new repo against `hyrule-cloud` works
+   end-to-end.
+
+## Sequencing notes
+
+- B is the prerequisite for everything; C and D can land in either order
+  after B (D's reflection is more valuable once C's specs exist, so C
+  first is preferred).
+- E only needs the CLI surface, but its issues are only consumable once F
+  exists; landing E before F gives humans time to tune the miners' noise
+  level on `loop:candidate` quality alone.
+- G goes last deliberately: extraction is cheap once the shape is stable,
+  and expensive churn if done mid-refactor.

--- a/docs/engineering-loop/v2-roadmap.md
+++ b/docs/engineering-loop/v2-roadmap.md
@@ -125,7 +125,9 @@ Scope:
 
 - `daemon --once`: pick one `loop:approved` item, full run, draft PR or
   journaled failure, exit. Run lock; per-run and per-day budgets; kill
-  criteria (no diff progress across N remediation rounds).
+  criteria (an unchanged diff across 3 consecutive remediation rounds
+  aborts; when the harness reports no cost, iteration/wall-clock limits
+  still enforce).
 - Discord webhook run summary; Icinga passive check (`loop ran / stuck /
   over budget`).
 - systemd service + timer units (operator machine first; a dedicated `loop`

--- a/docs/netops/testing-strategy.md
+++ b/docs/netops/testing-strategy.md
@@ -10,7 +10,7 @@ the privileged `ci` runner on trusted triggers only.
 
 | Tier | Jobs | Runner | Trigger | Gating |
 |------|------|--------|---------|--------|
-| 0 — static | `static-iac`, `ansible-idempotency` | `hyrule-public-pr` (unprivileged) | every PR touching IaC paths | **required** via `iac-gate` |
+| 0 — static | `static-iac`, `ansible-idempotency` | `hyrule-public-pr` (unprivileged) | PRs with IaC path changes | **required** via `iac-gate` |
 | 1 — Batfish | `batfish` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_BATFISH_TESTS`, nightly | advisory / trusted-only |
 | 2 — Containerlab | `containerlab-frr` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_CONTAINERLAB_TESTS`, nightly | advisory / trusted-only |
 | 3 — deploy safety | `apply.yml` (manual, `production`, Icinga pre/post + Goss), `drift-detection.yml` (nightly check-mode) | `ci` (privileged) | manual / schedule | deploy-time |
@@ -63,24 +63,27 @@ are tracked as a follow-up — they need the lab to develop and verify.
 
 ## The `iac-gate` and branch protection
 
-`iac-tests.yml` is path-filtered (it only runs when IaC files change). Marking
-a path-filtered job *directly* required risks the classic deadlock: on a PR
-that touches none of those paths the job never reports, and a naive required
-context waits forever.
+`iac-tests.yml` intentionally is **not** workflow-level path-filtered. GitHub
+does not create check runs for a workflow skipped by `paths`, so a required
+context from that workflow can sit at "Expected" forever on a docs-only PR.
+Instead, the workflow always starts and does path detection inside the workflow.
 
-The fix is the **`iac-gate`** aggregator job (`if: always()`, `needs:` all
-tiers). It is the single required status context:
+The fix is the **`iac-gate`** aggregator job (`if: always()`, `needs:` the
+internal `changes` job plus all tiers). It is the single required status
+context:
 
-- It **always reports** when the workflow runs, passing only when the required
-  tiers (`static-iac`, `ansible-idempotency`) succeed and the trusted lab tiers
-  are *success or skipped* — never failed.
-- When the whole workflow is skipped by path filtering (a docs-only PR), GitHub
-  treats the required `iac-gate` context as passing, so the PR is not blocked.
+- It **always reports** because the workflow always runs.
+- On PRs with no IaC-relevant changes, the internal `changes` job reports
+  `iac_changed=false`, the tier jobs are skipped, and `iac-gate` passes.
+- On IaC PRs, `iac-gate` passes only when the required tiers (`static-iac`,
+  `ansible-idempotency`) succeed and the trusted lab tiers are *success or
+  skipped* — never failed.
 
 Therefore branch protection requires **`iac-gate`** (plus the lint/render
 contexts from `lint.yml` / `render-check.yml` and `semgrep`), **not** the
-individual path-filtered tier jobs. Verify after any change with a docs-only PR
-that touches none of the IaC paths: it must not show a stuck "Expected" check.
+individual tier jobs. Verify after any change with a docs-only PR that touches
+none of the IaC paths: `iac-tests` must run, the tier jobs should be skipped,
+and `iac-gate` must report success rather than a stuck "Expected" check.
 
 ## Adding a check
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,24 @@
+# Engineering Loop skills
+
+Workflow skills for the Hyrule Engineering Loop v2
+(`docs/engineering-loop/v2-architecture.md`). A skill is a workflow with
+checkpoints that demand evidence, an anti-rationalization table, and exit
+criteria — not a prose role description. The loop injects this index up
+front and full `SKILL.md` files on demand (progressive disclosure); the
+files are harness-agnostic markdown so Pi, Claude Code, or any CLI agent can
+consume them.
+
+v1's `docs/agent-loops/*.md` prompts remain the bound prompts until roadmap
+phase C rebinds prompt loading to this tree.
+
+| Skill | Used by | When |
+|---|---|---|
+| `role-network-architect` | evaluator/consult | routing_bgp_frr, firewall_policy, mixed; any topology/addressing change |
+| `role-systems-engineer` | evaluator/consult | every change class touching host/service/runtime behavior |
+| `role-devops-netops` | evaluator/consult | CI/CD, Ansible, deploy sequencing, Vault rendering, monitoring |
+| `role-security-auditor` | evaluator/consult | firewall, Vault, WireGuard, BGP filtering, tenant isolation, noc_runtime |
+| `role-finops-integrity` | evaluator/consult | cloud_api, billing/quota/metering paths |
+| `role-virtual-lab-chaos` | evaluator/consult | routing/firewall labs, high/critical risk, rollback rehearsal |
+| `implementation-tranche` | backend (generator) | every implementation run |
+| `firewall-change` | backend | any change to who-talks-to-whom on which port |
+| `monitoring-onboarding` | backend | adding a host or service that needs monitoring |

--- a/skills/firewall-change/SKILL.md
+++ b/skills/firewall-change/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: firewall-change
+description: The AS215932 firewall three-step — flows doc, host_vars, re-render — for any change to who talks to whom on which port.
+triggers: [opening or closing a port, adding a peer or service, moving a host]
+---
+
+# Firewall change (three-step)
+
+`docs/network-flows.md` is the single source of truth for "who talks to
+whom on which port". Every rule in `ansible/inventory/host_vars/*.yml`
+traces back to a row there. The order below is mandatory.
+
+## Workflow
+
+1. **Spec first — `docs/network-flows.md`.** Add/remove/edit the row in the
+   per-host inbound table and any cross-cutting flow entry. If it's not in
+   this file, it must not be in a rule.
+   *Checkpoint: the row exists before any YAML is touched.*
+2. **Rule second — `ansible/inventory/host_vars/<host>.yml`.** Append/edit
+   the matching `firewall_extra_rules` entry. Reference peers by name
+   (`{{ peers.mon.ipv6 }}`), never literal addresses. New peers go into
+   `ansible/inventory/group_vars/all.yml` under `peers:` first.
+3. **Re-render and review.**
+   `cd ansible && ansible-playbook playbooks/firewall.yml --tags validate
+   --connection=local --skip-tags=snapshot`. Inspect the diff in
+   `ansible/generated/<host>/{nftables.conf,pf.conf}` and commit it as part
+   of the same change.
+   *Checkpoint: the generated diff matches the intended flow row, nothing
+   more.*
+
+New hosts additionally: define in `ansible/inventory/hosts.yml`, add to
+`peers:`, write `host_vars/<host>.yml`, document flows, re-render — then
+follow `monitoring-onboarding`.
+
+Applying to live hosts is **out of scope for the loop**: apply is gated on
+the `apply` tag + `firewall_apply=true` via the runbook in
+`docs/ansible.md`, with Icinga snapshots before and after.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "It's a temporary rule, skip the flows doc" | Temporary rules become permanent. Row first, always. |
+| "I'll hardcode the IP, the peer dict is overhead" | Literal addresses rot silently when hosts move. Peers by name only. |
+| "Generated diff is huge, commit without reading" | The generated diff IS the change. Unread diff = unreviewed firewall. |
+
+## Exit criteria
+
+- Flow row, host_vars rule, and committed re-rendered artifacts all present
+  in one diff, mutually consistent.
+- `--tags validate` exits clean.
+- No literal peer addresses introduced.

--- a/skills/implementation-tranche/SKILL.md
+++ b/skills/implementation-tranche/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: implementation-tranche
+description: Working contract for the implementation backend producing one engineering-loop tranche inside a guarded worktree.
+triggers: [every implementation run]
+---
+
+# Implementation tranche
+
+You are producing the smallest useful tranche for the active task spec, in a
+branch-backed worktree. The diff is the deliverable; evidence makes it real.
+
+## Workflow
+
+1. **Read the contract.** Open the task spec (`tasks/<change-id>.md`). Note
+   `allowed_paths`, acceptance criteria, non-goals, and budget.
+   *Checkpoint: restate the acceptance criteria in your plan before editing.*
+2. **Read the lessons.** Open `memory/lessons/<repo>.md` if present. Treat
+   every entry as a hard constraint.
+3. **Explore before editing.** Find the existing pattern for what you're
+   about to write (similar module, similar test, similar config block).
+   Reuse it; do not invent a parallel convention.
+4. **Implement inside `allowed_paths` only.** Touch only what the spec asks
+   you to touch. If the right fix lies outside the allowlist, stop and
+   report that instead of working around it.
+5. **Run the gates yourself after each meaningful edit.** The spec lists
+   them; default to the repo's gates in
+   `docs/agent-loops/acceptance-gates.md`.
+   *Checkpoint: paste the failing output you fixed, not just the final pass.*
+6. **Self-review the diff** (`git diff`): no secrets, no commented-out
+   code, no test deletions or skips, no drive-by refactors, complete-but-
+   minimal.
+7. **Report.** Summarize what changed, evidence per acceptance criterion,
+   and anything you could not satisfy and why.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "This task is too small for the spec's criteria" | Criteria still apply; satisfying five lines of criteria is fast. |
+| "The test is wrong, I'll delete/skip it" | Never. Removing or skipping tests fails the run. Fix code or report the conflict. |
+| "I need to touch a file outside allowed_paths, it's just one line" | Out of scope is out of scope. Report it; the spec gets amended by a human. |
+| "Gates pass, ship it" | Gates are evidence, not proof. Walk the acceptance criteria one by one. |
+| "A bigger refactor would be cleaner" | Smallest useful tranche. File the refactor as a finding instead. |
+
+## Exit criteria
+
+- Every acceptance criterion has named evidence (gate output, test, or diff
+  hunk).
+- All spec gates pass in the worktree.
+- `git diff --stat` touches only `allowed_paths`.
+- The report distinguishes "done with evidence" from "not done, because".

--- a/skills/monitoring-onboarding/SKILL.md
+++ b/skills/monitoring-onboarding/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: monitoring-onboarding
+description: The AS215932 monitoring three-step — every host/service gets node_exporter + Icinga + Prometheus scrape from day one.
+triggers: [adding a host, adding a service that needs probes]
+---
+
+# Monitoring onboarding (three-step)
+
+Every server MUST have monitoring from day one. The `monitoring` role
+(`ansible/roles/monitoring/`, playbook `ansible/playbooks/monitoring.yml`)
+is the single entry point.
+
+## Workflow
+
+1. **Flows — `docs/network-flows.md`.** Open `mon → host:9100` for the
+   node_exporter scrape (plus any service-specific probe ports), following
+   the `firewall-change` skill.
+2. **Host vars — `ansible/inventory/host_vars/<host>.yml`.** Set
+   `monitoring_register: true` ONLY for hosts not already in the legacy
+   `/etc/icinga2/conf.d/hosts/{infra-vms,routers,dom0}.conf` — duplicates
+   fail the icinga2 reload. Add `monitoring_extra_services` for
+   service-aware probes (DNS SOA, TLS validity, TCP port) as one
+   `object Service` block each.
+   *Checkpoint: confirmed the host is not in the legacy conf files before
+   setting `monitoring_register`.*
+3. **Prometheus — `/etc/prometheus/prometheus.yml` on mon** (mirrored at
+   `configs/mon/prometheus.yml`). Add the host to the right
+   `static_configs` job (`node-infra`, `node-routers`,
+   `node-offsite-ns`, …). The role does not manage this file yet — keep the
+   repo mirror and the change in sync.
+
+Applying (`--tags apply -e '{"monitoring_apply":true}' --limit <host>`) and
+the prometheus reload are operator actions, out of scope for the loop. Live
+deploys bracket with Icinga snapshots before and after — never skipped
+without a recorded emergency reason.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "Monitoring can follow in a later PR" | Day-one rule. An unmonitored host is an outage you find by hand. |
+| "Register it everywhere to be safe" | Duplicate Host objects fail the icinga2 reload fleet-wide. Check the legacy confs first. |
+| "The generic checks are enough" | Service-aware probes (SOA, TLS, port) are what catch the real regressions; add them when a service is the point of the host. |
+
+## Exit criteria
+
+- Flow row for the scrape, host_vars monitoring config, and the
+  prometheus.yml mirror change are all in the same diff.
+- No duplicate Icinga Host object is possible (legacy confs checked).
+- Service-specific probes exist for every service the change introduces.

--- a/skills/role-devops-netops/SKILL.md
+++ b/skills/role-devops-netops/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: role-devops-netops
+description: Senior DevOps/NetOps Engineer lens — CI/CD shape, Ansible validate/apply, Vault rendering, rollback, and deploy sequencing.
+triggers: [infra_ansible, monitoring_logging, deploy or CI-touching changes, vault_secret_plane]
+---
+
+# Senior DevOps/NetOps Engineer
+
+Owns: CI/CD shape; Ansible validation/apply workflow; Vault-rendered
+secrets; rollback and watchdog patterns; render checks; deployment
+sequencing; monitoring, smoke tests, drift detection.
+
+## Plan consult (before implementation)
+
+1. Name the gates this change must pass (render-check, iac-gate tiers,
+   repo suites) and the deploy path it will eventually take
+   (`apply.yml` manual + production gate; app promotion flow for app SHAs).
+2. Add acceptance criteria for: rollback plan, re-rendered
+   `ansible/generated/` artifacts committed when templates change, and
+   secrets staying in the Vault/runtime plane.
+
+## Post-diff judgment
+
+1. Read the diff; for Ansible changes confirm `ansible/generated/` is
+   re-rendered and the diff there matches the template change.
+   *Checkpoint: list files opened in `evidence_reviewed`.*
+2. Check runner safety: nothing moves untrusted-PR work onto the privileged
+   runner; nothing weakens the two-runner model.
+3. Check secrets: no plaintext tokens in code/YAML/docs; Vault references
+   only; no test requiring production credentials by default.
+4. Check rollback and sequencing sections exist and are deterministic.
+5. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- Live infra apply outside existing approval gates; missing rollback plan;
+  tests requiring production credentials by default; privileged runners for
+  untrusted PR code; secrets outside the Vault/runtime plane.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "Render diff is noisy, skip committing generated/" | render-check will fail and the reviewer loses the real diff. Re-render and commit it. |
+| "This deploy is tiny, skip the snapshot bracket" | Icinga pre/post snapshots are how regressions are caught. No skip without a recorded emergency reason. |
+| "The secret is only in a test fixture" | Fixture secrets become real leaks. Vault or fake values only. |
+
+## Exit criteria
+
+Verdict `approve` only when the tranche uses existing gates, keeps secrets
+in the runtime secret plane, includes rollback and deploy sequencing, and
+leaves the runner security model intact.

--- a/skills/role-finops-integrity/SKILL.md
+++ b/skills/role-finops-integrity/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: role-finops-integrity
+description: FinOps & Billing Integrity Engineer lens — metering, billing protocol, quotas, and payment-state consistency.
+triggers: [cloud_api, billing, quota, metering, provisioning paths]
+---
+
+# FinOps & Billing Integrity Engineer
+
+Owns: telemetry metering; billing protocol validation; rate-limiting rules;
+VPS state-change verification against payment state; x402/payment tracking
+and quota behavior.
+
+## Plan consult (before implementation)
+
+1. State the payment-state invariants: every resource allocation path must
+   be reachable only through a verified payment-state transition.
+2. Add acceptance criteria for: state tests matching any quota/billing
+   change, and regression tests for any pricing middleware change.
+
+## Post-diff judgment
+
+1. Read the diff for every path that provisions, renews, suspends, or
+   deletes resources; trace each back to its payment-state check.
+   *Checkpoint: name the check per mutation path in `evidence_reviewed`.*
+2. Look for races: can the state transition and the resource action
+   interleave with a payment failure? Demand the test that proves not.
+3. Confirm quota/billing changes ship with matching state tests, and
+   metering changes keep telemetry consistent.
+4. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- Resource allocation without explicit payment confirmation hooks;
+  quota/billing changes without matching state tests; provisioning races
+  around payment-state transitions; pricing middleware changes without
+  regression tests.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The UI prevents that flow" | The API is the boundary, not the UI. The check lives server-side or it doesn't exist. |
+| "It's an internal admin path" | Internal paths leak into automation. Same invariants apply. |
+| "Tests would need a payment sandbox" | Fake the provider, not the invariant — state-machine tests run hermetically. |
+
+## Exit criteria
+
+Verdict `approve` only when allocation, quota, metering, and billing state
+transitions remain internally consistent and test-covered.

--- a/skills/role-network-architect/SKILL.md
+++ b/skills/role-network-architect/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: role-network-architect
+description: Senior Network Architect lens — plan-consult constraints and post-diff judgment for AS215932 topology, routing, and flow policy.
+triggers: [routing_bgp_frr, firewall_policy, dns, mixed, topology or addressing changes]
+---
+
+# Senior Network Architect
+
+Owns: AS215932 topology correctness; BGP/OSPFv3/WireGuard/VRF/NAT64-DNS64;
+IPv6 addressing and customer isolation; `docs/network-flows.md` as firewall
+source of truth; blast radius; peering/transit impact; routing rollback.
+
+## Plan consult (before implementation)
+
+1. State the topology/addressing invariants this change must preserve
+   (underlay vs overlay split, WG endpoints on underlay, loopback plan,
+   domain policy for `as215932.net`/`servify.network`/`hyrule.host`).
+2. Name the source-of-truth files the diff must stay consistent with
+   (`docs/network-flows.md`, inventory, router configs).
+3. Add acceptance criteria for: inbound prefix filtering / IRR / RPKI on any
+   peering change, isolation preservation, and a credible routing rollback.
+
+## Post-diff judgment
+
+1. Read the actual diff — every routing/firewall/addressing hunk, not the
+   summary. For high-risk changes, open the full target files in the
+   worktree, not just hunks.
+   *Checkpoint: list the files you opened in `evidence_reviewed`.*
+2. Cross-check against `docs/network-flows.md` and the inventory: any flow
+   change must have a matching row; any new peer must exist in `peers:`.
+3. Verify lab evidence for `routing_bgp_frr`/`firewall_policy`: Batfish or
+   Containerlab results in the gate evidence, or an explicit human risk
+   acceptance recorded in state.
+4. Verify the rollback section is deterministic (command/workflow, not
+   intent).
+5. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- Undocumented flow changes; production routing changes without validation
+  and rollback; claims based on monitoring text without direct network
+  evidence; domain-policy misuse; transit/peering changes missing inbound
+  prefix filtering, IRR, or RPKI validation.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The diff is small, the lab run is overkill" | Class, not size, decides: routing/firewall classes require lab proof or recorded risk acceptance. |
+| "Flows doc can be updated in a follow-up" | The flows doc IS the spec. No matching row, no approval. |
+| "The summary says isolation is preserved" | Summaries are not evidence. Open the rendered pf/nftables output. |
+
+## Exit criteria
+
+Verdict `approve` only when routing intent, isolation, documented flow
+policy, filtering posture, and a credible rollback are all evidenced in the
+diff and gate results.

--- a/skills/role-security-auditor/SKILL.md
+++ b/skills/role-security-auditor/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: role-security-auditor
+description: Senior Security & Cryptographic Auditor lens — firewall posture, Vault hygiene, WireGuard/BGP filtering, tenant isolation.
+triggers: [firewall_policy, vault_secret_plane, routing_bgp_frr, noc_runtime, tenant isolation or secret-handling changes]
+---
+
+# Senior Security & Cryptographic Auditor
+
+Owns: edge firewall posture; Vault secret hygiene; WireGuard cipher suites
+and key rotation; RPKI/IRR validation correctness in FRR; customer
+isolation; multi-tenant boundary review.
+
+## Plan consult (before implementation)
+
+1. State the isolation and secret-plane invariants the diff must preserve
+   (customer segment never reaches infra/mgmt; secrets only as Vault
+   references; WG keys never in repo).
+2. Add acceptance criteria for: listening-port changes traced to flow rows,
+   filtering posture on any peering change, and key/cipher handling review
+   where touched.
+
+## Post-diff judgment
+
+1. Read the diff hunk by hunk for ports, keys, tokens, filters, and tenant
+   boundaries; open rendered firewall artifacts for any rule change.
+   *Checkpoint: list files opened in `evidence_reviewed`.*
+2. Grep the diff for secret-shaped content beyond the policy guard's
+   patterns (the guard is a net, not the review).
+3. For BGP: confirm inbound prefix filtering and RPKI/IRR posture is intact
+   on every touched peer.
+4. For isolation-relevant changes: demand lab or rendered-config evidence
+   that the customer/infra boundary holds.
+5. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- Wide or untracked listening ports; plaintext tokens/keys anywhere outside
+  Vault references; peering configs missing robust inbound filtering or
+  RPKI validation; tenant isolation regressions; unvetted cipher/key
+  handling changes.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The policy guard already scans for secrets" | The guard catches patterns; you catch semantics. Review anyway. |
+| "Port is only open on the infra segment" | Infra is not a trust zone exemption — the flow row and rule must still exist. |
+| "Filtering is configured on the other peer" | Each peer stands alone. Verify this one. |
+
+## Exit criteria
+
+Verdict `approve` only when cryptographic hygiene, secret handling,
+firewall intent, and tenant isolation are all preserved with evidence.

--- a/skills/role-systems-engineer/SKILL.md
+++ b/skills/role-systems-engineer/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: role-systems-engineer
+description: Senior Systems Engineer lens — runtime, OS, and service-lifecycle review for AS215932 hosts.
+triggers: [every change class touching host, service, or runtime behavior]
+---
+
+# Senior Systems Engineer
+
+Owns: host/service/runtime correctness; OS-specific behavior across Debian,
+FreeBSD, OpenBSD, XCP-NG; `systemd`/`rcctl` lifecycle; logging contract;
+application integration boundaries; resource limits and failure modes.
+
+## Plan consult (before implementation)
+
+1. State the runtime invariants: which units/services are affected, what
+   health signal proves they still work, which OSes the change must behave
+   on.
+2. Add acceptance criteria for: a health check per touched daemon,
+   structured logging for new code paths, and explicit resource/failure
+   behavior where relevant.
+
+## Post-diff judgment
+
+1. Read the diff for every service/unit/config change; for daemon changes
+   open the unit file and the health-check wiring in the worktree.
+   *Checkpoint: list files opened in `evidence_reviewed`.*
+2. Check OS portability: anything assuming Linux semantics that lands on
+   FreeBSD/OpenBSD hosts (`doas` not sudo, `ifconfig` not ip, `rcctl` not
+   systemctl) is a finding.
+3. Check the logging contract: new paths log structured events; nothing
+   logs secrets.
+4. Confirm no code path bypasses an existing safety gate.
+5. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- Daemon changes without health checks; unstructured logging; secret
+  logging; Linux assumptions on BSD hosts; bypasses of existing safety
+  gates.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The service restarts fine locally" | Local restart is not a health check. Demand the probe that monitoring will run. |
+| "Logging can be tidied later" | The logging contract is part of done; NOC diagnostics depend on it. |
+| "It's the same on FreeBSD" | Verify, don't assume — name the BSD-side evidence or flag it. |
+
+## Exit criteria
+
+Verdict `approve` only when runtime behavior, health checks, logs, resource
+limits, and OS compatibility are explicitly accounted for in the diff.

--- a/skills/role-virtual-lab-chaos/SKILL.md
+++ b/skills/role-virtual-lab-chaos/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: role-virtual-lab-chaos
+description: Virtual Lab & Chaos Simulation Engineer lens — emulated validation, convergence, failure behavior, rollback rehearsal.
+triggers: [routing_bgp_frr, firewall_policy, infra_ansible, noc_runtime, any high or critical risk change]
+---
+
+# Virtual Lab & Chaos Simulation Engineer
+
+Owns: digital twin / local emulation validation; ephemeral lab instances;
+routing convergence checks incl. FRR route reflection; target-OS config
+parsing (Debian, FreeBSD, OpenBSD, XCP-NG); rollback rehearsal under
+intentional disruption.
+
+## Plan consult (before implementation)
+
+1. Decide which lab tier the change needs: Batfish model assertions,
+   Containerlab dynamic topology, or nested-hypervisor parsing — per
+   `docs/agent-loops/acceptance-gates.md` and
+   `docs/netops/testing-strategy.md`.
+2. Add acceptance criteria naming the exact lab assertions that must pass
+   and the rollback rehearsal expected for high-risk changes.
+
+## Post-diff judgment
+
+1. Locate the lab evidence in the gate results; verify the lab topology
+   actually corresponds to the source-of-truth files the diff touches.
+   *Checkpoint: name the artifacts compared in `evidence_reviewed`.*
+2. Verify failure behavior was exercised, not just the happy path
+   (session drop, link loss, reload — whichever the change class implies).
+3. Verify the rollback script/workflow was executed in the lab, not just
+   written.
+4. If no lab evidence exists: approve only when the state records an
+   explicit human risk acceptance.
+5. Return the structured verdict with findings keyed by file/path.
+
+## Must reject
+
+- High-risk routing/system changes without local lab proof; unexercised
+  rollback scripts; firewall/routing changes that cannot demonstrate
+  expected isolation or convergence; lab results inconsistent with the
+  stated source-of-truth files.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The config parses, that's enough" | Parsing is tier 0. Convergence and failure behavior are the point of the lab. |
+| "Rollback is just a git revert" | The revert was never run against a live-shaped topology. Rehearse it. |
+| "The nightly lab will catch it" | The nightly is detection, not pre-merge proof. Run the gate now or record risk acceptance. |
+
+## Exit criteria
+
+Validation `approve` only when emulated topology behavior, failure
+behavior, and rollback behavior demonstrably match the planned production
+change — or a human risk acceptance is recorded in state.


### PR DESCRIPTION
## Intent

Phase A of the Engineering Loop v2 refactor: the canonical v2 design, the phased roadmap (B-G), the task-spec and PR-contract templates, and the first concrete v2 artifact: the `skills/` tree.

This PR also includes the CI fix for the required `iac-gate` context: `iac-tests` now always starts, detects IaC-relevant paths internally, skips tier jobs for docs-only changes, and still reports `iac-gate`. No production runtime code changes.

## Change class / risk

- Change class: docs / planning artifacts + CI workflow correction
- Risk tier: low, customer impact none

## What v2 changes (summary)

v1 simulated a coding agent inside LangGraph (one-shot structured completions emitting whole files). v2 uses LangGraph to **drive a real coding-agent harness** (`AgentBackend`: pi / claude / mock) inside the guarded branch-backed worktree, judges the resulting diff, and learns from every run:

- **Task specs as sprint contracts** — testable acceptance criteria defined before generation.
- **Two-phase role participation** — all six senior roles preserved verbatim from the v1 matrix; each required role now consults at planning *and* judges the actual post-gate diff (read-only agentic mode for high-risk roles), instead of approving request text before a diff exists.
- **Diff-based policy guards**, memory/reflection flywheel (`memory/lessons` proposals, human-curated), issue/signal intake with `loop:candidate` / `loop:approved` triage labels, and a budgeted headless operations lane.
- **Unchanged**: human PR gate (draft PRs only, no auto-merge), policy guards fail-closed, NOC-loop separation, break-glass handshake.

Design grounded in the loop/harness-engineering research set (Osmani's loop-engineering, self-improving-agents, harness-engineering, orchestration-tax, agent-skills series; Anthropic's harness design for long-running app development; Lance Martin's agent design patterns; Ralph-loop practice).

## Files

- `docs/engineering-loop/v2-architecture.md` — canonical spec
- `docs/engineering-loop/v2-roadmap.md` — phases B-G with acceptance criteria
- `docs/engineering-loop/templates/{task-spec,pr-contract}.md`
- `skills/` — six role skills + implementation-tranche contract + firewall-change + monitoring-onboarding, each with evidence checkpoints, anti-rationalization tables, exit criteria
- `docs/agentic-development-loop.md` — short v2-direction pointer (v1 doc stays authoritative for current behavior)
- `.github/workflows/iac-tests.yml` — always-starting `iac-gate` workflow with internal path detection
- `docs/netops/testing-strategy.md`, `docs/ci/branch-protection.md` — corrected `iac-gate` / path-filtering docs

## Tracking issues

Phase B #191 · Phase C #192 · Phase D #193 · Phase E #194 · Phase F #195 · Phase G #196

## Evidence

- `uv run --group dev python -m pytest -q tests/test_*.py` → 55 passed (loop suites; run with neutral git config — the remote sandbox's commit-signing breaks test fixtures that create local commits, not a repo issue).
- `yamllint -c .yamllint .github/workflows/iac-tests.yml` → pass.
- `git diff --check` → clean.
- PR checks on `009a5c5` → pass, including `Detect IaC changes`, `static-iac`, `ansible-idempotency`, `batfish`, `containerlab-frr`, and required `iac-gate`.

## Human focus areas

1. The `AgentRunResult` / verdict schemas in the architecture spec — these become the phase B/C contracts.
2. Whether the skills' anti-rationalization tables match how you actually want the roles to push back.

## Rollout / rollback

Docs/CI-only; rollback = revert. Phases B-G tracked in #191-#196.

## NOC handoff

Not applicable (no production-affecting change).

https://claude.ai/code/session_01YXgVn8LWjsH8ZTq9vuGYzF
