### PR TITLE
Publish Hyrule support mail routing

### DIFF
--- a/ansible/generated/mail/mail/aliases
+++ b/ansible/generated/mail/mail/aliases
@@ -8,3 +8,4 @@ noc: noc
 abuse: noc+abuse
 peering: noc+peering
 dh: noc+dh
+support: noc+support

--- a/ansible/generated/mail/mail/dkim_signing.conf
+++ b/ansible/generated/mail/mail/dkim_signing.conf
@@ -7,4 +7,8 @@ domain {
         path = "/etc/mail/dkim/private/as215932.net.key";
         selector = "dkim";
     }
+    hyrule.host {
+        path = "/etc/mail/dkim/private/as215932.net.key";
+        selector = "dkim";
+    }
 }

--- a/ansible/generated/mail/mail/smtpd.conf
+++ b/ansible/generated/mail/mail/smtpd.conf
@@ -18,5 +18,6 @@ action "local" lmtp "/var/dovecot/lmtp" alias <aliases>
 action "outbound" relay
 
 match from any for domain "as215932.net" action "local"
+match from any for domain "hyrule.host" action "local"
 match from local for local action "local"
 match from any auth for any action "outbound"

--- a/ansible/inventory/host_vars/mail.yml
+++ b/ansible/inventory/host_vars/mail.yml
@@ -56,14 +56,19 @@ monitoring_extra_services:
 
 # --- Mail role ---
 mail_domain: as215932.net
+mail_extra_domains:
+  - hyrule.host
 mail_hostname: mail.as215932.net
 mail_ipv6: "{{ peers.mail.ipv6 }}"
 mail_ipv4: "{{ mail_failover_ipv4 | default('') }}"
 mail_ipv4_gw: "{{ mail_failover_ipv4_gateway | default('') }}"
 mail_shared_user: noc
+mail_dkim_extra_domains:
+  - hyrule.host
 mail_dovecot_listen: "*, ::"
 mail_role_addresses:
   - noc
   - abuse
   - peering
   - dh
+  - support

--- a/ansible/roles/mail_openbsd/defaults/main.yml
+++ b/ansible/roles/mail_openbsd/defaults/main.yml
@@ -3,6 +3,7 @@ mail_apply: false
 mail_generated_dir: "{{ playbook_dir }}/../generated"
 
 mail_domain: as215932.net
+mail_extra_domains: []
 mail_hostname: "mail.{{ mail_domain }}"
 mail_ipv6: "{{ peers.mail.ipv6 }}"
 mail_ipv4: "{{ mail_failover_ipv4 | default('') }}"
@@ -10,6 +11,7 @@ mail_shared_user: noc
 mail_role_addresses: [noc, abuse, peering, dh]
 
 mail_dkim_selector: dkim
+mail_dkim_extra_domains: []
 mail_dkim_private_key_path: "/etc/mail/dkim/private/{{ mail_domain }}.key"
 mail_dkim_public_key_path: "/etc/mail/dkim/{{ mail_domain }}.pub"
 mail_dkim_private_key: "{{ vault_mail_dkim_private_key | default(lookup('env', 'MAIL_DKIM_PRIVATE_KEY'), true) | default('', true) }}"

--- a/ansible/roles/mail_openbsd/templates/rspamd-dkim_signing.conf.j2
+++ b/ansible/roles/mail_openbsd/templates/rspamd-dkim_signing.conf.j2
@@ -3,8 +3,10 @@
 allow_username_mismatch = true;
 
 domain {
-    {{ mail_domain }} {
+{% for domain in [mail_domain] + mail_dkim_extra_domains %}
+    {{ domain }} {
         path = "{{ mail_dkim_private_key_path }}";
         selector = "{{ mail_dkim_selector }}";
     }
+{% endfor %}
 }

--- a/ansible/roles/mail_openbsd/templates/smtpd.conf.j2
+++ b/ansible/roles/mail_openbsd/templates/smtpd.conf.j2
@@ -17,6 +17,8 @@ listen on all port 587 tls-require pki "{{ mail_hostname }}" auth mask-src filte
 action "local" lmtp "/var/dovecot/lmtp" alias <aliases>
 action "outbound" relay
 
-match from any for domain "{{ mail_domain }}" action "local"
+{% for domain in [mail_domain] + mail_extra_domains %}
+match from any for domain "{{ domain }}" action "local"
+{% endfor %}
 match from local for local action "local"
 match from any auth for any action "outbound"

--- a/configs/hyrule.host.zone
+++ b/configs/hyrule.host.zone
@@ -5,7 +5,7 @@ $ORIGIN hyrule.host.
 $TTL 3600
 
 @       IN  SOA   ns1.servify.network. admin.servify.network. (
-                  2026051601 ; serial (YYYYMMDDNN)
+                  2026061301 ; serial (YYYYMMDDNN)
                   3600       ; refresh (1h)
                   900        ; retry (15m)
                   604800     ; expire (7d)
@@ -14,6 +14,14 @@ $TTL 3600
 ; Nameservers are infrastructure identity, intentionally under servify.network.
 @       IN  NS    ns1.servify.network.
 @       IN  NS    ns2.servify.network.
+
+; Mail for Hyrule customer support.
+@       IN  MX    10 mail.as215932.net.
+@       IN  TXT   "v=spf1 ip4:51.91.236.215 ip6:2a0c:b641:b50:2::90 -all"
+_dmarc  IN  TXT   "v=DMARC1; p=none; rua=mailto:noc@as215932.net; adkim=s; aspf=s"
+; DKIM selector for Rspamd signing on mail.as215932.net.
+dkim._domainkey IN TXT ( "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxF/V0NkAuLkXFZ6WVPqTrdi1na7DZKHXFl605qBrhhgiFM6oR65kPivhwKcP7S+8PsbxAIzZb2irl1RUZqeTrYigsetugKyg7ONX1o5C9+JEO+BuY4ug6Lg9LRMy00q+DNKV7HxD"
+                  "3Cp8mwEcJNiMXHzGhEGzry5O93mzkT/vFSxytwrsLychXpt6OKQ2lcgO5YKxa5xwRrQdpTVYup2hHwSD85rUtkoaCDPPzyx3BTbCvGMf7MkIPR4A/UHH0h+/pA+fGfElECzkZXqBNLYWrEnRIlsI36bjXBITnuGl/l6Vhzazjgc0xGjJcGBRenP5nqxN9Jw8vbDGgjmTxFMmbwIDAQAB" )
 
 ; --- Verification / site ownership tokens ---
 @       IN  TXT   "google-site-verification=pbrhNLnPwPQ5MkW5HgpRFDtG-2jus8peu0luKerDWso"


### PR DESCRIPTION
## Summary
- accept `hyrule.host` on the OpenSMTPD mail role
- route `support` to the shared NOC mailbox via plus addressing
- add MX/SPF/DMARC/DKIM DNS records for `hyrule.host`
- refresh tracked generated mail artifacts

## Validation
- `ansible-playbook playbooks/mail_openbsd.yml --tags validate --connection=local --skip-tags=snapshot` from `ansible/`
- `scripts/ci/iac-static.sh` outside sandbox with Ansible temp dirs under `/tmp`

## Launch checklist
Unblocks the `support@hyrule.host` contact-publishing item in AS215932/network-operations#142.