### PR TITLE
Engineering Loop v2 Phase F: budgeted headless operations lane

### DIFF
--- a/configs/loop/hyrule-engineering-loop.service
+++ b/configs/loop/hyrule-engineering-loop.service
@@ -1,0 +1,50 @@
+# /etc/systemd/system/hyrule-engineering-loop.service
+# Deploy to: an operator machine or a dedicated `loop` VM — NEVER the
+# privileged `ci` runner. The backend executes generated code; the daemon
+# refuses to run when GITHUB_ACTIONS is set, but do not schedule it there
+# regardless. A dedicated `loop` VM goes through the standard
+# docs/network-flows.md + firewall + monitoring onboarding three-steps.
+#
+# Oneshot, timer-driven: one cycle picks one loop:approved issue, runs the
+# full graph, and ends with a draft PR or a journaled failure, then exits.
+
+[Unit]
+Description=AS215932 Engineering Loop operations lane (one budgeted cycle)
+After=network-online.target
+Wants=network-online.target
+# Belt and braces: do not even attempt a cycle on a CI runner.
+ConditionEnvironment=!GITHUB_ACTIONS
+
+[Service]
+Type=oneshot
+User=loop
+Group=loop
+WorkingDirectory=/opt/engineering-loop
+EnvironmentFile=/opt/engineering-loop/.env
+# .env provides: HYRULE_DISCORD_WEBHOOK, HYRULE_ICINGA_URL/USER/PASSWORD,
+# the loop's GH token for `gh`, and any model/provider keys. It must NOT
+# contain production Vault tokens or fleet SSH material — the backend env
+# is scrubbed, but keep the surface minimal.
+ExecStart=/opt/engineering-loop/.venv/bin/hyrule-engineering-loop daemon --once \
+    --workspace-root /opt/engineering-loop/workspace \
+    --output-root /var/lib/engineering-loop/runs \
+    --state-dir-path /var/lib/engineering-loop/state \
+    --memory-dir /opt/engineering-loop/workspace/hyrule-infra/memory
+# A run never blocks the next timer fire indefinitely; the daemon enforces
+# its own per-run wall-clock budget, this is the hard backstop.
+TimeoutStartSec=3600
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=engineering-loop
+
+# Security hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/opt/engineering-loop /var/lib/engineering-loop
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/loop/hyrule-engineering-loop.timer
+++ b/configs/loop/hyrule-engineering-loop.timer
@@ -1,0 +1,20 @@
+# /etc/systemd/system/hyrule-engineering-loop.timer
+# Deploy to: the same operator machine / `loop` VM as the service.
+#
+# Hourly cadence; the daemon's own per-run and per-day budgets (and the run
+# lock) bound the work, so the timer only needs to fire often enough to keep
+# the Icinga freshness check (check_interval = 90m) green. Keep this cadence
+# and the icinga engineering-loop.conf freshness window in step.
+
+[Unit]
+Description=Schedule the AS215932 Engineering Loop operations lane
+
+[Timer]
+OnCalendar=hourly
+# Avoid stampeding other top-of-hour jobs.
+RandomizedDelaySec=300
+Persistent=true
+Unit=hyrule-engineering-loop.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/mon/icinga2/services/engineering-loop.conf
+++ b/configs/mon/icinga2/services/engineering-loop.conf
@@ -1,0 +1,31 @@
+// /etc/icinga2/conf.d/services/engineering-loop.conf — Engineering Loop operations-lane heartbeat.
+//
+// The `hyrule-engineering-loop daemon --once` cycle submits a passive check
+// result here every run (Icinga API process-check-result against
+// service `noc!engineering-loop`):
+//   OK (0)   — published a draft PR, idle queue, or held lock
+//   WARN (1) — run paused for triage, or a daily budget was reached
+//   CRIT (2) — daemon error, or it refused to run on a CI runner
+//
+// Active checks stay enabled with the `dummy` command as a freshness
+// fallback: as long as passive results keep arriving inside the
+// freshness window the dummy never runs. If the systemd timer stops
+// firing, no passive result arrives, and after `check_interval` the dummy
+// fires CRIT — that is the "loop stopped running" stale alert.
+
+apply Service "engineering-loop" {
+  check_command = "dummy"
+  enable_active_checks = true
+  enable_passive_checks = true
+
+  // Freshness window: the timer is expected to fire well inside this.
+  // Tune alongside the OnCalendar= in the systemd timer unit.
+  check_interval = 90m
+  retry_interval = 15m
+  max_check_attempts = 1
+
+  vars.dummy_state = 2
+  vars.dummy_text = "stale: no engineering-loop daemon result within the freshness window (timer stopped?)"
+
+  assign where host.name == "noc"
+}

--- a/docs/agentic-development-loop.md
+++ b/docs/agentic-development-loop.md
@@ -906,6 +906,40 @@ Phase 23 (v2 Phase E) adds intake and the label-gated triage inbox:
   explicit operator action, never implicit); `/loop triage` in Pi shows
   the queue.
 
+Phase 24 (v2 Phase F) adds the operations lane — scheduled, budgeted,
+one-item-at-a-time autonomy that still ends at a draft PR:
+
+- `hyrule-engineering-loop daemon --once` runs one cycle: acquire the run
+  lock, check the per-day budget ledger, pick the highest-scored
+  `loop:approved` issue, run the full graph, and either publish a **draft
+  PR** (clean run — the human pre-authorized the work by applying the
+  label; merge stays human-gated) or leave a journaled failure for triage,
+  then exit;
+- safety rails (`src/hyrule_engineering_loop/daemon.py`): a pid run lock
+  with stale-lock detection (one cycle at a time); per-run budgets
+  (iterations, wall-clock, cost) flowed into the backend, plus a per-day
+  ledger (runs + cost); and the no-progress kill criterion — an unchanged
+  worktree diff across `STALL_ROUND_LIMIT` (3) consecutive remediation
+  rounds aborts to human sign-off, so a backend that cannot make progress
+  stops even when the harness reports no cost;
+- **the backend never runs on a CI runner**: the daemon refuses outright
+  when `GITHUB_ACTIONS` is set, and the systemd unit carries
+  `ConditionEnvironment=!GITHUB_ACTIONS`;
+- observability: a one-line Discord run summary
+  (`HYRULE_DISCORD_WEBHOOK`) and an Icinga passive check result
+  (`HYRULE_ICINGA_*` → service `noc!engineering-loop`); the Icinga service
+  (`configs/mon/icinga2/services/engineering-loop.conf`) keeps active
+  `dummy` freshness checks enabled, so when the timer stops firing the
+  passive result goes stale and the check alerts CRIT;
+- scheduling: `configs/loop/hyrule-engineering-loop.{service,timer}`
+  (oneshot + hourly timer) on an operator machine first; a dedicated
+  `loop` VM later goes through the standard `docs/network-flows.md` +
+  firewall + monitoring onboarding three-steps.
+
+Autonomy stays PR-only end to end: the loop picks, builds, verifies, and
+opens draft PRs; every merge and every production apply remains a human
+action.
+
 From Pi, use the global extension command:
 
 ```text

--- a/src/hyrule_engineering_loop/cli.py
+++ b/src/hyrule_engineering_loop/cli.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from langgraph.checkpoint.memory import MemorySaver
 
 from hyrule_engineering_loop.canary import CanaryDryRunError, run_sibling_repo_canary
+from hyrule_engineering_loop.daemon import DaemonConfig, daemon_once
 from hyrule_engineering_loop.feature import (
     FeatureIntakeError,
     FeaturePreflightError,
@@ -453,6 +454,31 @@ def backend_canary_command(args: argparse.Namespace) -> int:
 DEFAULT_INTAKE_REPO = "AS215932/network-operations"
 
 
+def daemon_command(args: argparse.Namespace) -> int:
+    """Run one budgeted operations-lane cycle."""
+    if not args.once:
+        print("[CLI] daemon currently supports only --once (timer-driven scheduling)")
+        return 2
+    config = DaemonConfig(
+        repos=tuple(args.repo) if args.repo else DaemonConfig.repos,
+        workspace_root=Path(args.workspace_root).expanduser()
+        if args.workspace_root
+        else DaemonConfig.workspace_root,
+        output_root=Path(args.output_root).expanduser()
+        if args.output_root
+        else DaemonConfig.output_root,
+        state_dir=Path(args.state_dir_path).expanduser()
+        if args.state_dir_path
+        else DaemonConfig.state_dir,
+        memory_dir=args.memory_dir,
+        max_runs_per_day=args.max_runs_per_day,
+        max_cost_usd_per_day=args.max_cost_usd_per_day,
+    )
+    report = daemon_once(config, client=GhCli())
+    print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+    return 0 if report.outcome not in {"error", "refused_ci"} else 1
+
+
 def intake_scan_command(args: argparse.Namespace) -> int:
     client = GhCli()
     signals, skipped = mine_all_signals(repo=args.repo, client=client)
@@ -766,6 +792,22 @@ def build_parser() -> argparse.ArgumentParser:
     feature_parser.add_argument("--dry-live", action="store_true")
     feature_parser.add_argument("--gate-command", nargs=argparse.REMAINDER)
     feature_parser.set_defaults(func=feature_command)
+
+    daemon_parser = subparsers.add_parser(
+        "daemon",
+        help="run one budgeted operations-lane cycle over the loop:approved queue",
+    )
+    daemon_parser.add_argument("--once", action="store_true", required=True)
+    daemon_parser.add_argument("--repo", action="append")
+    daemon_parser.add_argument("--workspace-root")
+    daemon_parser.add_argument("--output-root")
+    daemon_parser.add_argument("--state-dir-path", dest="state_dir_path")
+    daemon_parser.add_argument("--memory-dir")
+    daemon_parser.add_argument("--max-runs-per-day", type=int, default=DaemonConfig.max_runs_per_day)
+    daemon_parser.add_argument(
+        "--max-cost-usd-per-day", type=float, default=DaemonConfig.max_cost_usd_per_day
+    )
+    daemon_parser.set_defaults(func=daemon_command)
 
     intake_parser = subparsers.add_parser("intake", help="signal mining and triage inbox")
     intake_subparsers = intake_parser.add_subparsers(dest="intake_command", required=True)

--- a/src/hyrule_engineering_loop/daemon.py
+++ b/src/hyrule_engineering_loop/daemon.py
@@ -1,0 +1,472 @@
+"""Operations lane — scheduled, budgeted, one-item-at-a-time autonomy.
+
+Phase F of the v2 architecture (``docs/engineering-loop/v2-architecture.md``
+§9). ``daemon_once`` runs one cycle: acquire the run lock, check the per-day
+budget ledger, pick exactly one ``loop:approved`` issue (highest triage
+score), run the full graph, and either publish a **draft PR** (clean run —
+the human pre-authorized the work by applying the label; merge stays
+human-gated) or leave a journaled failure for triage. Every cycle reports a
+one-line summary to Discord and a passive check result to Icinga, then
+exits.
+
+Hard rules: one run at a time (pid lock with stale detection); per-run and
+per-day budgets; the backend never executes on a CI runner — the daemon
+refuses outright when ``GITHUB_ACTIONS`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+from base64 import b64encode
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, TypeAlias
+
+from hyrule_engineering_loop.feature import run_feature_intake
+from hyrule_engineering_loop.intake import (
+    APPROVED_LABEL,
+    GhClient,
+    IntakeItem,
+    list_issues_with_label,
+)
+from hyrule_engineering_loop.pr import publish_promoted_worktrees
+from hyrule_engineering_loop.state import ChangeClass, RiskLevel
+
+Poster: TypeAlias = Callable[[str, dict[str, Any]], None]
+FeatureRunner: TypeAlias = Callable[..., dict[str, Any]]
+Publisher: TypeAlias = Callable[..., list[dict[str, Any]]]
+
+DEFAULT_LOCK_MAX_AGE_SECONDS = 2 * 60 * 60
+
+LABEL_CHANGE_CLASSES: dict[str, ChangeClass] = {
+    "bug": "app_bugfix",
+    "firewall": "firewall_policy",
+    "bgp": "routing_bgp_frr",
+    "ospf": "routing_bgp_frr",
+    "dns": "dns",
+    "monitoring": "monitoring_logging",
+    "ansible": "infra_ansible",
+}
+HIGH_RISK_LABELS = frozenset({"critical", "security"})
+
+
+class DaemonError(RuntimeError):
+    """Raised when a daemon cycle cannot run at all."""
+
+
+@dataclass(frozen=True)
+class DaemonConfig:
+    """One-cycle configuration; everything has an env-overridable default."""
+
+    repos: tuple[str, ...] = ("AS215932/network-operations",)
+    workspace_root: Path = Path("/home/svag/Dev")
+    output_root: Path = Path("/tmp/hyrule-loop-daemon")
+    state_dir: Path = Path(".engineering-loop-state/daemon")
+    memory_dir: str | None = None
+    allowed_paths: tuple[str, ...] = ("docs",)
+    remote: str = "origin"
+    max_runs_per_day: int = 6
+    max_cost_usd_per_day: float = 25.0
+    max_iterations_per_run: int = 20
+    max_wall_clock_minutes_per_run: int = 45
+    max_cost_usd_per_run: float = 5.0
+    lock_max_age_seconds: int = DEFAULT_LOCK_MAX_AGE_SECONDS
+
+
+@dataclass
+class DaemonReport:
+    """Outcome of one daemon cycle."""
+
+    outcome: str
+    detail: str = ""
+    issue: dict[str, Any] | None = None
+    change_id: str | None = None
+    state_path: str | None = None
+    pr_url: str | None = None
+    journal_path: str | None = None
+    cost_usd: float = 0.0
+    wall_clock_seconds: float = 0.0
+    notifications: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome,
+            "detail": self.detail,
+            "issue": self.issue,
+            "change_id": self.change_id,
+            "state_path": self.state_path,
+            "pr_url": self.pr_url,
+            "journal_path": self.journal_path,
+            "cost_usd": round(self.cost_usd, 4),
+            "wall_clock_seconds": round(self.wall_clock_seconds, 1),
+            "notifications": self.notifications,
+        }
+
+
+# --- lock ---------------------------------------------------------------
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def acquire_lock(state_dir: Path, *, max_age_seconds: int) -> Path | None:
+    """Take the run lock; return None when another live run holds it."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = state_dir / "daemon.lock"
+    if lock_path.exists():
+        try:
+            holder = json.loads(lock_path.read_text(encoding="utf-8"))
+            pid = int(holder.get("pid", -1))
+            started = float(holder.get("started_at", 0.0))
+        except (json.JSONDecodeError, ValueError):
+            pid, started = -1, 0.0
+        fresh = (time.time() - started) < max_age_seconds
+        if pid > 0 and fresh and _pid_alive(pid):
+            return None
+        # Stale lock: holder is dead or too old — break it.
+        lock_path.unlink(missing_ok=True)
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "started_at": time.time()}),
+        encoding="utf-8",
+    )
+    return lock_path
+
+
+def release_lock(lock_path: Path | None) -> None:
+    if lock_path is not None:
+        lock_path.unlink(missing_ok=True)
+
+
+# --- per-day ledger -------------------------------------------------------
+
+
+def _ledger_path(state_dir: Path, day: str) -> Path:
+    return state_dir / f"ledger-{day}.json"
+
+
+def load_ledger(state_dir: Path, day: str) -> dict[str, Any]:
+    path = _ledger_path(state_dir, day)
+    if not path.exists():
+        return {"runs": 0, "cost_usd": 0.0, "wall_clock_seconds": 0.0}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else {}
+    except json.JSONDecodeError:
+        return {"runs": 0, "cost_usd": 0.0, "wall_clock_seconds": 0.0}
+
+
+def update_ledger(
+    state_dir: Path, day: str, *, cost_usd: float, wall_clock_seconds: float
+) -> dict[str, Any]:
+    ledger = load_ledger(state_dir, day)
+    ledger["runs"] = int(ledger.get("runs", 0)) + 1
+    ledger["cost_usd"] = float(ledger.get("cost_usd", 0.0)) + cost_usd
+    ledger["wall_clock_seconds"] = (
+        float(ledger.get("wall_clock_seconds", 0.0)) + wall_clock_seconds
+    )
+    state_dir.mkdir(parents=True, exist_ok=True)
+    _ledger_path(state_dir, day).write_text(
+        json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return ledger
+
+
+# --- reporting ------------------------------------------------------------
+
+
+def _default_http_post(url: str, payload: dict[str, Any]) -> None:
+    headers = {"Content-Type": "application/json"}
+    auth = payload.pop("_basic_auth", None)
+    if isinstance(auth, str):
+        headers["Authorization"] = f"Basic {auth}"
+    headers.update(payload.pop("_headers", {}))
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=20):
+        pass
+
+
+def notify_discord(report: DaemonReport, *, poster: Poster | None = None) -> bool:
+    """One-line run summary to the configured Discord webhook."""
+    webhook = os.environ.get("HYRULE_DISCORD_WEBHOOK")
+    if not webhook:
+        return False
+    parts = [f"engineering-loop: {report.outcome}"]
+    if report.change_id:
+        parts.append(report.change_id)
+    if report.pr_url:
+        parts.append(report.pr_url)
+    if report.detail:
+        parts.append(report.detail)
+    parts.append(f"cost=${report.cost_usd:.2f} wall={int(report.wall_clock_seconds)}s")
+    (poster or _default_http_post)(webhook, {"content": " | ".join(parts)})
+    return True
+
+
+ICINGA_EXIT_STATUS: dict[str, int] = {
+    "published": 0,
+    "idle": 0,
+    "needs_triage": 1,
+    "over_budget": 1,
+    "locked": 0,
+    "refused_ci": 2,
+    "error": 2,
+}
+
+
+def notify_icinga(report: DaemonReport, *, poster: Poster | None = None) -> bool:
+    """Submit a passive check result; freshness alerting is Icinga-side config."""
+    url = os.environ.get("HYRULE_ICINGA_URL")
+    user = os.environ.get("HYRULE_ICINGA_USER")
+    password = os.environ.get("HYRULE_ICINGA_PASSWORD")
+    check = os.environ.get("HYRULE_ICINGA_CHECK", "noc!engineering-loop")
+    if not url or not user or not password:
+        return False
+    payload: dict[str, Any] = {
+        "type": "Service",
+        "filter": f'service.__name=="{check}"',
+        "exit_status": ICINGA_EXIT_STATUS.get(report.outcome, 2),
+        "plugin_output": (
+            f"loop {report.outcome}"
+            + (f": {report.change_id}" if report.change_id else "")
+            + (f" ({report.detail})" if report.detail else "")
+        ),
+        "_basic_auth": b64encode(f"{user}:{password}".encode()).decode(),
+        "_headers": {"Accept": "application/json"},
+    }
+    (poster or _default_http_post)(
+        f"{url.rstrip('/')}/v1/actions/process-check-result", payload
+    )
+    return True
+
+
+# --- issue -> run mapping ---------------------------------------------------
+
+
+def classify_issue(item: IntakeItem) -> tuple[ChangeClass, RiskLevel]:
+    """Map issue labels onto a change class and risk level."""
+    change_class: ChangeClass = "app_feature"
+    for label in item.labels:
+        mapped = LABEL_CHANGE_CLASSES.get(label.lower())
+        if mapped is not None:
+            change_class = mapped
+            break
+    risk: RiskLevel = (
+        "high" if any(label.lower() in HIGH_RISK_LABELS for label in item.labels) else "low"
+    )
+    return change_class, risk
+
+
+def repo_name_for_issue(item: IntakeItem) -> str:
+    """Map a GitHub repo onto the sibling checkout directory name."""
+    short = item.repo.rsplit("/", 1)[-1]
+    if short == "network-operations":
+        return "hyrule-infra"
+    return short
+
+
+def _issue_body(item: IntakeItem, *, client: GhClient) -> str:
+    raw = client.run(
+        ["issue", "view", str(item.number), "--repo", item.repo, "--json", "body"]
+    )
+    try:
+        decoded = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return ""
+    return str(decoded.get("body", "")) if isinstance(decoded, dict) else ""
+
+
+def _change_id_for(item: IntakeItem) -> str:
+    repo_slug = item.repo.rsplit("/", 1)[-1].upper().replace("-", "_")
+    return f"ISSUE_{repo_slug}_{item.number}"
+
+
+def _run_cost(final_state: dict[str, Any]) -> float:
+    return sum(
+        float(run.get("cost", {}).get("usd") or 0.0)
+        for run in final_state.get("backend_results", [])
+        if isinstance(run, dict)
+    )
+
+
+# --- the cycle --------------------------------------------------------------
+
+
+def daemon_once(
+    config: DaemonConfig,
+    *,
+    client: GhClient,
+    feature_runner: FeatureRunner | None = None,
+    publisher: Publisher | None = None,
+    discord_poster: Poster | None = None,
+    icinga_poster: Poster | None = None,
+) -> DaemonReport:
+    """Run one autonomous cycle: pick one approved item, run, publish or journal."""
+    started = time.monotonic()
+    if os.environ.get("GITHUB_ACTIONS"):
+        return _finish(
+            DaemonReport(
+                outcome="refused_ci",
+                detail="backend execution never runs on a CI runner",
+            ),
+            discord_poster,
+            icinga_poster,
+        )
+
+    state_dir = config.state_dir.expanduser().resolve()
+    lock_path = acquire_lock(state_dir, max_age_seconds=config.lock_max_age_seconds)
+    if lock_path is None:
+        # Deliberately no notifications: a held lock means another cycle is
+        # already reporting; double-reporting would mask real staleness.
+        return DaemonReport(outcome="locked", detail="another run holds the lock")
+
+    try:
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        ledger = load_ledger(state_dir, day)
+        if int(ledger.get("runs", 0)) >= config.max_runs_per_day:
+            return _finish(
+                DaemonReport(
+                    outcome="over_budget",
+                    detail=f"daily run budget reached ({config.max_runs_per_day})",
+                ),
+                discord_poster,
+                icinga_poster,
+            )
+        if float(ledger.get("cost_usd", 0.0)) >= config.max_cost_usd_per_day:
+            return _finish(
+                DaemonReport(
+                    outcome="over_budget",
+                    detail=f"daily cost budget reached (${config.max_cost_usd_per_day:.2f})",
+                ),
+                discord_poster,
+                icinga_poster,
+            )
+
+        queue = list_issues_with_label(list(config.repos), APPROVED_LABEL, client=client)
+        if not queue:
+            return _finish(
+                DaemonReport(outcome="idle", detail="approved queue is empty"),
+                discord_poster,
+                icinga_poster,
+            )
+        item = queue[0]
+        change_class, risk = classify_issue(item)
+        change_id = _change_id_for(item)
+        body = _issue_body(item, client=client)
+
+        output_root = config.output_root.expanduser().resolve() / change_id.lower()
+        output_root.mkdir(parents=True, exist_ok=True)
+        request_path = output_root / "request.md"
+        request_path.write_text(
+            f"# {item.title}\n\n"
+            f"- source issue: {item.url}\n"
+            f"- labels: {', '.join(item.labels)}\n\n"
+            f"{body}\n",
+            encoding="utf-8",
+        )
+
+        runner = feature_runner or run_feature_intake
+        result = runner(
+            change_id=change_id,
+            change_class=change_class,
+            workspace_root=config.workspace_root,
+            output_root=output_root,
+            repo_name=repo_name_for_issue(item),
+            request_path=request_path,
+            allowed_paths=list(config.allowed_paths),
+            source_files=["README.md"],
+            memory_dir=config.memory_dir,
+            backend_budget={
+                "max_iterations": config.max_iterations_per_run,
+                "max_wall_clock_minutes": config.max_wall_clock_minutes_per_run,
+                "max_cost_usd": config.max_cost_usd_per_run,
+            },
+        )
+        final_state = dict(result.get("final_state", {}))
+        final_state["risk_level"] = final_state.get("risk_level", risk)
+        cost = _run_cost(final_state)
+        report = DaemonReport(
+            outcome="needs_triage",
+            issue={"repo": item.repo, "number": item.number, "title": item.title},
+            change_id=change_id,
+            state_path=str(result.get("state_path")),
+            cost_usd=cost,
+            journal_path=(final_state.get("reflection_results") or {}).get("journal_path"),
+        )
+
+        if result.get("signoff_status") == "ready_for_review" and final_state.get(
+            "promotion_results"
+        ):
+            # The human pre-authorized this work by applying loop:approved;
+            # publication still ends at a DRAFT PR — merge stays human.
+            publish_state = {
+                **final_state,
+                "approval_decision": "approved",
+                "requires_human_signoff": False,
+            }
+            publish = publisher or publish_promoted_worktrees
+            pr_results = publish(
+                publish_state,
+                remote=config.remote,
+                commit_message=f"{change_id}: {item.title}",
+                pr_title=item.title,
+                pr_body=f"Closes {item.url}",
+                pr_labels=[],
+                pr_reviewers=[],
+                create_github_pr=True,
+            )
+            report.outcome = "published"
+            github = pr_results[0].get("github_pr", {}) if pr_results else {}
+            report.pr_url = github.get("url") if isinstance(github, dict) else None
+            report.detail = f"draft PR from {item.repo}#{item.number}"
+        else:
+            failure = result.get("failure_summary") or {}
+            report.detail = str(
+                failure.get("error_excerpt", "run paused for operator triage")
+            )[:200]
+
+        report.wall_clock_seconds = time.monotonic() - started
+        update_ledger(
+            state_dir,
+            day,
+            cost_usd=report.cost_usd,
+            wall_clock_seconds=report.wall_clock_seconds,
+        )
+        return _finish(report, discord_poster, icinga_poster)
+    except Exception as exc:
+        report = DaemonReport(outcome="error", detail=str(exc)[:300])
+        report.wall_clock_seconds = time.monotonic() - started
+        return _finish(report, discord_poster, icinga_poster)
+    finally:
+        release_lock(lock_path)
+
+
+def _finish(
+    report: DaemonReport,
+    discord_poster: Poster | None,
+    icinga_poster: Poster | None,
+) -> DaemonReport:
+    try:
+        if notify_discord(report, poster=discord_poster):
+            report.notifications.append("discord")
+    except Exception as exc:
+        report.notifications.append(f"discord_failed: {exc}")
+    try:
+        if notify_icinga(report, poster=icinga_poster):
+            report.notifications.append("icinga")
+    except Exception as exc:
+        report.notifications.append(f"icinga_failed: {exc}")
+    return report

--- a/src/hyrule_engineering_loop/feature.py
+++ b/src/hyrule_engineering_loop/feature.py
@@ -200,6 +200,7 @@ def build_feature_state(
     dry_live_mode: bool = False,
     task_spec_path: Path | None = None,
     memory_dir: str | None = None,
+    backend_budget: dict[str, Any] | None = None,
 ) -> GraphState:
     """Build a graph state from operator-friendly feature-intake arguments."""
     workspace_root = workspace_root.expanduser().resolve()
@@ -266,6 +267,8 @@ def build_feature_state(
         state["task_spec"] = supplied_spec
     if memory_dir is not None:
         state["memory_dir"] = memory_dir
+    if backend_budget is not None:
+        state["backend_budget"] = dict(backend_budget)
     if model_policy_file is not None:
         state["model_policy_file"] = model_policy_file
     return state
@@ -338,6 +341,7 @@ def run_feature_intake(
     live_mode: bool = False,
     task_spec: Path | None = None,
     memory_dir: str | None = None,
+    backend_budget: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run the graph from a human-authored feature request."""
     state = build_feature_state(
@@ -358,6 +362,7 @@ def run_feature_intake(
         live_mode=live_mode,
         task_spec_path=task_spec,
         memory_dir=memory_dir,
+        backend_budget=backend_budget,
     )
     if live_mode:
         preflight = preflight_feature_state(state, output_root=output_root, live=True)

--- a/src/hyrule_engineering_loop/graph.py
+++ b/src/hyrule_engineering_loop/graph.py
@@ -122,8 +122,8 @@ def pre_gate_policy_router(state: GraphState) -> Route:
 
 
 def delegate_router(state: GraphState) -> Route:
-    """Route backend outcome onward; budget exhaustion and spec refusal stop."""
-    if state.get("implementation_writer_status") in {"budget_exhausted", "refused"}:
+    """Route backend outcome onward; budget/spec/stall failures stop the run."""
+    if state.get("implementation_writer_status") in {"budget_exhausted", "refused", "stalled"}:
         return "human_signoff"
     return "gate_execution"
 

--- a/src/hyrule_engineering_loop/nodes.py
+++ b/src/hyrule_engineering_loop/nodes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any, Iterable, cast
@@ -58,6 +59,10 @@ from hyrule_engineering_loop.trace import trace_event, with_trace, write_loop_tr
 from hyrule_engineering_loop.workspace import cleanup_workspace
 
 StateUpdate = dict[str, Any]
+
+# Abort a run after this many consecutive remediation rounds with an
+# unchanged worktree diff (the Phase F no-progress kill criterion).
+STALL_ROUND_LIMIT = 3
 
 ALL_ROLES: tuple[RoleName, ...] = (
     "network_architect",
@@ -650,6 +655,8 @@ def delegate_implementation_node(state: GraphState) -> StateUpdate:
     all_operations = [*state.get("proposed_mutation_operations", []), *new_operations]
     backend_runs: list[dict[str, Any]] = []
     changed_paths: list[str] = []
+    run_diffs: list[str] = []
+    has_worktree_run = False
     requires_signoff = False
 
     if writer_status != "failed":
@@ -657,6 +664,7 @@ def delegate_implementation_node(state: GraphState) -> StateUpdate:
         constraints = constraints_from_state(state)
         worktrees = state.get("worktree_results") or []
         if worktrees:
+            has_worktree_run = True
             for worktree in worktrees:
                 repo = str(worktree.get("repo", ""))
                 backend = create_backend(
@@ -673,6 +681,7 @@ def delegate_implementation_node(state: GraphState) -> StateUpdate:
                 )
                 backend_runs.append({"repo": repo, **result.as_dict()})
                 changed_paths.extend(result.changed_paths)
+                run_diffs.append(f"{repo}\n{result.diff}")
                 if result.status == "budget_exhausted":
                     writer_status = "budget_exhausted"
                     requires_signoff = True
@@ -736,6 +745,35 @@ def delegate_implementation_node(state: GraphState) -> StateUpdate:
                 }
             )
             retry_key = retry_key or "backend"
+
+    # Kill criterion (Phase F): if the backend produces a diff byte-identical
+    # to the previous remediation round's, count a no-progress round. After
+    # STALL_ROUND_LIMIT consecutive unchanged rounds the run aborts to human
+    # sign-off — this catches a backend that cannot make progress even when
+    # the harness reports no cost (iteration/wall-clock budgets alone would
+    # let it spin). Only worktree runs carry a meaningful diff.
+    if has_worktree_run and writer_status not in {"failed", "budget_exhausted"}:
+        fingerprint = hashlib.sha256("\n".join(sorted(run_diffs)).encode()).hexdigest()
+        prior_fingerprint = state.get("last_diff_fingerprint")
+        if prior_fingerprint is not None and fingerprint == prior_fingerprint:
+            stall_rounds = int(state.get("stall_rounds", 0)) + 1
+        else:
+            stall_rounds = 0
+        update["last_diff_fingerprint"] = fingerprint
+        update["stall_rounds"] = stall_rounds
+        if stall_rounds >= STALL_ROUND_LIMIT:
+            writer_status = "stalled"
+            requires_signoff = True
+            errors.append(
+                {
+                    "node": "delegate_implementation",
+                    "domain": "devops",
+                    "message": (
+                        f"backend made no diff progress across {stall_rounds} consecutive "
+                        "remediation rounds; aborting to human sign-off"
+                    ),
+                }
+            )
 
     update["implementation_writer_status"] = writer_status
     if requires_signoff:

--- a/src/hyrule_engineering_loop/state.py
+++ b/src/hyrule_engineering_loop/state.py
@@ -165,6 +165,8 @@ class GraphState(TypedDict):
     memory_dir: NotRequired[str]
     memory_context: NotRequired[Dict[str, Any]]
     reflection_results: NotRequired[Dict[str, Any]]
+    last_diff_fingerprint: NotRequired[str]
+    stall_rounds: NotRequired[int]
     diff_preview: NotRequired[Annotated[List[Dict[str, Any]], operator.add]]
     trace_events: NotRequired[Annotated[List[Dict[str, Any]], operator.add]]
     loop_trace_path: NotRequired[str]

--- a/tests/test_phase24_daemon.py
+++ b/tests/test_phase24_daemon.py
@@ -1,0 +1,368 @@
+"""Phase F (v2): the budgeted, locked, observable operations lane."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from hyrule_engineering_loop.daemon import (
+    DaemonConfig,
+    DaemonReport,
+    acquire_lock,
+    classify_issue,
+    daemon_once,
+    notify_discord,
+    notify_icinga,
+)
+from hyrule_engineering_loop.intake import IntakeItem
+from hyrule_engineering_loop.nodes import STALL_ROUND_LIMIT, delegate_implementation_node
+from hyrule_engineering_loop.promotion import rollback_promotions, setup_worktrees_for_state
+from hyrule_engineering_loop.state import GraphState
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    completed = subprocess.run(command, cwd=cwd, capture_output=True, check=False, text=True)
+    assert completed.returncode == 0, completed.stderr
+
+
+def _init_repo(path: Path, *, remote: Path | None = None) -> None:
+    path.mkdir(parents=True)
+    _run(["git", "init"], path)
+    _run(["git", "config", "user.email", "loop@example.invalid"], path)
+    _run(["git", "config", "user.name", "Engineering Loop"], path)
+    (path / "README.md").write_text(f"{path.name}\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], path)
+    _run(["git", "commit", "-m", "initial"], path)
+    if remote is not None:
+        _run(["git", "init", "--bare", str(remote)], path)
+        _run(["git", "remote", "add", "origin", str(remote)], path)
+
+
+class FakeGh:
+    """Records gh calls; serves canned JSON by command prefix."""
+
+    def __init__(self, responses: dict[str, str]) -> None:
+        self.calls: list[list[str]] = []
+        self.responses = responses
+
+    def run(self, args: list[str]) -> str:
+        self.calls.append(list(args))
+        key = " ".join(args[:2])
+        return self.responses.get(key, "[]")
+
+
+def _approved_issue_json(number: int, *, repo: str, labels: list[str]) -> str:
+    return json.dumps(
+        [
+            {
+                "number": number,
+                "title": "Add a docs note",
+                "body": "## Context\nx\n## Action items\n1. y\n## Related\n- z",
+                "labels": [{"name": name} for name in labels],
+                "url": f"https://github.com/{repo}/issues/{number}",
+                "updatedAt": "2026-06-12T00:00:00Z",
+            }
+        ]
+    )
+
+
+# --- AC1: run lock ----------------------------------------------------------
+
+
+def test_second_invocation_exits_immediately_on_the_lock(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    # A live, fresh lock held by this very process.
+    held = acquire_lock(state_dir, max_age_seconds=3600)
+    assert held is not None
+
+    config = DaemonConfig(state_dir=state_dir, output_root=tmp_path / "out")
+    gh = FakeGh({"issue list": "[]"})
+    report = daemon_once(config, client=gh)
+
+    assert report.outcome == "locked"
+    # Locked cycle does not even query the queue, and stays silent.
+    assert gh.calls == []
+    assert report.notifications == []
+
+
+def test_stale_lock_is_broken(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "daemon.lock").write_text(
+        json.dumps({"pid": 999_999_999, "started_at": 0.0}), encoding="utf-8"
+    )
+    lock = acquire_lock(state_dir, max_age_seconds=3600)
+    assert lock is not None  # dead-pid lock was broken and re-taken
+
+
+# --- AC: CI-runner refusal --------------------------------------------------
+
+
+def test_daemon_refuses_to_run_on_ci(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    config = DaemonConfig(state_dir=tmp_path / "state")
+    report = daemon_once(config, client=FakeGh({}))
+    assert report.outcome == "refused_ci"
+
+
+# --- AC4: end-to-end seeded issue -> draft PR, no human input --------------
+
+
+def test_seeded_approved_issue_becomes_draft_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _init_repo(workspace / "hyrule-cloud", remote=tmp_path / "hyrule-cloud.git")
+    repo = "AS215932/hyrule-cloud"
+
+    gh = FakeGh(
+        {
+            "issue list": _approved_issue_json(241, repo=repo, labels=["loop:approved", "monitoring"]),
+            "issue view": json.dumps({"body": "## Context\nAdd a docs note.\n"}),
+        }
+    )
+    monkeypatch.setenv("HYRULE_MOCK_GITHUB_PR_URL", "https://github.invalid/pr/1")
+
+    discord: list[dict[str, Any]] = []
+    icinga: list[dict[str, Any]] = []
+    monkeypatch.setenv("HYRULE_DISCORD_WEBHOOK", "https://discord.invalid/webhook")
+    monkeypatch.setenv("HYRULE_ICINGA_URL", "https://mon.invalid:5665")
+    monkeypatch.setenv("HYRULE_ICINGA_USER", "loop")
+    monkeypatch.setenv("HYRULE_ICINGA_PASSWORD", "x")
+
+    config = DaemonConfig(
+        repos=(repo,),
+        workspace_root=workspace,
+        output_root=tmp_path / "runs",
+        state_dir=tmp_path / "state",
+        memory_dir=str(tmp_path / "memory"),
+    )
+
+    report = daemon_once(
+        config,
+        client=gh,
+        discord_poster=lambda url, payload: discord.append(payload),
+        icinga_poster=lambda url, payload: icinga.append(payload),
+    )
+
+    # No human input between "timer fire" (daemon_once) and the draft PR.
+    assert report.outcome == "published"
+    assert report.pr_url == "https://github.invalid/pr/1"
+    assert report.change_id == "ISSUE_HYRULE_CLOUD_241"
+
+    # The branch was really pushed to the bare remote.
+    branches = subprocess.run(
+        ["git", "branch", "-a"],
+        cwd=tmp_path / "hyrule-cloud.git",
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "hyrule-feature/" in branches
+
+    # Reporting fired on both channels.
+    assert report.notifications == ["discord", "icinga"]
+    assert "published" in discord[0]["content"]
+    assert icinga[0]["exit_status"] == 0
+
+    # The ledger recorded the run.
+    ledger_files = list((tmp_path / "state").glob("ledger-*.json"))
+    assert ledger_files and json.loads(ledger_files[0].read_text())["runs"] == 1
+
+
+def test_idle_queue_reports_idle(tmp_path: Path) -> None:
+    config = DaemonConfig(
+        repos=("AS215932/network-operations",),
+        state_dir=tmp_path / "state",
+        output_root=tmp_path / "out",
+    )
+    report = daemon_once(config, client=FakeGh({"issue list": "[]"}))
+    assert report.outcome == "idle"
+
+
+# --- AC2: per-run budget exhaustion is journaled, next run unaffected -------
+
+
+def _paused_run(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "state_path": str(kwargs["output_root"] / "state" / f"{kwargs['change_id']}.json"),
+        "signoff_status": "needs_operator_triage",
+        "failure_summary": {"error_excerpt": "backend budget exhausted: wall clock"},
+        "final_state": {
+            "backend_results": [{"cost": {"usd": 0.0}}],
+            "reflection_results": {
+                "written": True,
+                "journal_path": str(kwargs["output_root"] / "journal.md"),
+            },
+        },
+    }
+
+
+def _published_run(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "state_path": str(kwargs["output_root"] / "state" / f"{kwargs['change_id']}.json"),
+        "signoff_status": "ready_for_review",
+        "final_state": {
+            "promotion_results": [{"repo": "hyrule-cloud", "branch": "b", "worktree_path": "w"}],
+            "noc_handoff_path": "h",
+            "backend_results": [{"cost": {"usd": 0.0}}],
+            "reflection_results": {"written": True},
+        },
+    }
+
+
+def test_budget_exhaustion_journals_and_next_run_unaffected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = "AS215932/hyrule-cloud"
+    gh = FakeGh(
+        {
+            "issue list": _approved_issue_json(7, repo=repo, labels=["loop:approved"]),
+            "issue view": json.dumps({"body": "## Context\nx\n"}),
+        }
+    )
+    monkeypatch.setenv("HYRULE_DISCORD_WEBHOOK", "https://discord.invalid/webhook")
+    config = DaemonConfig(
+        repos=(repo,),
+        workspace_root=tmp_path / "workspace",
+        output_root=tmp_path / "runs",
+        state_dir=tmp_path / "state",
+    )
+    (tmp_path / "workspace").mkdir()
+
+    discord: list[dict[str, Any]] = []
+    report1 = daemon_once(
+        config,
+        client=gh,
+        feature_runner=_paused_run,
+        discord_poster=lambda url, payload: discord.append(payload),
+    )
+
+    assert report1.outcome == "needs_triage"
+    assert report1.pr_url is None
+    assert "budget exhausted" in report1.detail
+    assert report1.notifications == ["discord"]
+    assert "needs_triage" in discord[0]["content"]
+
+    published: list[dict[str, Any]] = []
+    report2 = daemon_once(
+        config,
+        client=gh,
+        feature_runner=_published_run,
+        publisher=lambda state, **kw: [{"github_pr": {"url": "https://github.invalid/pr/9"}}],
+        discord_poster=lambda url, payload: published.append(payload),
+    )
+
+    assert report2.outcome == "published"
+    assert report2.pr_url == "https://github.invalid/pr/9"
+
+    ledger = json.loads(next((tmp_path / "state").glob("ledger-*.json")).read_text())
+    assert ledger["runs"] == 2
+
+
+def test_daily_run_budget_stops_further_runs(tmp_path: Path) -> None:
+    repo = "AS215932/hyrule-cloud"
+    config = DaemonConfig(
+        repos=(repo,),
+        state_dir=tmp_path / "state",
+        output_root=tmp_path / "out",
+        max_runs_per_day=0,
+    )
+    report = daemon_once(config, client=FakeGh({"issue list": "[]"}))
+    assert report.outcome == "over_budget"
+    assert "run budget" in report.detail
+
+
+# --- kill criterion: stall detection ----------------------------------------
+
+
+def test_unchanged_diff_across_rounds_aborts_to_signoff(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _init_repo(workspace / "hyrule-cloud")
+
+    base: GraphState = cast(
+        GraphState,
+        {
+            "change_id": "STALL_TEST",
+            "change_class": "app_feature",
+            "risk_level": "low",
+            "customer_impact": "none",
+            "source_of_truth_files": ["hyrule-cloud:README.md"],
+            "proposed_mutations": {},
+            "mcp_schema_breaking": False,
+            "emulated_lab_verified": "not_applicable",
+            "validation_errors": [],
+            "role_approvals": {},
+            "retry_counters": {},
+            "rollback_plan": "",
+            "noc_handoff_metadata": {},
+            "requires_human_signoff": False,
+            "promotion_enabled": True,
+            "promotion_repositories": {"hyrule-cloud": str(workspace / "hyrule-cloud")},
+            "promotion_allowed_paths": {"hyrule-cloud": ["docs"]},
+            "promotion_worktree_root": str(tmp_path / "worktrees"),
+            "promotion_branch_prefix": "hyrule-feature",
+            "feature_request": "stall",
+            "llm_mock_responses": {
+                "implementation_writer": {
+                    "approved": True,
+                    "proposed_mutations": [
+                        {
+                            "path": "hyrule-cloud:docs/stall.md",
+                            "content": "# Stall\n",
+                            "operation": "create",
+                        }
+                    ],
+                }
+            },
+        },
+    )
+    worktrees = setup_worktrees_for_state(base)
+    base["worktree_results"] = worktrees
+
+    fingerprint: str | None = None
+    stall_rounds = 0
+    statuses: list[str] = []
+    for _ in range(STALL_ROUND_LIMIT + 1):
+        state = cast(GraphState, dict(base))
+        if fingerprint is not None:
+            state["last_diff_fingerprint"] = fingerprint
+            state["stall_rounds"] = stall_rounds
+        update = delegate_implementation_node(state)
+        statuses.append(update["implementation_writer_status"])
+        fingerprint = update["last_diff_fingerprint"]
+        stall_rounds = update["stall_rounds"]
+
+    # First few rounds proceed; the run aborts once the diff has been
+    # unchanged for STALL_ROUND_LIMIT consecutive rounds.
+    assert statuses[-1] == "stalled"
+    assert statuses[:STALL_ROUND_LIMIT] == ["complete"] * STALL_ROUND_LIMIT
+    rollback_promotions(worktrees)
+
+
+# --- reporting helpers ------------------------------------------------------
+
+
+def test_classify_issue_maps_labels() -> None:
+    item = IntakeItem(
+        repo="r", number=1, title="t", url="u",
+        labels=("firewall", "critical"), updated_at="", score=0.0, body_complete=True,
+    )
+    change_class, risk = classify_issue(item)
+    assert change_class == "firewall_policy"
+    assert risk == "high"
+
+
+def test_notifications_skip_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("HYRULE_DISCORD_WEBHOOK", "HYRULE_ICINGA_URL"):
+        monkeypatch.delenv(key, raising=False)
+    report = DaemonReport(outcome="idle")
+    assert notify_discord(report) is False
+    assert notify_icinga(report) is False


### PR DESCRIPTION
## Intent

The "continuously suggest and build" mode: a scheduled, budgeted, one-item-at-a-time daemon consumes the `loop:approved` queue and ends each cycle at a **draft PR** — with a run lock, hard budgets, a no-progress kill criterion, and Discord + Icinga observability. Autonomy stays PR-only: every merge and apply remains human-gated. Phase F of the v2 refactor (`docs/engineering-loop/v2-architecture.md` §9–§10).

**Stacked on the B–E chain (base `feat/loop-v2-phase-d`)** — review for the Phase F commits only.

## Change class / risk

- Change class: `noc_runtime`-adjacent (unattended operation), risk tier high per the roadmap — but mock-default and PR-only; nothing merges or applies
- Task spec: `docs/engineering-loop/v2-roadmap.md` § F; tracking issue #195

## AI transparency

- Authored by Claude Fable 5 (Claude Code session, operator-reviewed)
- All tests offline against a fake `gh` client, local git repos with bare remotes, and the mocked GitHub-PR URL; no live calls

## Evidence

- [x] AC1 — two concurrent invocations: the second exits immediately on the lock (and stays silent so it can't mask staleness); stale/dead-pid locks are broken (tests)
- [x] AC2 — per-run budget exhaustion produces a draft-PR-less journaled `needs_triage` outcome with a Discord summary, and the next run publishes normally; the ledger records both (test)
- [x] AC3 — the Icinga service (`engineering-loop.conf`) keeps active `dummy` freshness checks enabled alongside passive results, so when the timer stops the check goes stale → CRIT; exit-status mapping unit-tested
- [x] AC4 — end-to-end: a seeded `loop:approved` docs issue becomes a draft PR (branch really pushed to a bare remote, mocked PR URL, both channels notified, ledger entry) with **no human input** between `daemon_once` and the PR (test)
- [x] Kill criterion: unchanged worktree diff across `STALL_ROUND_LIMIT` (3) rounds aborts to human sign-off (test); CI execution refused when `GITHUB_ACTIONS` set (test)
- `pytest`: **155 passed** offline; `mypy --strict src` clean (28 files); `daemon.py` + tests ruff-clean; systemd timer verifies, service verifies modulo the not-yet-installed binary path

## Human focus areas

1. **The auto-publish step** (`daemon.py`, "published" branch) — a clean run sets `approval_decision: approved` *itself* and calls `publish_promoted_worktrees(..., create_github_pr=True)`. The authorization is the human-applied `loop:approved` label, and it still ends at a **draft** PR, but this is the one place the daemon flips the approval flag without an interactive `approve`. Confirm that's the intended contract.
2. **Issue→run mapping** (`classify_issue`, `repo_name_for_issue`, allowed paths default `["docs"]`) — the label→change-class map and the conservative docs-only default are first cuts; widening allowed paths for autonomous runs is a deliberate future decision.
3. **systemd/Icinga cadence coupling** — timer `OnCalendar=hourly` must stay inside the Icinga `check_interval=90m` freshness window; documented in both files.

## Pre-existing (out of scope)

Ruff flags two nits that predate this PR (from the merged Phase C): an unused `RoleName` import in `graph.py` and an `E402` in `llm.py`. `lint.yml` doesn't run ruff so they're invisible to current CI; Phase G stands up `ruff check` on the new repo's CI and is the right place to sweep them.

## Expected production impact

None until deployed and the timer is enabled. Mock-default; the daemon refuses CI; publication is draft-only.

## Rollback plan

Disable the systemd timer (`systemctl disable --now hyrule-engineering-loop.timer`); revert the merge. No state migrations; the per-day ledger and lock are disposable files.

## NOC handoff

- expected alerts: `noc!engineering-loop` goes CRIT (stale) if the timer stops firing — that is the intended signal, not a regression
- affected hosts/services: the operator machine / future `loop` VM only
- rollback trigger: runaway cost or unexpected PR volume → disable the timer
- operator command/workflow: `systemctl disable --now hyrule-engineering-loop.timer`

## Post-deploy checks

`daemon --once` by hand against a seeded `loop:approved` docs issue; confirm a draft PR appears, the Discord summary posts, and `noc!engineering-loop` shows OK; then enable the timer and confirm the freshness check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)