### PR TITLE
Improve noc-agent MCP health monitoring

### DIFF
--- a/.github/workflows/app-promotion-deploy.yml
+++ b/.github/workflows/app-promotion-deploy.yml
@@ -8,6 +8,10 @@ on:
       - ansible/inventory/host_vars/noc.yml
       - ansible/inventory/host_vars/api.yml
       - ansible/inventory/host_vars/web.yml
+      - configs/mon/icinga2/**
+      - configs/xo-mcp-package.json
+      - configs/noc-agent.env.j2
+      - ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
 
 permissions:
   contents: read
@@ -31,19 +35,46 @@ jobs:
       - id: detect
         run: |
           set -euo pipefail
-          changed="$(git diff --name-only HEAD^ HEAD -- ansible/inventory/host_vars/noc.yml ansible/inventory/host_vars/api.yml ansible/inventory/host_vars/web.yml)"
+          changed="$(git diff --name-only HEAD^ HEAD -- \
+            ansible/inventory/host_vars/noc.yml \
+            ansible/inventory/host_vars/api.yml \
+            ansible/inventory/host_vars/web.yml \
+            configs/mon/icinga2 \
+            configs/xo-mcp-package.json \
+            configs/noc-agent.env.j2 \
+            ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2)"
           python3 - "$changed" <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import sys
 
           changed = set(sys.argv[1].splitlines())
           matrix = []
-          if "ansible/inventory/host_vars/noc.yml" in changed:
-              matrix.append({"playbook": "noc", "limit": "noc"})
+
+          def add_once(playbook: str, limit: str) -> None:
+              entry = {"playbook": playbook, "limit": limit}
+              if entry not in matrix:
+                  matrix.append(entry)
+
+          mon_icinga_changed = any(path.startswith("configs/mon/icinga2/") for path in changed)
+          noc_changed = any(path in changed for path in {
+              "ansible/inventory/host_vars/noc.yml",
+              "configs/xo-mcp-package.json",
+              "configs/noc-agent.env.j2",
+              "ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2",
+          })
+
+          # Ordering matters for NOC monitoring changes: install mon-side
+          # CheckCommand/script definitions before the monitoring role renders
+          # host services that reference them, then deploy noc-side services.
+          if mon_icinga_changed or noc_changed:
+              add_once("icinga2", "mon")
+          if noc_changed:
+              add_once("monitoring", "noc")
+              add_once("noc", "noc")
           if "ansible/inventory/host_vars/api.yml" in changed:
-              matrix.append({"playbook": "cloud", "limit": "api"})
+              add_once("cloud", "api")
           if "ansible/inventory/host_vars/web.yml" in changed:
-              matrix.append({"playbook": "web", "limit": "web"})
+              add_once("web", "web")
           print(f"matrix={json.dumps({'include': matrix})}")
           print(f"has_changes={'true' if matrix else 'false'}")
           PY

--- a/ansible/generated/noc/icinga_host.conf
+++ b/ansible/generated/noc/icinga_host.conf
@@ -33,16 +33,12 @@ object Service "noc-agent-health" {
 
 object Service "noc-agent-mcp-health" {
   host_name = "noc"
-  check_command = "http"
+  check_command = "noc_agent_mcp_health"
   check_interval = 1m
   retry_interval = 30s
   notes = "MCP subprocess connectivity for Prometheus/SSH and Xen Orchestra tools"
-  vars.http_address = "2a0c:b641:b50:2::a0"
-  vars.http_port = 8000
-  vars.http_uri = "/health/mcp"
-  vars.http_ipv6 = true
-  vars.http_timeout = 10
-  vars.http_expect_body_regex = "\"status\":\"ok\""
+  vars.noc_mcp_host = "2a0c:b641:b50:2::a0"
+  vars.noc_mcp_port = 8000
 }
 
 object Service "noc-agent-config-health" {

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -8,6 +8,11 @@
 noc_agent_version: c2ae3a9a59d2e6e9600b14c9b33350a029e65faf
 hyrule_mcp_version: 78b97ee626d665160b9bd3c3741589392655a00e
 
+# XO MCP occasionally takes >5s to answer tools/list via supergateway during
+# streamable-HTTP session churn. Keep Icinga + app health probes below their
+# 15s HTTP wrapper timeout while avoiding false 5s flaps.
+noc_agent_mcp_health_timeout_seconds: 12
+
 firewall_extra_rules:
   # Webhooks from Alertmanager + Icinga2 on mon.
   - { proto: tcp, dport: 8000, src: "{{ peers.mon.ipv6 }}", comment: "noc-agent webhook from mon (Alertmanager + Icinga)" }

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -33,17 +33,16 @@ monitoring_extra_services:
       http_expect_body_regex: '"status":"ok"'
 
   - name: noc-agent-mcp-health
-    check_command: http
+    # Custom check: surfaces /health/mcp's per-source JSON state instead of
+    # the generic check_http "503 + pattern not found" output.
+    # CheckCommand defined in configs/mon/icinga2/services/noc-agent-mcp-health.conf.
+    check_command: noc_agent_mcp_health
     interval: 1m
     retry: 30s
     notes: "MCP subprocess connectivity for Prometheus/SSH and Xen Orchestra tools"
     vars:
-      http_address: "{{ peers.noc.ipv6 }}"
-      http_port: 8000
-      http_uri: "/health/mcp"
-      http_ipv6: true
-      http_timeout: 10
-      http_expect_body_regex: '"status":"ok"'
+      noc_mcp_host: "{{ peers.noc.ipv6 }}"
+      noc_mcp_port: 8000
 
   - name: noc-agent-config-health
     check_command: http

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -43,6 +43,7 @@ HYRULE_MCP_CMD="/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py"
 HYRULE_MCP_URL=http://127.0.0.1:8765/mcp
 XO_MCP_CMD="npx -y @xen-orchestra/mcp"
 XO_MCP_URL=http://127.0.0.1:8766/mcp
+MCP_HEALTH_TIMEOUT_SECONDS={{ noc_agent_mcp_health_timeout_seconds | default('12') }}
 XO_URL=https://xo.servify.network
 {% raw %}{{ with secret "kv/data/noc-agent" -}}
 XO_USERNAME={{ or .Data.data.xo_username "" }}

--- a/configs/mon/icinga2/scripts/check_noc_agent_mcp_health.sh
+++ b/configs/mon/icinga2/scripts/check_noc_agent_mcp_health.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# check_noc_agent_mcp_health.sh — Icinga2 check executed on mon.
+#
+# Curls noc-agent's /health/mcp and surfaces the JSON body's per-source
+# state. The stock check_http output only reports HTTP 503 + regex failure;
+# this wrapper identifies whether hyrule-mcp or xo-mcp is degraded and why.
+#
+# Usage: check_noc_agent_mcp_health.sh <ipv6> <port>
+
+set -u
+
+if [ "$#" -ne 2 ]; then
+    echo "UNKNOWN - usage: $0 <ipv6> <port>"
+    exit 3
+fi
+host="$1"; port="$2"
+
+body="$(mktemp)"
+err_log="$(mktemp)"
+trap 'rm -f "$body" "$err_log"' EXIT
+
+code="$(curl -sS --max-time 15 -o "$body" -w '%{http_code}' \
+    "http://[$host]:$port/health/mcp" 2>"$err_log")" || {
+    reason="$(tr '\n' ' ' < "$err_log" | sed 's/  */ /g')"
+    echo "CRITICAL - /health/mcp unreachable from mon: ${reason:-curl exit non-zero}"
+    exit 2
+}
+
+field() {
+    val="$(jq -r "$1 // \"?\"" "$body" 2>/dev/null)" || val="?"
+    [ "$val" = "null" ] && val="?"
+    printf '%s' "$val"
+}
+
+source_detail() {
+    src="$1"
+    ready="$(field ".sources.$src.ready")"
+    tools="$(field ".sources.$src.tool_count")"
+    error="$(field ".sources.$src.error")"
+    printf '%s_ready=%s %s_tools=%s %s_error=%s' "$src" "$ready" "$src" "$tools" "$src" "$error"
+}
+
+status="$(field '.status')"
+hyrule="$(source_detail hyrule)"
+xo="$(source_detail xo)"
+detail="status=$status $hyrule $xo"
+
+case "$code" in
+    200)
+        if [ "$status" = "ok" ]; then
+            echo "OK - $detail"
+            exit 0
+        fi
+        echo "CRITICAL - http=200 but $detail"
+        exit 2
+        ;;
+    503)
+        echo "CRITICAL - $detail"
+        exit 2
+        ;;
+    *)
+        echo "UNKNOWN - http=$code $detail"
+        exit 3
+        ;;
+esac

--- a/configs/mon/icinga2/services/noc-agent-mcp-health.conf
+++ b/configs/mon/icinga2/services/noc-agent-mcp-health.conf
@@ -1,0 +1,19 @@
+// /etc/icinga2/conf.d/services/noc-agent-mcp-health.conf
+//
+// Custom CheckCommand for noc-agent's /health/mcp endpoint. The stock
+// check_http command reports only HTTP 503 + "pattern not found" when one
+// MCP source degrades. This wrapper extracts the per-source readiness/error
+// fields so alerts identify whether hyrule-mcp or xo-mcp is failing.
+//
+// Service object lives in host_vars/noc.yml :: monitoring_extra_services
+// (rendered into /etc/icinga2/conf.d/hosts/ansible/noc.conf by the
+// monitoring role) and references this CheckCommand by name.
+
+object CheckCommand "noc_agent_mcp_health" {
+  command = [ "/etc/icinga2/scripts/check_noc_agent_mcp_health.sh" ]
+
+  arguments = {
+    "host" = { skip_key = true; order = 1; value = "$noc_mcp_host$" }
+    "port" = { skip_key = true; order = 2; value = "$noc_mcp_port$" }
+  }
+}

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -54,6 +54,7 @@ HYRULE_MCP_CMD="/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py"
 HYRULE_MCP_URL=http://127.0.0.1:8765/mcp
 XO_MCP_CMD="npx -y @xen-orchestra/mcp"
 XO_MCP_URL=http://127.0.0.1:8766/mcp
+MCP_HEALTH_TIMEOUT_SECONDS={{ noc_agent_mcp_health_timeout_seconds | default('12') }}
 
 # --- Xen Orchestra (consumed by the XO MCP child) ---
 XO_URL=https://xo.servify.network

--- a/configs/xo-mcp-package.json
+++ b/configs/xo-mcp-package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@xen-orchestra/mcp": "1.0.1",
-    "supergateway": "3.4.0"
+    "@xen-orchestra/mcp": "1.4.0",
+    "supergateway": "3.4.3"
   }
 }


### PR DESCRIPTION
## Summary
- replace noc-agent-mcp-health's generic check_http probe with a custom wrapper that reports per-source /health/mcp JSON state
- set production MCP_HEALTH_TIMEOUT_SECONDS=12 explicitly in noc host vars/env templates
- upgrade local XO MCP wrapper dependencies: @xen-orchestra/mcp 1.0.1 → 1.4.0 and supergateway 3.4.0 → 3.4.3
- update app-promotion deploy ordering so mon-side Icinga command files apply before NOC monitoring services reference them

## Validation
- `ansible-playbook playbooks/monitoring.yml --tags validate --connection=local --skip-tags=snapshot --limit noc`
- `ansible-playbook playbooks/icinga2.yml --tags validate --connection=local --skip-tags=snapshot --limit mon`
- copied the new check script to mon /tmp and ran it against live noc-agent: `OK - status=ok hyrule_ready=true hyrule_tools=34 ... xo_ready=true xo_tools=8 ...`
- checked npm latest versions: @xen-orchestra/mcp=1.4.0, supergateway=3.4.3
- workflow YAML parsed successfully; local matrix check confirms NOC changes deploy in order: icinga2/mon → monitoring/noc → noc/noc
- `yamllint .github/workflows/app-promotion-deploy.yml ansible/inventory/host_vars/noc.yml`

## Related
- Pairs with noc-agent app PR: https://github.com/AS215932/noc-agent/pull/17