### PR TITLE
Engineering Loop v2 Phase G (1/2): extraction tooling + runbook

### DIFF
--- a/docs/ci/engineering-loop-extraction.md
+++ b/docs/ci/engineering-loop-extraction.md
@@ -1,0 +1,134 @@
+# Engineering Loop extraction runbook (Phase G)
+
+How the Hyrule Engineering Loop moves from `AS215932/network-operations` into
+its own repo, `AS215932/engineering-loop`, with history preserved. This is the
+final phase of the v2 refactor (`docs/engineering-loop/v2-roadmap.md` § G,
+issue #196). It is deliberately operator-gated: the loop's backend executes
+generated code, so the new repo must land on the **unprivileged** runner, and
+the destructive removal from network-operations must not merge until the new
+repo is proven working.
+
+## Why a new repo, why now
+
+Decision of record (design PR #190): v2 ultimately lives in a dedicated repo.
+Extraction goes last because it is cheap once the shape is stable and expensive
+churn mid-refactor. Phases B–F are merged; the shape is stable.
+
+## What moves (history preserved)
+
+`scripts/extract-engineering-loop.sh` keeps exactly these paths, with the full
+history of every commit that touched them:
+
+- `src/hyrule_engineering_loop/`
+- `tests/test_engineering_graph.py`, `tests/test_phase*.py` (NOT `tests/iac/`
+  or `tests/goss/` — those stay)
+- `docs/agent-loops/`, `docs/agentic-development-loop.md`,
+  `docs/engineering-loop/`
+- `skills/`, `integrations/pi/`, `configs/loop/`
+- `model-policy.yml`, `engineering-loop-policy.yml`
+- `pyproject.toml`, `uv.lock`
+
+The extraction tooling itself (`scripts/extract-engineering-loop.sh`,
+`scripts/cutover-remove-loop.sh`, this runbook, `integrations/engineering-loop/`
+scaffolding) **stays** in network-operations for provenance.
+
+> The roadmap says "git subtree split"; the script uses `git filter-repo`
+> instead because the loop spans many top-level paths and a subset of `tests/`,
+> which subtree split cannot select. filter-repo is the modern tool for
+> multi-path history extraction and satisfies AC1 (history preserved).
+
+## Prerequisites
+
+- `git filter-repo` (`uv tool install git-filter-repo`, or `uvx git-filter-repo`
+  works without installing — the script falls back to it).
+- `gh` authenticated to the `AS215932` org with repo-create rights.
+- Org admin access to assign the new repo to a runner group.
+
+## Step 1 — extract and verify locally (safe, repeatable)
+
+```bash
+scripts/extract-engineering-loop.sh \
+  --source /home/svag/Dev/hyrule-infra \
+  --ref <ref-with-the-full-loop> \
+  --target /tmp/engineering-loop-export \
+  --verify
+```
+
+`--verify` runs `pytest` + `mypy --strict` in the extracted tree. Also confirm
+`uvx ruff check src tests` is clean and `git log --follow
+src/hyrule_engineering_loop/graph.py` shows pre-extraction history (AC1).
+Re-run freely — it only ever touches a scratch clone and the target dir.
+
+## Step 2 — create the repo and push (operator, irreversible)
+
+```bash
+gh repo create AS215932/engineering-loop --private \
+  --source /tmp/engineering-loop-export --remote origin
+GIT_SSH_COMMAND="ssh -i ~/.ssh/id_servify -o IdentitiesOnly=yes" \
+  git -C /tmp/engineering-loop-export push -u origin HEAD:main
+```
+
+## Step 3 — runner group and branch protection (AC2)
+
+- Add `engineering-loop` to the **`public-pr`** runner group (label
+  `hyrule-public-pr`). Do **NOT** add it to `hyrule-ci` or the privileged
+  `hyrule`/`hyrule-infra` runner — see `docs/ci/security-model.md`.
+- Protect `main`, requiring the three checks from `.github/workflows/ci.yml`:
+  `ruff`, `mypy`, `pytest`. Confirm the first CI run is green on `ci-pr`.
+
+## Step 4 — repoint the Pi extension (in the new repo)
+
+The Pi extension moved with the extraction. In the new repo, update
+`integrations/pi/extensions/hyrule-loop/`:
+
+- the install/sync instructions reference `AS215932/engineering-loop`;
+- `index.ts` runs `uv run hyrule-engineering-loop` with `cwd` = the
+  engineering-loop checkout (the loop CLI/package now lives there), while the
+  `--memory-dir` and repo-autodetect roots still point at the
+  `network-operations` (a.k.a. `hyrule-infra`) checkout, which is where
+  `memory/` for infra work and the sibling `hyrule-*` repos live. These two
+  roots diverge after extraction — split the single `infraRepo` config field
+  accordingly. Re-sync the installed copy under `~/.pi`.
+
+## Step 5 — sibling-canary from the new repo (AC4)
+
+From the engineering-loop checkout:
+
+```bash
+uv run hyrule-engineering-loop sibling-canary \
+  --workspace-root /home/svag/Dev \
+  --repo-name hyrule-cloud \
+  --output-root /tmp/eng-loop-canary
+```
+
+It must complete end-to-end (repo adapter → policy → promotion → handoff) and
+stop before approval. This proves the loop still drives a sibling repo from its
+new home.
+
+## Step 6 — cut over network-operations (AC3, only after 1–5 pass)
+
+```bash
+scripts/cutover-remove-loop.sh --dry-run   # review what will be removed
+scripts/cutover-remove-loop.sh             # git rm + pointer doc
+cd ansible && ansible-playbook playbooks/firewall.yml --tags validate \
+  --connection=local --skip-tags snapshot   # sanity: render still works
+```
+
+Then commit and open the cutover PR. Confirm network-operations CI stays green
+— `lint.yml` (yamllint/ansible-lint/shellcheck/jinja-syntax), `render-check`,
+and `iac-tests` are all independent of the loop package (nothing in
+network-operations imports `hyrule_engineering_loop`). Merge the cutover PR only
+after the new repo's CI is green and Step 5 passed.
+
+## Step 7 — finalize the inventory
+
+Update `docs/ci/org-cicd-inventory.md`: flip the `engineering-loop` row from
+"pending extraction" to live, with its required checks and `public-pr` runner
+group assignment recorded.
+
+## Rollback
+
+Before Step 6 merges, rollback is trivial — the new repo is additive and
+network-operations is untouched. After Step 6, restoring the loop into
+network-operations means reverting the cutover commit (the code is intact in
+git history); prefer fixing forward in the new repo instead.

--- a/docs/ci/org-cicd-inventory.md
+++ b/docs/ci/org-cicd-inventory.md
@@ -20,6 +20,7 @@ change.
 | `noc-agent` | Python ≥3.14, PydanticAI / langgraph / redis / mcp | none | **Not protected** | No | Sourcery (to remove) | none yet |
 | `hyrule-mcp` | Python ≥3.14, mcp | none | **Not protected** | No | Sourcery (to remove) | none yet |
 | `as215932.net` | Static HTML / CSS + `deploy.sh` | none | **Not protected** | `deploy.sh` (trigger TBD) | Sourcery (to remove) | none yet |
+| `engineering-loop` | Python (uv), LangGraph | `ci.yml` (`ruff`, `mypy`, `pytest`) | **Protected** — required: `ruff`, `mypy`, `pytest` (strict) | No (opens draft PRs only) | claude-for-github | planned |
 
 Notes:
 
@@ -41,6 +42,13 @@ Notes:
 - `noc-agent` and `hyrule-mcp` both require **Python ≥3.14** and currently
   declare **no ruff/mypy**; both ship a `test_live_smoke.py` that needs live
   infrastructure (must be deselected in CI).
+- `engineering-loop` was extracted from `network-operations` (Phase G of the
+  v2 refactor, issue #196) with history preserved; see
+  `docs/ci/engineering-loop-extraction.md`. Its CI runs **only** on the
+  unprivileged `ci-pr` runner (group `public-pr`) — never `hyrule-ci` — because
+  its backend executes generated code; the daemon refuses to run when
+  `GITHUB_ACTIONS` is set. The full suite is offline (mock backend, no API
+  keys). Until the extraction lands this row is **pending**.
 
 ## Runner topology (today)
 
@@ -92,9 +100,12 @@ Code Scanning, free for these public repos.
 - **Two-runner security model**: keep the privileged `ci-runner` (`hyrule`,
   `hyrule-infra`, group `hyrule-ci`) for deploy/apply/Vault/labs only; add a new
   **unprivileged `ci-pr`** runner (label `hyrule-public-pr`, its own `public-pr`
-  runner group permitting all six repos) with no Vault, no `id_ci`, no
-  `secrets.env`, and no management-overlay reachability. All untrusted-PR-code
-  jobs (PR-Agent, Semgrep, lint/test/build/static checks) move to `ci-pr`.
+  runner group permitting all repos — the original six plus `engineering-loop`)
+  with no Vault, no `id_ci`, no `secrets.env`, and no management-overlay
+  reachability. All untrusted-PR-code jobs (PR-Agent, Semgrep,
+  lint/test/build/static checks) move to `ci-pr`. `engineering-loop` is
+  **`ci-pr`-only** by construction — its loop backend runs generated code, so
+  it must never touch the privileged runner.
 - **PR-Agent** replaces Sourcery: advisory, read/comment-only, OpenRouter
   primary `openrouter/deepseek/deepseek-v4-flash`, fallback
   `openrouter/minimax/minimax-m2.7`, pinned `The-PR-Agent/pr-agent` Docker

--- a/integrations/engineering-loop/README.md
+++ b/integrations/engineering-loop/README.md
@@ -1,0 +1,48 @@
+# Hyrule Engineering Loop
+
+Autonomous development loop for the AS215932 (Hyrule / Servify) infrastructure.
+A LangGraph runtime that classifies a change, plans it into a task spec,
+delegates implementation to a real coding-agent backend inside a guarded
+worktree, re-runs gates, has senior-role agents judge the resulting diff,
+learns from every run, and stops at a **draft PR** for human sign-off. Merges
+and production applies are always human-gated.
+
+Extracted from `AS215932/network-operations` (history preserved) once the v2
+refactor stabilized — see that repo's `docs/engineering-loop/` for the design
+spec and roadmap, and `docs/agentic-development-loop.md` here for the runtime.
+
+## Layout
+
+- `src/hyrule_engineering_loop/` — the LangGraph runtime, `AgentBackend`,
+  policy/judgment/memory/intake/daemon modules, and the operator CLI.
+- `tests/` — the phased test suites (`test_engineering_graph.py`,
+  `test_phase*.py`), fully offline (mock backend, no API keys).
+- `skills/` — role, writer, and ISP-procedure skills the loop injects.
+- `docs/agent-loops/`, `docs/agentic-development-loop.md`,
+  `docs/engineering-loop/` — role cards, runtime reference, and v2 design.
+- `integrations/pi/` — the Pi `/loop` extension.
+- `configs/loop/` — systemd service + timer for the operations lane.
+- `model-policy.yml`, `engineering-loop-policy.yml` — model/backend routing
+  and the mutation/publication policy guards.
+
+## Develop
+
+```bash
+uv run --group dev python -m pytest -q
+uv run --group dev mypy --strict src
+uvx ruff check src tests
+```
+
+## Run
+
+```bash
+uv run hyrule-engineering-loop --help
+# one operations-lane cycle over the loop:approved queue:
+uv run hyrule-engineering-loop daemon --once
+```
+
+## Safety
+
+The backend executes generated code. CI runs only on the unprivileged
+`ci-pr` runner (label `hyrule-public-pr`); the daemon refuses to run when
+`GITHUB_ACTIONS` is set. Never schedule it on a privileged runner.

--- a/integrations/engineering-loop/ci.yml
+++ b/integrations/engineering-loop/ci.yml
@@ -1,0 +1,41 @@
+# .github/workflows/ci.yml for AS215932/engineering-loop
+#
+# Runs on the UNPRIVILEGED ci-pr runner (label hyrule-public-pr, runner group
+# public-pr). The loop's backend executes generated code, so this repo must
+# NEVER be added to the privileged hyrule-ci group or the hyrule/hyrule-infra
+# runner. Required checks for branch protection on main: ruff, mypy, pytest.
+---
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    steps:
+      - uses: actions/checkout@v6
+      - name: ruff
+        run: uvx ruff check src tests
+
+  mypy:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    steps:
+      - uses: actions/checkout@v6
+      - name: mypy --strict
+        run: uv run --group dev mypy --strict src
+
+  pytest:
+    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
+    steps:
+      - uses: actions/checkout@v6
+      - name: pytest
+        # HYRULE_MOCK_LLM defaults on; the suite runs fully offline with the
+        # MockBackend and never invokes a real harness binary or provider.
+        run: uv run --group dev python -m pytest -q

--- a/integrations/engineering-loop/gitignore
+++ b/integrations/engineering-loop/gitignore
@@ -1,0 +1,13 @@
+# Stored as `gitignore` (no leading dot) so it is reviewable in
+# network-operations; extract-engineering-loop.sh installs it as `.gitignore`
+# in the new repo.
+__pycache__/
+*.py[cod]
+.venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.engineering-loop-state/
+*.egg-info/
+dist/
+build/

--- a/scripts/cutover-remove-loop.sh
+++ b/scripts/cutover-remove-loop.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# cutover-remove-loop.sh — Phase G cutover: remove the Engineering Loop from
+# network-operations after it has been extracted to AS215932/engineering-loop.
+#
+# DANGER: this deletes ~5k LOC of loop runtime, its tests, docs, skills, the
+# Pi extension, the loop's pyproject/uv.lock, and the policy files. Run it
+# ONLY after the new repo is live, its CI is green, and a sibling-canary run
+# from the new repo has succeeded (docs/ci/engineering-loop-extraction.md).
+# The Pi extension (integrations/pi/) moves WITH the extraction, so this
+# removes it from network-operations; repointing the extension's install
+# path/config to the engineering-loop checkout happens in the new repo (a
+# post-extraction runbook step). It leaves a pointer doc at
+# docs/agentic-development-loop.md. It does NOT commit — review
+# `git status`/`git diff` and commit yourself, then open the cutover PR.
+#
+# Usage: scripts/cutover-remove-loop.sh [--dry-run]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+NEW_REPO="AS215932/engineering-loop"
+
+# Mirror of extract-engineering-loop.sh PATHS, plus the loop test suites.
+REMOVE_PATHS=(
+  src/hyrule_engineering_loop
+  docs/agent-loops
+  docs/engineering-loop
+  skills
+  integrations/pi
+  configs/loop
+  model-policy.yml
+  engineering-loop-policy.yml
+  pyproject.toml
+  uv.lock
+  tests/test_engineering_graph.py
+)
+
+cd "${REPO_ROOT}"
+
+remove() {
+  local target="$1"
+  if [ ! -e "${target}" ]; then
+    echo "   (already absent) ${target}"
+    return
+  fi
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    echo "   would git rm -r ${target}"
+  else
+    git rm -r --quiet "${target}"
+    echo "   removed ${target}"
+  fi
+}
+
+echo ">> removing migrated loop paths"
+for p in "${REMOVE_PATHS[@]}"; do remove "${p}"; done
+
+echo ">> removing loop test suites (tests/test_phase*.py)"
+shopt -s nullglob
+for f in tests/test_phase*.py; do remove "${f}"; done
+shopt -u nullglob
+
+POINTER="docs/agentic-development-loop.md"
+echo ">> writing pointer doc at ${POINTER}"
+if [ "${DRY_RUN}" -eq 1 ]; then
+  echo "   would overwrite ${POINTER} with a pointer to ${NEW_REPO}"
+else
+  cat > "${POINTER}" <<EOF
+# Hyrule Engineering Loop — moved
+
+The Hyrule Engineering Loop now lives in its own repository:
+**[${NEW_REPO}](https://github.com/${NEW_REPO})**.
+
+This includes the LangGraph runtime, the \`AgentBackend\`, the senior-role
+skills, the task-spec / two-phase-review / memory / intake / operations-lane
+machinery, the Pi \`/loop\` extension, and the design docs (\`docs/engineering-loop/\`,
+\`docs/agent-loops/\`, and the runtime reference formerly at this path).
+
+History was preserved via \`git filter-repo\` (Phase G of the v2 refactor; see
+that repo and \`AS215932/network-operations#196\`). The extraction tooling that
+produced it remains here at \`scripts/extract-engineering-loop.sh\` and
+\`docs/ci/engineering-loop-extraction.md\` for provenance.
+
+Nothing in network-operations imports the loop; it operates on this repo (and
+the other \`hyrule-*\` repos) from the outside, opening draft PRs that humans
+review and merge.
+EOF
+  git add "${POINTER}"
+  echo "   wrote ${POINTER}"
+fi
+
+echo
+echo ">> done. Review with: git status && git diff --cached --stat"
+echo "   Then commit and open the cutover PR. Verify network-operations CI"
+echo "   (lint/render/iac-gate) stays green — none of it depends on the loop."

--- a/scripts/extract-engineering-loop.sh
+++ b/scripts/extract-engineering-loop.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# extract-engineering-loop.sh — Phase G of the Engineering Loop v2 refactor.
+#
+# Produces a history-preserving export of the Engineering Loop subtree from
+# network-operations into a standalone working copy, ready to push to
+# AS215932/engineering-loop. The roadmap calls this "git subtree split", but
+# subtree split only handles a single directory prefix; the loop spans many
+# top-level paths (src/, a subset of tests/, several docs/ subtrees, skills/,
+# integrations/pi/, and a few root files), so this uses git-filter-repo, the
+# modern tool for multi-path history extraction. Every commit that touched a
+# kept path is preserved (AC1: history for migrated files survives).
+#
+# This script is non-destructive to the source: it operates on a fresh clone
+# in a temp dir, never on your working checkout. It does NOT create the GitHub
+# repo or push — those are the operator's irreversible steps, see
+# docs/ci/engineering-loop-extraction.md.
+#
+# Usage:
+#   scripts/extract-engineering-loop.sh [--source <path-or-url>] \
+#       [--ref <git-ref>] --target <dir> [--verify]
+#
+#   --source  network-operations checkout or clone URL (default: this repo root)
+#   --ref     ref holding the full loop code (default: the current HEAD)
+#   --target  output directory for the extracted repo (required; must not exist)
+#   --verify  run pytest + mypy --strict in the extracted tree afterwards
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCAFFOLD_DIR="${REPO_ROOT}/integrations/engineering-loop"
+
+SOURCE="${REPO_ROOT}"
+REF="HEAD"
+TARGET=""
+VERIFY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --ref) REF="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --verify) VERIFY=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "${TARGET}" ]; then
+  echo "error: --target <dir> is required" >&2
+  exit 2
+fi
+if [ -e "${TARGET}" ]; then
+  echo "error: target already exists: ${TARGET}" >&2
+  exit 2
+fi
+
+# Paths to migrate, with history. Keep this list in step with the roadmap
+# (docs/engineering-loop/v2-roadmap.md, section G) and the cutover script.
+PATHS=(
+  src/hyrule_engineering_loop
+  docs/agent-loops
+  docs/agentic-development-loop.md
+  docs/engineering-loop
+  skills
+  integrations/pi
+  configs/loop
+  model-policy.yml
+  engineering-loop-policy.yml
+  pyproject.toml
+  uv.lock
+  tests/test_engineering_graph.py
+)
+# The loop test suites are tests/test_phase*.py; everything else under tests/
+# (iac/, goss/) belongs to network-operations and stays behind.
+PATH_GLOBS=(
+  'tests/test_phase*.py'
+)
+
+filter_repo() {
+  if command -v git-filter-repo >/dev/null 2>&1; then
+    git filter-repo "$@"
+  elif command -v uvx >/dev/null 2>&1; then
+    uvx git-filter-repo "$@"
+  else
+    echo "error: git-filter-repo not found (install via 'uv tool install git-filter-repo' or pipx)" >&2
+    exit 3
+  fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+echo ">> cloning ${SOURCE}@${REF} into a scratch clone"
+git clone --no-local --quiet "${SOURCE}" "${WORKDIR}/clone"
+git -C "${WORKDIR}/clone" checkout --quiet --detach "${REF}"
+
+echo ">> filtering to the engineering-loop subtree (history preserved)"
+FILTER_ARGS=()
+for p in "${PATHS[@]}"; do FILTER_ARGS+=(--path "${p}"); done
+for g in "${PATH_GLOBS[@]}"; do FILTER_ARGS+=(--path-glob "${g}"); done
+( cd "${WORKDIR}/clone" && filter_repo "${FILTER_ARGS[@]}" --force )
+
+echo ">> materializing new-repo scaffolding"
+mkdir -p "${WORKDIR}/clone/.github/workflows"
+cp "${SCAFFOLD_DIR}/ci.yml" "${WORKDIR}/clone/.github/workflows/ci.yml"
+cp "${SCAFFOLD_DIR}/README.md" "${WORKDIR}/clone/README.md"
+cp "${SCAFFOLD_DIR}/gitignore" "${WORKDIR}/clone/.gitignore"
+( cd "${WORKDIR}/clone" \
+  && git add .github/workflows/ci.yml README.md .gitignore \
+  && git -c user.name='Engineering Loop' -c user.email='loop@as215932.net' \
+       commit --quiet -m "Add standalone repo CI, README, and gitignore" )
+
+mv "${WORKDIR}/clone" "${TARGET}"
+echo ">> extracted repo ready at: ${TARGET}"
+echo "   commits: $(git -C "${TARGET}" rev-list --count HEAD)"
+
+if [ "${VERIFY}" -eq 1 ]; then
+  echo ">> verifying extracted tree (pytest + mypy --strict)"
+  ( cd "${TARGET}" \
+    && uv run --group dev python -m pytest -q \
+    && uv run --group dev mypy --strict src )
+  echo ">> verification passed"
+fi
+
+cat <<EOF
+
+Next (operator, irreversible — see docs/ci/engineering-loop-extraction.md):
+  gh repo create AS215932/engineering-loop --private --source ${TARGET} --remote origin
+  git -C ${TARGET} push -u origin HEAD:main
+Then add the repo to the 'public-pr' runner group and protect main on the
+ci/ruff/mypy checks. Only after the new repo's CI is green and a sibling-canary
+run succeeds should the network-operations cutover (scripts/cutover-remove-loop.sh)
+be merged.
+EOF

--- a/src/hyrule_engineering_loop/graph.py
+++ b/src/hyrule_engineering_loop/graph.py
@@ -37,7 +37,7 @@ from hyrule_engineering_loop.nodes import (
     workspace_cleanup_node,
     worktree_setup_node,
 )
-from hyrule_engineering_loop.state import GraphState, RoleName
+from hyrule_engineering_loop.state import GraphState
 
 Route = Literal[
     "network_architect",

--- a/src/hyrule_engineering_loop/llm.py
+++ b/src/hyrule_engineering_loop/llm.py
@@ -16,10 +16,10 @@ from typing import Any, Literal, Protocol, TypeVar
 
 from pydantic import BaseModel, Field
 
-ModelT = TypeVar("ModelT", bound=BaseModel)
-
 from hyrule_engineering_loop.model_policy import ModelPolicyNode, ModelSelection, provider_env
 from hyrule_engineering_loop.state import GraphState
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
 class FileMutation(BaseModel):

--- a/src/hyrule_engineering_loop/memory.py
+++ b/src/hyrule_engineering_loop/memory.py
@@ -243,7 +243,7 @@ def render_lesson_proposal(state: GraphState, patterns: list[dict[str, Any]]) ->
         f"# Lesson proposal: {state['change_id']}",
         "",
         f"- generated_at: {datetime.now(UTC).isoformat()}",
-        f"- target lessons file(s): "
+        "- target lessons file(s): "
         + ", ".join(f"memory/lessons/{repo}.md" for repo in repos),
         "",
         "The loop never edits its own rulebook: review, edit, and merge the",

--- a/tests/test_phase23_intake.py
+++ b/tests/test_phase23_intake.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import pytest
 


### PR DESCRIPTION
## Intent

Prepare the extraction of the Engineering Loop into its own repo (`AS215932/engineering-loop`) with history preserved: the extraction script, the new repo's CI/README scaffolding, the operator runbook, and the CI-inventory row. **Additive and safe to merge anytime** — it removes nothing and network-operations CI is unaffected. The destructive cutover is the separate, operator-gated PR 2/2. Phase G of the v2 refactor (`docs/engineering-loop/v2-roadmap.md` § G).

**Stacked on the B–F chain (base `feat/loop-v2-phase-d`).**

## Why two PRs

Extraction is irreversible at two points I cannot do autonomously: creating the org repo and pushing to it. And removing ~5k LOC from network-operations is unsafe until the new repo is proven working. So this PR is all-additive preparation; the operator runs the extraction (Step 1–5 of the runbook), then merges PR 2/2 (the cutover). The runbook enforces that ordering.

## Change class / risk

- Change class: tooling + docs (repo surgery prep), risk tier low — nothing removed, nothing executed in CI
- Task spec: `docs/engineering-loop/v2-roadmap.md` § G; tracking issue #196

## AI transparency

- Authored by Claude Fable 5 (Claude Code session, operator-reviewed)

## Evidence (proven locally against this branch's HEAD)

- [x] AC1 — **history preserved**: `extract-engineering-loop.sh --verify` produced a 20-commit standalone repo; `git log --follow src/hyrule_engineering_loop/graph.py` traces back through Phases F→C to "Add Hyrule Engineering Loop (#189)"
- [x] extracted tree is green: **155 passed**, `mypy --strict` clean, `ruff check src tests` clean (the new repo's three required checks)
- [x] extraction scoping verified: `configs/` → only `loop/`; `docs/` → only `agent-loops` / `agentic-development-loop.md` / `engineering-loop` (the `docs/ci/` runbook correctly stays behind); `integrations/` → only `pi/`; `tests/` → only the loop suites (no `iac/`/`goss/`); no `ansible/` leakage
- [x] new-repo CI pinned to the **unprivileged** `ci-pr` runner (`hyrule-public-pr`), never `hyrule-ci`
- [x] both scripts shellcheck-clean (`--severity=error`); the CI workflow yamllints clean
- network-operations side untouched: its `pytest`/`mypy` still green; lint/render/iac unaffected

The five ruff fixes (commit 1) are pre-existing nits in the loop code, cleaned here so the preserved history lands ruff-clean and the new repo's gate is green from the first run (network-operations doesn't run ruff, so it's a no-op there).

## Human focus areas

1. **`git filter-repo` vs the roadmap's "git subtree split"** — subtree split can't select a subset of `tests/` or individual root files across many top-level paths; filter-repo is the correct multi-path tool and is what satisfies AC1. Flagging the deliberate deviation from the roadmap wording.
2. **Pi extension repoint** (runbook Step 4) — after extraction the extension's `infraRepo` config conflates two now-divergent roots (the loop CLI lives in engineering-loop; `memory/` + sibling repos live in network-operations). The runbook calls for splitting that field; it's a small rework done in the new repo, deliberately not attempted here.
3. The icinga `engineering-loop.conf` (Phase F) **stays** in network-operations — it's monitoring config deployed to `mon`, not loop runtime. Confirm that's the intended home.

## Operator steps this PR cannot do

Creating `AS215932/engineering-loop`, pushing, assigning the `public-pr` runner group, branch protection, and the AC4 sibling-canary — all in `docs/ci/engineering-loop-extraction.md`.

## Rollback

Revert the merge; entirely additive, no state.

## NOC handoff / Post-deploy

Not applicable (no production-affecting change). Post-merge: run the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)