### PR TITLE
Allow Caddy to reach Icinga Web

### DIFF
--- a/ansible/generated/mon/nftables.conf
+++ b/ansible/generated/mon/nftables.conf
@@ -36,6 +36,7 @@ table inet filter {
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
+        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 80 counter accept comment "Icinga Web from proxy"
         ip6 saddr 2a0c:b641:b50:2::40 tcp dport 3000 counter accept comment "Grafana from proxy"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter self-scrape"
         ip6 saddr 2a0c:b641:b50:2::a0 tcp dport 9090 counter accept comment "Prometheus API from noc-agent"

--- a/ansible/inventory/host_vars/mon.yml
+++ b/ansible/inventory/host_vars/mon.yml
@@ -6,7 +6,8 @@
 mon_discord_webhook_url: "{{ lookup('ansible.builtin.env', 'MON_DISCORD_WEBHOOK_URL') | default('') }}"
 
 firewall_extra_rules:
-  # Grafana via Caddy.
+  # Icinga Web + Grafana via Caddy.
+  - { proto: tcp, dport: 80, src: "{{ peers.proxy.ipv6 }}", comment: "Icinga Web from proxy" }
   - { proto: tcp, dport: 3000, src: "{{ peers.proxy.ipv6 }}", comment: "Grafana from proxy" }
 
   # Self-scrape (mon scrapes its own node_exporter).

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -116,6 +116,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
+| proxy | TCP | 80 | Icinga Web via Caddy |
 | proxy | TCP | 3000 | Grafana via Caddy |
 | self | TCP | 9100 | node_exporter (Prometheus self-scrape) |
 | noc | TCP | 5665, 9090 | Icinga2 API / Prometheus query API for noc-agent |


### PR DESCRIPTION
## Summary
- allow proxy/Caddy to reach mon's Icinga Web nginx listener on TCP/80
- document the mon inbound flow
- update generated nftables artifact

## Validation
- Applied firewall role to mon with `firewall_apply=true`
- Verified `https://mon.servify.network/icingaweb2` reaches the Icinga Web login page
- Verified proxy can connect directly to `http://[2a0c:b641:b50:2::50]/icingaweb2`

## Note
The deploy snapshot helper degraded because `/etc/icinga2/scripts/.icinga-snapshot.env` is missing on mon.