### PR TITLE
Engineering Loop v2 Phase E: intake + label-gated triage inbox

### DIFF
--- a/docs/agentic-development-loop.md
+++ b/docs/agentic-development-loop.md
@@ -231,6 +231,9 @@ Pi uses one command as the daily entry point:
 /loop --plan
   -> read latest Plan Mode proposed plan and send it as the request
 
+/loop triage
+  -> review the intake queue (approved work + candidate inbox)
+
 /loop lessons
   -> review memory lessons and pending lesson proposals
 
@@ -239,6 +242,7 @@ Pi uses one command as the daily entry point:
        start new request
        show latest summary
        show latest trace
+       triage intake queue
        review lessons & proposals
        cleanup latest worktree
        approve latest state
@@ -878,6 +882,29 @@ Phase 22 (v2 Phase D) adds the memory + reflection flywheel:
   a lesson into a deterministic gate or policy rule
   (`engineering-loop-policy.yml`, a gate script, or a CI workflow), and
   the lesson is retired. Lessons are working memory; gates are law.
+
+Phase 23 (v2 Phase E) adds intake and the label-gated triage inbox:
+
+- the inbox is the GitHub issue tracker, gated by two labels:
+  `loop:candidate` (machine-proposed, awaiting human triage) and
+  `loop:approved` (human-blessed, eligible for autonomous runs — the only
+  thing the Phase F operations lane will consume). **Nothing in the loop
+  can apply `loop:approved`**; a human relabels after review;
+- `src/hyrule_engineering_loop/intake/` holds the heartbeat:
+  `github_issues.py` (org-repo scan, deterministic scoring by label
+  weights + age + body completeness, fingerprint dedupe, candidate filing
+  with self-contained Context / Action items / Related bodies) and
+  `signals.py` (read-only miners: Icinga unhandled problems, Prometheus
+  firing alerts, `drift-detection` / `netops-nightly` failures —
+  unconfigured sources skip gracefully; NetFlow joins later);
+- miners are strictly read-only (HTTP GETs, `gh run list`); the only write
+  in the whole package is candidate-issue creation, and a signal already
+  represented by an open issue files nothing (the body carries a hidden
+  `loop-fingerprint` marker);
+- operator surface: `hyrule-engineering-loop intake scan [--dry-run]`,
+  `intake queue`, and `intake labels --apply` (label creation is an
+  explicit operator action, never implicit); `/loop triage` in Pi shows
+  the queue.
 
 From Pi, use the global extension command:
 

--- a/integrations/pi/extensions/hyrule-loop/index.ts
+++ b/integrations/pi/extensions/hyrule-loop/index.ts
@@ -427,6 +427,23 @@ async function approveLatest(ctx: ExtensionContext, pi: ExtensionAPI): Promise<v
 	ctx.ui.notify(result.code === 0 ? `Approved latest loop state.\n${result.stdout}` : result.stderr || result.stdout, result.code === 0 ? "info" : "error");
 }
 
+async function triageIntake(ctx: ExtensionContext, pi: ExtensionAPI): Promise<void> {
+	const config = await loadConfig(ctx);
+	const result = await runLoopCli(pi, config, ["intake", "queue"], ctx);
+	if (result.code !== 0) {
+		ctx.ui.notify(result.stderr || result.stdout || "intake queue failed", "error");
+		return;
+	}
+	ctx.ui.notify(
+		[
+			"Hyrule loop intake (relabel candidates to loop:approved to authorize):",
+			"",
+			result.stdout.trim(),
+		].join("\n"),
+		"info",
+	);
+}
+
 async function reviewLessons(ctx: ExtensionContext, pi: ExtensionAPI): Promise<void> {
 	const config = await loadConfig(ctx);
 	const memoryDir = join(config.infraRepo, "memory");
@@ -602,6 +619,7 @@ export default function hyruleLoopExtension(pi: ExtensionAPI): void {
 					"Start new request",
 					"Show latest summary",
 					"Show latest trace",
+					"Triage intake queue",
 					"Review lessons & proposals",
 					"Cleanup latest worktree",
 					"Approve latest state",
@@ -612,6 +630,8 @@ export default function hyruleLoopExtension(pi: ExtensionAPI): void {
 					await showLatest(ctx);
 				} else if (choice === "Show latest trace") {
 					await showTrace(ctx);
+				} else if (choice === "Triage intake queue") {
+					await triageIntake(ctx, pi);
 				} else if (choice === "Review lessons & proposals") {
 					await reviewLessons(ctx, pi);
 				} else if (choice === "Cleanup latest worktree") {
@@ -624,6 +644,7 @@ export default function hyruleLoopExtension(pi: ExtensionAPI): void {
 
 			if (/^status$/i.test(command)) return showLatest(ctx);
 			if (/^trace$/i.test(command)) return showTrace(ctx);
+			if (/^triage$/i.test(command)) return triageIntake(ctx, pi);
 			if (/^lessons$/i.test(command)) return reviewLessons(ctx, pi);
 			if (/^cleanup$/i.test(command)) return cleanupLatest(ctx, pi);
 			if (/^approve$/i.test(command)) return approveLatest(ctx, pi);

--- a/src/hyrule_engineering_loop/cli.py
+++ b/src/hyrule_engineering_loop/cli.py
@@ -18,6 +18,15 @@ from hyrule_engineering_loop.feature import (
     run_feature_intake,
 )
 from hyrule_engineering_loop.graph import build_graph
+from hyrule_engineering_loop.intake import (
+    APPROVED_LABEL,
+    CANDIDATE_LABEL,
+    GhCli,
+    ensure_labels,
+    list_issues_with_label,
+    mine_all_signals,
+    signals_to_candidates,
+)
 from hyrule_engineering_loop.memory import list_memory
 from hyrule_engineering_loop.model_policy import (
     model_policy_snapshot,
@@ -441,6 +450,67 @@ def backend_canary_command(args: argparse.Namespace) -> int:
     return 0
 
 
+DEFAULT_INTAKE_REPO = "AS215932/network-operations"
+
+
+def intake_scan_command(args: argparse.Namespace) -> int:
+    client = GhCli()
+    signals, skipped = mine_all_signals(repo=args.repo, client=client)
+    report = signals_to_candidates(
+        signals, repo=args.repo, client=client, dry_run=args.dry_run
+    )
+    report.skipped_miners = skipped
+    payload = report.as_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"intake scan ({'dry-run, nothing filed' if args.dry_run else 'filed'}):")
+    for entry in payload["filed"]:
+        print(f"  - {entry['source']}: {entry['title']}" + (f" -> {entry['url']}" if entry.get("url") else ""))
+    for entry in payload["deduplicated"]:
+        print(f"  - deduplicated (open issue #{entry['existing_issue']}): {entry['title']}")
+    for note in payload["skipped_miners"]:
+        print(f"  - skipped: {note}")
+    return 0
+
+
+def intake_queue_command(args: argparse.Namespace) -> int:
+    client = GhCli()
+    repos = args.repo or [DEFAULT_INTAKE_REPO]
+    approved = list_issues_with_label(repos, APPROVED_LABEL, client=client)
+    candidates = list_issues_with_label(repos, CANDIDATE_LABEL, client=client)
+    payload = {
+        "approved": [item.as_dict() for item in approved],
+        "candidates": [item.as_dict() for item in candidates],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(f"approved (eligible for autonomous runs, label {APPROVED_LABEL}):")
+    for item in approved or []:
+        print(f"  - [{item.score:.1f}] {item.repo}#{item.number} {item.title}")
+    if not approved:
+        print("  - (none)")
+    print(f"candidates (awaiting human triage, label {CANDIDATE_LABEL}):")
+    for item in candidates or []:
+        print(f"  - [{item.score:.1f}] {item.repo}#{item.number} {item.title}")
+    if not candidates:
+        print("  - (none)")
+    return 0
+
+
+def intake_labels_command(args: argparse.Namespace) -> int:
+    repos = args.repo or [DEFAULT_INTAKE_REPO]
+    if not args.apply:
+        print(f"would create {CANDIDATE_LABEL} and {APPROVED_LABEL} in: {', '.join(repos)}")
+        print("re-run with --apply to create them")
+        return 0
+    created = ensure_labels(repos, client=GhCli())
+    for item in created:
+        print(f"ensured {item}")
+    return 0
+
+
 def lessons_command(args: argparse.Namespace) -> int:
     """Review lessons and pending proposals; merging stays a human git action."""
     import os
@@ -696,6 +766,34 @@ def build_parser() -> argparse.ArgumentParser:
     feature_parser.add_argument("--dry-live", action="store_true")
     feature_parser.add_argument("--gate-command", nargs=argparse.REMAINDER)
     feature_parser.set_defaults(func=feature_command)
+
+    intake_parser = subparsers.add_parser("intake", help="signal mining and triage inbox")
+    intake_subparsers = intake_parser.add_subparsers(dest="intake_command", required=True)
+
+    intake_scan_parser = intake_subparsers.add_parser(
+        "scan",
+        help="mine read-only signals and file candidate issues (loop:candidate)",
+    )
+    intake_scan_parser.add_argument("--repo", default=DEFAULT_INTAKE_REPO)
+    intake_scan_parser.add_argument("--dry-run", action="store_true")
+    intake_scan_parser.add_argument("--json", action="store_true")
+    intake_scan_parser.set_defaults(func=intake_scan_command)
+
+    intake_queue_parser = intake_subparsers.add_parser(
+        "queue",
+        help="show the approved queue and the candidate triage inbox",
+    )
+    intake_queue_parser.add_argument("--repo", action="append")
+    intake_queue_parser.add_argument("--json", action="store_true")
+    intake_queue_parser.set_defaults(func=intake_queue_command)
+
+    intake_labels_parser = intake_subparsers.add_parser(
+        "labels",
+        help="create the loop:candidate / loop:approved labels (operator action)",
+    )
+    intake_labels_parser.add_argument("--repo", action="append")
+    intake_labels_parser.add_argument("--apply", action="store_true")
+    intake_labels_parser.set_defaults(func=intake_labels_command)
 
     lessons_parser = subparsers.add_parser(
         "lessons",

--- a/src/hyrule_engineering_loop/intake/__init__.py
+++ b/src/hyrule_engineering_loop/intake/__init__.py
@@ -1,0 +1,42 @@
+"""Intake — the loop's heartbeat (v2 Phase E).
+
+The triage inbox is the GitHub issue tracker itself, gated by labels:
+``loop:candidate`` is machine-proposed work awaiting human triage;
+``loop:approved`` is human-blessed work eligible for autonomous runs.
+Signal miners are read-only and emit candidate issues — never direct runs —
+and nothing in this package can apply ``loop:approved``.
+"""
+
+from hyrule_engineering_loop.intake.github_issues import (
+    APPROVED_LABEL,
+    CANDIDATE_LABEL,
+    GhCli,
+    GhClient,
+    IntakeItem,
+    ensure_labels,
+    file_candidate_issue,
+    find_fingerprint_issue,
+    list_issues_with_label,
+    score_issue,
+)
+from hyrule_engineering_loop.intake.signals import (
+    Signal,
+    mine_all_signals,
+    signals_to_candidates,
+)
+
+__all__ = [
+    "APPROVED_LABEL",
+    "CANDIDATE_LABEL",
+    "GhCli",
+    "GhClient",
+    "IntakeItem",
+    "Signal",
+    "ensure_labels",
+    "file_candidate_issue",
+    "find_fingerprint_issue",
+    "list_issues_with_label",
+    "mine_all_signals",
+    "score_issue",
+    "signals_to_candidates",
+]

--- a/src/hyrule_engineering_loop/intake/github_issues.py
+++ b/src/hyrule_engineering_loop/intake/github_issues.py
@@ -1,0 +1,305 @@
+"""GitHub-issue intake: the label-gated triage inbox.
+
+Label protocol (v2 architecture §8):
+
+- ``loop:candidate`` — machine-proposed work awaiting human triage. The
+  only label this package ever applies.
+- ``loop:approved`` — human-blessed work, eligible for autonomous runs
+  (consumed by the Phase F operations lane). **Nothing here can apply it**;
+  a human relabels candidates after review.
+
+All GitHub access goes through the ``gh`` CLI behind a small client
+protocol so tests run fully offline against a fake.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+CANDIDATE_LABEL = "loop:candidate"
+APPROVED_LABEL = "loop:approved"
+
+FINGERPRINT_MARKER = "loop-fingerprint:"
+
+# Deterministic, documented scoring weights for queue ordering.
+LABEL_SCORE_WEIGHTS: dict[str, float] = {
+    "critical": 5.0,
+    "security": 4.0,
+    "bug": 2.0,
+    "firewall": 2.0,
+    "bgp": 2.0,
+    "monitoring": 1.0,
+    "routine": 1.0,
+}
+MAX_AGE_SCORE = 2.0
+
+
+class IntakeError(RuntimeError):
+    """Raised when the intake layer cannot complete an operation."""
+
+
+class GhClient(Protocol):
+    """Minimal ``gh`` invocation surface; fakes implement this in tests."""
+
+    def run(self, args: list[str]) -> str:
+        """Run ``gh <args>`` and return stdout; raise ``IntakeError`` on failure."""
+        ...
+
+
+class GhCli:
+    """Real ``gh`` CLI client."""
+
+    def run(self, args: list[str]) -> str:
+        completed = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise IntakeError(
+                completed.stderr.strip() or completed.stdout.strip() or "gh failed"
+            )
+        return completed.stdout
+
+
+@dataclass(frozen=True)
+class IntakeItem:
+    """One scored issue from the triage inbox."""
+
+    repo: str
+    number: int
+    title: str
+    url: str
+    labels: tuple[str, ...]
+    updated_at: str
+    score: float
+    body_complete: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repo": self.repo,
+            "number": self.number,
+            "title": self.title,
+            "url": self.url,
+            "labels": list(self.labels),
+            "updated_at": self.updated_at,
+            "score": round(self.score, 2),
+            "body_complete": self.body_complete,
+        }
+
+
+def signal_fingerprint(source: str, identifier: str) -> str:
+    """Stable fingerprint embedded in candidate bodies for dedupe."""
+    return hashlib.sha256(f"{source}:{identifier}".encode()).hexdigest()[:16]
+
+
+def _body_complete(body: str) -> bool:
+    return all(section in body for section in ("## Context", "## Action items", "## Related"))
+
+
+def _age_days(updated_at: str) -> float:
+    try:
+        updated = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    return max(0.0, (datetime.now(UTC) - updated).total_seconds() / 86_400)
+
+
+def score_issue(*, labels: list[str], body: str, updated_at: str) -> float:
+    """Deterministic triage score: label weights + bounded age + body quality."""
+    score = 1.0
+    for label in labels:
+        score += LABEL_SCORE_WEIGHTS.get(label.lower(), 0.0)
+    score += min(MAX_AGE_SCORE, _age_days(updated_at) / 30.0)
+    if _body_complete(body):
+        score += 1.0
+    return score
+
+
+def list_issues_with_label(
+    repos: list[str],
+    label: str,
+    *,
+    client: GhClient,
+) -> list[IntakeItem]:
+    """List open issues carrying ``label`` across repos, highest score first."""
+    items: list[IntakeItem] = []
+    for repo in repos:
+        raw = client.run(
+            [
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--label",
+                label,
+                "--json",
+                "number,title,body,labels,url,updatedAt",
+            ]
+        )
+        try:
+            decoded = json.loads(raw or "[]")
+        except json.JSONDecodeError as exc:
+            raise IntakeError(f"unexpected gh issue list output for {repo}") from exc
+        for issue in decoded if isinstance(decoded, list) else []:
+            labels = [
+                str(entry.get("name", ""))
+                for entry in issue.get("labels", [])
+                if isinstance(entry, dict)
+            ]
+            body = str(issue.get("body", ""))
+            updated_at = str(issue.get("updatedAt", ""))
+            items.append(
+                IntakeItem(
+                    repo=repo,
+                    number=int(issue.get("number", 0)),
+                    title=str(issue.get("title", "")),
+                    url=str(issue.get("url", "")),
+                    labels=tuple(labels),
+                    updated_at=updated_at,
+                    score=score_issue(labels=labels, body=body, updated_at=updated_at),
+                    body_complete=_body_complete(body),
+                )
+            )
+    return sorted(items, key=lambda item: item.score, reverse=True)
+
+
+def find_fingerprint_issue(repo: str, fingerprint: str, *, client: GhClient) -> int | None:
+    """Return the open issue number already carrying this signal fingerprint."""
+    raw = client.run(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--search",
+            f"{FINGERPRINT_MARKER} {fingerprint}",
+            "--json",
+            "number",
+        ]
+    )
+    try:
+        decoded = json.loads(raw or "[]")
+    except json.JSONDecodeError as exc:
+        raise IntakeError(f"unexpected gh search output for {repo}") from exc
+    for issue in decoded if isinstance(decoded, list) else []:
+        if isinstance(issue, dict) and issue.get("number") is not None:
+            return int(issue["number"])
+    return None
+
+
+def render_candidate_body(
+    *,
+    context: str,
+    action_items: list[str],
+    related: list[str],
+    fingerprint: str,
+) -> str:
+    """Self-contained candidate body per the org issue convention."""
+    lines = [
+        "## Context",
+        "",
+        context.strip(),
+        "",
+        "## Action items",
+        "",
+        *(f"{index}. {item}" for index, item in enumerate(action_items, start=1)),
+        "",
+        "## Related",
+        "",
+        *(f"- {item}" for item in related),
+        "",
+        "Filed by the Engineering Loop intake scan. Review and relabel to",
+        f"`{APPROVED_LABEL}` to make it eligible for autonomous runs.",
+        "",
+        f"<!-- {FINGERPRINT_MARKER} {fingerprint} -->",
+    ]
+    return "\n".join(lines)
+
+
+def file_candidate_issue(
+    *,
+    repo: str,
+    title: str,
+    context: str,
+    action_items: list[str],
+    related: list[str],
+    fingerprint: str,
+    client: GhClient,
+) -> str:
+    """File one candidate issue. Applies ``loop:candidate`` and nothing else."""
+    body = render_candidate_body(
+        context=context,
+        action_items=action_items,
+        related=related,
+        fingerprint=fingerprint,
+    )
+    stdout = client.run(
+        [
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--label",
+            CANDIDATE_LABEL,
+            "--body",
+            body,
+        ]
+    )
+    return stdout.strip()
+
+
+def ensure_labels(repos: list[str], *, client: GhClient) -> list[str]:
+    """Create the two protocol labels (explicit operator action, idempotent)."""
+    created: list[str] = []
+    for repo in repos:
+        for label, color, description in (
+            (CANDIDATE_LABEL, "fbca04", "Machine-proposed work awaiting human triage"),
+            (APPROVED_LABEL, "0e8a16", "Human-approved; eligible for autonomous loop runs"),
+        ):
+            client.run(
+                [
+                    "label",
+                    "create",
+                    label,
+                    "--repo",
+                    repo,
+                    "--color",
+                    color,
+                    "--description",
+                    description,
+                    "--force",
+                ]
+            )
+            created.append(f"{repo}:{label}")
+    return created
+
+
+@dataclass
+class IntakeReport:
+    """Outcome of one intake scan."""
+
+    filed: list[dict[str, Any]] = field(default_factory=list)
+    deduplicated: list[dict[str, Any]] = field(default_factory=list)
+    skipped_miners: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "filed": self.filed,
+            "deduplicated": self.deduplicated,
+            "skipped_miners": self.skipped_miners,
+            "dry_run": self.dry_run,
+        }

--- a/src/hyrule_engineering_loop/intake/signals.py
+++ b/src/hyrule_engineering_loop/intake/signals.py
@@ -1,0 +1,257 @@
+"""Read-only signal miners: infrastructure telemetry into candidate issues.
+
+Each miner observes one signal source — Icinga unhandled problems,
+Prometheus firing alerts, nightly drift-detection artifacts,
+``netops-nightly`` failures — and emits :class:`Signal` objects. Miners are
+strictly read-only (HTTP GETs and ``gh run list`` queries); the only write
+anywhere in intake is candidate-issue creation, and a signal already
+represented by an open issue files nothing (fingerprint dedupe).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, TypeAlias
+
+from hyrule_engineering_loop.intake.github_issues import (
+    GhClient,
+    IntakeReport,
+    file_candidate_issue,
+    find_fingerprint_issue,
+    signal_fingerprint,
+)
+
+HttpGet: TypeAlias = Callable[[str, dict[str, str]], str]
+
+DEFAULT_WORKFLOWS = ("drift-detection.yml", "netops-nightly.yml")
+MAX_SIGNALS_PER_SOURCE = 10
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One actionable observation from a read-only miner."""
+
+    source: str
+    identifier: str
+    title: str
+    context: str
+    action_items: tuple[str, ...]
+    related: tuple[str, ...]
+
+    @property
+    def fingerprint(self) -> str:
+        return signal_fingerprint(self.source, self.identifier)
+
+
+def _default_http_get(url: str, headers: dict[str, str]) -> str:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return str(response.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"GET {url} failed: {exc}") from exc
+
+
+def mine_icinga(http_get: HttpGet | None = None) -> tuple[list[Signal], str | None]:
+    """Unhandled, non-acknowledged service problems from the Icinga API."""
+    url = os.environ.get("HYRULE_ICINGA_URL")
+    user = os.environ.get("HYRULE_ICINGA_USER")
+    password = os.environ.get("HYRULE_ICINGA_PASSWORD")
+    if not url or not user or not password:
+        return [], "icinga: HYRULE_ICINGA_URL/USER/PASSWORD not configured"
+
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    raw = (http_get or _default_http_get)(
+        f"{url.rstrip('/')}/v1/objects/services"
+        "?filter=service.state!=0%26%26service.acknowledgement==0",
+        {"Authorization": f"Basic {token}", "Accept": "application/json"},
+    )
+    decoded = json.loads(raw)
+    signals: list[Signal] = []
+    for result in decoded.get("results", [])[:MAX_SIGNALS_PER_SOURCE]:
+        attrs = result.get("attrs", {}) if isinstance(result, dict) else {}
+        name = str(attrs.get("__name") or attrs.get("name") or "unknown-service")
+        state = attrs.get("state")
+        signals.append(
+            Signal(
+                source="icinga",
+                identifier=name,
+                title=f"Icinga unhandled problem: {name}",
+                context=(
+                    f"The Icinga service check `{name}` is in state {state} and is "
+                    "neither acknowledged nor in a downtime. The Engineering Loop "
+                    "intake scan flagged it as a candidate for engineering work "
+                    "(recurring problems usually need a config or code change, "
+                    "not another ack)."
+                ),
+                action_items=(
+                    f"Investigate why `{name}` keeps failing.",
+                    "Decide: fix the underlying config/code, tune the check, or "
+                    "document the expected state.",
+                ),
+                related=(f"icinga service `{name}`", "monitoring role / host_vars"),
+            )
+        )
+    return signals, None
+
+
+def mine_prometheus(http_get: HttpGet | None = None) -> tuple[list[Signal], str | None]:
+    """Firing Prometheus alerts via the HTTP API."""
+    url = os.environ.get("HYRULE_PROMETHEUS_URL")
+    if not url:
+        return [], "prometheus: HYRULE_PROMETHEUS_URL not configured"
+
+    raw = (http_get or _default_http_get)(
+        f"{url.rstrip('/')}/api/v1/alerts", {"Accept": "application/json"}
+    )
+    decoded = json.loads(raw)
+    alerts = decoded.get("data", {}).get("alerts", [])
+    signals: list[Signal] = []
+    for alert in alerts[:MAX_SIGNALS_PER_SOURCE]:
+        if not isinstance(alert, dict) or alert.get("state") != "firing":
+            continue
+        labels = alert.get("labels", {}) if isinstance(alert.get("labels"), dict) else {}
+        name = str(labels.get("alertname", "unknown-alert"))
+        instance = str(labels.get("instance", ""))
+        identifier = f"{name}@{instance}" if instance else name
+        signals.append(
+            Signal(
+                source="prometheus",
+                identifier=identifier,
+                title=f"Prometheus alert firing: {identifier}",
+                context=(
+                    f"The Prometheus alert `{name}`"
+                    + (f" on `{instance}`" if instance else "")
+                    + " is firing. If this is a recurring breach it likely needs an "
+                    "engineering change (capacity, config, or alert tuning)."
+                ),
+                action_items=(
+                    f"Check the alert expression and recent history for `{name}`.",
+                    "Fix the underlying cause or tune the rule with a justification.",
+                ),
+                related=("configs/mon/prometheus.yml", f"alert `{name}`"),
+            )
+        )
+    return signals, None
+
+
+def mine_workflow_failures(
+    *,
+    repo: str,
+    client: GhClient,
+    workflows: tuple[str, ...] = DEFAULT_WORKFLOWS,
+) -> tuple[list[Signal], str | None]:
+    """Most recent failed run per nightly workflow (read-only ``gh run list``)."""
+    signals: list[Signal] = []
+    for workflow in workflows:
+        raw = client.run(
+            [
+                "run",
+                "list",
+                "--repo",
+                repo,
+                "--workflow",
+                workflow,
+                "--limit",
+                "1",
+                "--json",
+                "conclusion,displayTitle,url,createdAt",
+            ]
+        )
+        try:
+            runs = json.loads(raw or "[]")
+        except json.JSONDecodeError:
+            continue
+        for run in runs if isinstance(runs, list) else []:
+            if not isinstance(run, dict) or run.get("conclusion") != "failure":
+                continue
+            created = str(run.get("createdAt", ""))[:10]
+            signals.append(
+                Signal(
+                    source="nightly",
+                    identifier=f"{workflow}:{created}",
+                    title=f"Nightly workflow failed: {workflow} ({created})",
+                    context=(
+                        f"The latest `{workflow}` run failed on {created}. Nightly "
+                        "failures are detection, not pre-merge proof — the drift or "
+                        "breakage they detect needs an engineering change."
+                    ),
+                    action_items=(
+                        f"Open the failed run and identify the failing step: {run.get('url')}",
+                        "File or fix the underlying drift/config issue.",
+                    ),
+                    related=(str(run.get("url", "")), f".github/workflows/{workflow}"),
+                )
+            )
+    return signals, None
+
+
+def mine_all_signals(
+    *,
+    repo: str,
+    client: GhClient,
+    http_get: HttpGet | None = None,
+) -> tuple[list[Signal], list[str]]:
+    """Run every configured miner; unconfigured sources skip gracefully."""
+    signals: list[Signal] = []
+    skipped: list[str] = []
+    miners: tuple[Callable[[], tuple[list[Signal], str | None]], ...] = (
+        lambda: mine_icinga(http_get),
+        lambda: mine_prometheus(http_get),
+        lambda: mine_workflow_failures(repo=repo, client=client),
+    )
+    for miner in miners:
+        try:
+            mined, note = miner()
+        except Exception as exc:
+            skipped.append(f"miner error: {exc}")
+            continue
+        signals.extend(mined)
+        if note:
+            skipped.append(note)
+    return signals, skipped
+
+
+def signals_to_candidates(
+    signals: list[Signal],
+    *,
+    repo: str,
+    client: GhClient,
+    dry_run: bool = False,
+) -> IntakeReport:
+    """Dedupe signals against open issues and file the new ones as candidates."""
+    report = IntakeReport(dry_run=dry_run)
+    for signal in signals:
+        existing = find_fingerprint_issue(repo, signal.fingerprint, client=client)
+        if existing is not None:
+            report.deduplicated.append(
+                {
+                    "title": signal.title,
+                    "fingerprint": signal.fingerprint,
+                    "existing_issue": existing,
+                }
+            )
+            continue
+        entry: dict[str, Any] = {
+            "title": signal.title,
+            "fingerprint": signal.fingerprint,
+            "repo": repo,
+            "source": signal.source,
+        }
+        if not dry_run:
+            entry["url"] = file_candidate_issue(
+                repo=repo,
+                title=signal.title,
+                context=signal.context,
+                action_items=list(signal.action_items),
+                related=list(signal.related),
+                fingerprint=signal.fingerprint,
+                client=client,
+            )
+        report.filed.append(entry)
+    return report

--- a/tests/test_phase23_intake.py
+++ b/tests/test_phase23_intake.py
@@ -1,0 +1,261 @@
+"""Phase E (v2): label-gated issue intake and read-only signal miners."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from hyrule_engineering_loop.intake import (
+    APPROVED_LABEL,
+    CANDIDATE_LABEL,
+    Signal,
+    ensure_labels,
+    file_candidate_issue,
+    list_issues_with_label,
+    mine_all_signals,
+    signals_to_candidates,
+)
+from hyrule_engineering_loop.intake.github_issues import IntakeError, signal_fingerprint
+from hyrule_engineering_loop.intake.signals import mine_icinga, mine_prometheus
+
+MUTATING_GH_COMMANDS = {"create", "edit", "close", "delete", "comment", "transfer", "label"}
+
+
+class FakeGh:
+    """Records every gh invocation; serves canned JSON per (command, repo)."""
+
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.responses = responses or {}
+
+    def run(self, args: list[str]) -> str:
+        self.calls.append(list(args))
+        key = " ".join(args[:2])
+        if key in self.responses:
+            return self.responses[key]
+        for full, response in self.responses.items():
+            if " ".join(args).startswith(full):
+                return response
+        return "[]"
+
+    def mutating_calls(self) -> list[list[str]]:
+        return [
+            call
+            for call in self.calls
+            if any(part in MUTATING_GH_COMMANDS for part in call[:2])
+        ]
+
+
+def _signal(identifier: str = "node-up@dns") -> Signal:
+    return Signal(
+        source="icinga",
+        identifier=identifier,
+        title=f"Icinga unhandled problem: {identifier}",
+        context="The check keeps failing.",
+        action_items=("Investigate.", "Fix or tune."),
+        related=("icinga",),
+    )
+
+
+def test_miners_are_read_only_and_dry_run_files_nothing() -> None:
+    gh = FakeGh()
+    signals, skipped = mine_all_signals(repo="AS215932/network-operations", client=gh)
+
+    # No Icinga/Prometheus env configured: those miners skip gracefully.
+    assert any("icinga" in note for note in skipped)
+    assert any("prometheus" in note for note in skipped)
+    # The only gh calls are read-only `run list` queries.
+    assert gh.mutating_calls() == []
+    assert all(call[:2] == ["run", "list"] for call in gh.calls)
+
+    report = signals_to_candidates(
+        [_signal()], repo="AS215932/network-operations", client=gh, dry_run=True
+    )
+    assert report.dry_run is True
+    assert len(report.filed) == 1
+    assert "url" not in report.filed[0]
+    assert gh.mutating_calls() == []
+    assert signals == []
+
+
+def test_duplicate_signal_files_nothing() -> None:
+    fingerprint = signal_fingerprint("icinga", "node-up@dns")
+    gh = FakeGh(
+        responses={
+            "issue list": json.dumps([{"number": 240}]),
+        }
+    )
+
+    report = signals_to_candidates(
+        [_signal()], repo="AS215932/network-operations", client=gh
+    )
+
+    assert report.filed == []
+    assert report.deduplicated[0]["existing_issue"] == 240
+    assert report.deduplicated[0]["fingerprint"] == fingerprint
+    assert gh.mutating_calls() == []
+
+
+def test_candidate_issue_body_and_label_protocol() -> None:
+    gh = FakeGh(
+        responses={
+            "issue list": "[]",
+            "issue create": "https://github.com/AS215932/network-operations/issues/241\n",
+        }
+    )
+
+    report = signals_to_candidates(
+        [_signal()], repo="AS215932/network-operations", client=gh
+    )
+
+    assert report.filed[0]["url"].endswith("/issues/241")
+    create_calls = [call for call in gh.calls if call[:2] == ["issue", "create"]]
+    assert len(create_calls) == 1
+    create = create_calls[0]
+
+    # AC3: the candidate label and nothing else. The body may *mention*
+    # loop:approved (it instructs the human how to authorize), but the label
+    # arguments never apply it.
+    label_values = [create[i + 1] for i, part in enumerate(create) if part == "--label"]
+    assert label_values == [CANDIDATE_LABEL]
+    body_index = create.index("--body") + 1
+    args_without_body = [part for i, part in enumerate(create) if i != body_index]
+    assert APPROVED_LABEL not in " ".join(args_without_body)
+
+    body = create[body_index]
+    assert "## Context" in body
+    assert "## Action items" in body
+    assert "## Related" in body
+    assert signal_fingerprint("icinga", "node-up@dns") in body
+
+
+def test_nothing_in_intake_can_apply_the_approved_label() -> None:
+    import hyrule_engineering_loop.intake.github_issues as gi
+    import hyrule_engineering_loop.intake.signals as sig
+    import inspect
+
+    for module in (gi, sig):
+        source = inspect.getsource(module)
+        # The approved label may be referenced (listing, docs) but never
+        # passed to a mutating gh subcommand.
+        for line in source.splitlines():
+            if "issue" in line and "create" in line:
+                assert "APPROVED_LABEL" not in line
+
+
+def test_approved_queue_lists_and_scores() -> None:
+    gh = FakeGh(
+        responses={
+            "issue list": json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "title": "routine cleanup",
+                        "body": "## Context\nx\n## Action items\n1. y\n## Related\n- z",
+                        "labels": [{"name": APPROVED_LABEL}, {"name": "routine"}],
+                        "url": "https://example/1",
+                        "updatedAt": "2026-06-01T00:00:00Z",
+                    },
+                    {
+                        "number": 2,
+                        "title": "critical fix",
+                        "body": "no sections",
+                        "labels": [{"name": APPROVED_LABEL}, {"name": "critical"}],
+                        "url": "https://example/2",
+                        "updatedAt": "2026-06-10T00:00:00Z",
+                    },
+                ]
+            )
+        }
+    )
+
+    items = list_issues_with_label(
+        ["AS215932/network-operations"], APPROVED_LABEL, client=gh
+    )
+
+    assert [item.number for item in items] == [2, 1]
+    assert items[0].score > items[1].score
+    assert items[1].body_complete is True
+    assert items[0].body_complete is False
+    assert gh.mutating_calls() == []
+
+
+def test_ensure_labels_is_an_explicit_operator_action() -> None:
+    gh = FakeGh()
+    created = ensure_labels(["AS215932/network-operations"], client=gh)
+
+    assert created == [
+        f"AS215932/network-operations:{CANDIDATE_LABEL}",
+        f"AS215932/network-operations:{APPROVED_LABEL}",
+    ]
+    # Label creation goes through `gh label create` only when invoked
+    # explicitly — the miners themselves never call it (covered above).
+    assert all(call[:2] == ["label", "create"] for call in gh.calls)
+
+
+def test_icinga_and_prometheus_miners_parse_get_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, str]]] = []
+
+    def fake_get(url: str, headers: dict[str, str]) -> str:
+        requests.append((url, headers))
+        if "/v1/objects/services" in url:
+            return json.dumps(
+                {"results": [{"attrs": {"__name": "dns!dns-soa", "state": 2}}]}
+            )
+        return json.dumps(
+            {
+                "data": {
+                    "alerts": [
+                        {
+                            "state": "firing",
+                            "labels": {"alertname": "NodeDown", "instance": "web"},
+                        },
+                        {"state": "pending", "labels": {"alertname": "Ignored"}},
+                    ]
+                }
+            }
+        )
+
+    monkeypatch.setenv("HYRULE_ICINGA_URL", "https://mon.example:5665")
+    monkeypatch.setenv("HYRULE_ICINGA_USER", "loop")
+    monkeypatch.setenv("HYRULE_ICINGA_PASSWORD", "x")
+    monkeypatch.setenv("HYRULE_PROMETHEUS_URL", "http://mon.example:9090")
+
+    icinga_signals, icinga_note = mine_icinga(fake_get)
+    prom_signals, prom_note = mine_prometheus(fake_get)
+
+    assert icinga_note is None and prom_note is None
+    assert icinga_signals[0].identifier == "dns!dns-soa"
+    assert prom_signals[0].identifier == "NodeDown@web"
+    assert len(prom_signals) == 1  # pending alerts are not signals
+    assert all(url.startswith(("https://mon", "http://mon")) for url, _ in requests)
+
+
+def test_gh_failure_raises_intake_error() -> None:
+    class FailingGh:
+        def run(self, args: list[str]) -> str:
+            raise IntakeError("boom")
+
+    with pytest.raises(IntakeError):
+        list_issues_with_label(["r"], APPROVED_LABEL, client=FailingGh())
+
+
+def test_candidate_filing_payload_is_self_contained() -> None:
+    gh = FakeGh(responses={"issue create": "https://example/242\n"})
+    url = file_candidate_issue(
+        repo="AS215932/network-operations",
+        title="t",
+        context="why this matters",
+        action_items=["step one"],
+        related=["docs/network-flows.md"],
+        fingerprint="abc123",
+        client=gh,
+    )
+    assert url == "https://example/242"
+    body = gh.calls[0][gh.calls[0].index("--body") + 1]
+    assert "Review and relabel" in body
+    assert f"`{APPROVED_LABEL}`" in body


### PR DESCRIPTION
## Intent

Give the loop a heartbeat: read-only miners turn Icinga problems, firing Prometheus alerts, and nightly workflow failures into candidate issues, and the GitHub issue tracker becomes the triage inbox — gated by labels so nothing runs without a human decision. Phase E of the v2 refactor (`docs/engineering-loop/v2-architecture.md` §8).

**Stacked on #201 (Phase D)** — review for the Phase E commits only; retarget as the stack merges.

## Change class / risk

- Change class: loop runtime (`mcp_diagnostic_tooling`-adjacent read-only consumers), risk tier medium per the roadmap (touches live-ish surfaces read-only); nothing executes work, nothing mutates infra
- Task spec: `docs/engineering-loop/v2-roadmap.md` § E; tracking issue #194

## AI transparency

- Authored by Claude Fable 5 (Claude Code session, operator-reviewed)
- All tests offline against a fake `gh` client and fake HTTP transports; no live calls

## Evidence

- [x] AC1 — miners are read-only: tests assert the fake `gh` recorded **zero mutating calls** during mining and dry-run scans; Icinga/Prometheus use GET-only transports; the only write in the package is `issue create`
- [x] AC2 — a signal already represented by an open issue files nothing (hidden `loop-fingerprint` body marker + open-issue search; same-signal-twice test)
- [x] AC3 — candidate issues carry Context / Action items / Related and **only** the `loop:candidate` label; nothing in intake can pass `loop:approved` to a mutating call (label-argument assertions + source-level check)
- [x] AC4 (Phase F dependency) — `list_issues_with_label(..., APPROVED_LABEL)` is the deterministic, scored queue the daemon will consume; covered by the queue test
- [x] Unconfigured signal sources skip gracefully (no env ⇒ note, not error); label creation is an explicit `intake labels --apply` operator action
- `pytest`: **145 passed** offline; `mypy --strict src` clean (27 files); `git diff --check` clean

## Human focus areas

1. **Scoring weights** (`github_issues.py::LABEL_SCORE_WEIGHTS`) — label weights + bounded age + body completeness. Deterministic and documented, but the weights are a first guess against your label taxonomy (`gh label list` showed critical/security/bug/firewall/bgp/monitoring/routine).
2. **Icinga/Prometheus transport** — direct read-only HTTP APIs (`HYRULE_ICINGA_URL/USER/PASSWORD`, `HYRULE_PROMETHEUS_URL`) rather than going through hyrule-mcp; the architecture says "via hyrule-mcp" but the loop is plain Python and the MCP server fronts SSH for *Claude* clients. Flagging the deviation — same read-only posture, different transport.
3. The default intake repo is `AS215932/network-operations`; multi-repo scan is supported on the queue side, single-repo on the filing side for now.

## Expected production impact

None. Read-only queries; candidate issues are the only artifact, and `--dry-run` previews without filing.

## Rollback plan

Revert the merge. Any filed candidate issues are ordinary issues — close them.

## NOC handoff

Not applicable.

## Post-deploy checks

After merge: `intake labels --apply`, then `intake scan --dry-run` against live signals; review the would-file list, run a real scan, and triage the first candidates via `/loop triage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)