### PR TITLE
Fix hyrule-cloud Vault Agent bootstrap apply

### DIFF
--- a/ansible/roles/hyrule_cloud/tasks/vault.yml
+++ b/ansible/roles/hyrule_cloud/tasks/vault.yml
@@ -11,6 +11,13 @@
          else hyrule_cloud_vault_secret_id }}
   no_log: true
 
+- name: Capture current hyrule-cloud Vault Agent state
+  ansible.builtin.systemd:
+    name: "vault-agent-{{ hyrule_cloud_vault_role_name }}"
+  register: hyrule_cloud_vault_agent_service
+  changed_when: false
+  failed_when: false
+
 - name: Set hyrule-cloud Vault Agent template list
   ansible.builtin.set_fact:
     hyrule_cloud_vault_agent_templates:
@@ -63,6 +70,10 @@
         group: "{{ hyrule_cloud_app_group }}"
         mode: "0750"
   no_log: "{{ hyrule_cloud_vault_agent_secret_id | length > 0 }}"
+
+- name: Flush handlers so Vault Agent uses updated AppRole/template inputs
+  ansible.builtin.meta: flush_handlers
+  when: hyrule_cloud_vault_agent_service.status.ActiveState | default("inactive") == "active"
 
 - name: Wait for Vault Agent to render hyrule-cloud env file
   ansible.builtin.wait_for:

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -125,6 +125,30 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertNotIn("XCPNG_XO_TOKEN", runner_template)
         self.assertNotIn("VAULT_HYRULE_CLOUD_SECRET_ID", runner_template)
 
+    def test_hyrule_cloud_flushes_vault_agent_before_render_waits(self):
+        tasks = yaml.safe_load((REPO / "ansible/roles/hyrule_cloud/tasks/vault.yml").read_text())
+        names = [task.get("name") for task in tasks]
+
+        state_index = names.index("Capture current hyrule-cloud Vault Agent state")
+        setup_index = names.index("Set up Vault Agent for hyrule-cloud secret delivery")
+        flush_index = names.index("Flush handlers so Vault Agent uses updated AppRole/template inputs")
+        wait_index = names.index("Wait for Vault Agent to render hyrule-cloud env file")
+
+        state_task = _task_by_name(tasks, "Capture current hyrule-cloud Vault Agent state")
+        self.assertEqual(state_task["register"], "hyrule_cloud_vault_agent_service")
+        self.assertFalse(state_task["changed_when"])
+        self.assertFalse(state_task["failed_when"])
+
+        flush_task = _task_by_name(tasks, "Flush handlers so Vault Agent uses updated AppRole/template inputs")
+        self.assertEqual(flush_task["ansible.builtin.meta"], "flush_handlers")
+        self.assertEqual(
+            flush_task["when"],
+            'hyrule_cloud_vault_agent_service.status.ActiveState | default("inactive") == "active"',
+        )
+        self.assertLess(state_index, setup_index)
+        self.assertLess(setup_index, flush_index)
+        self.assertLess(flush_index, wait_index)
+
     def test_github_runner_vault_token_sink_is_runner_readable(self):
         defaults = yaml.safe_load((REPO / "ansible/roles/vault_agent/defaults/main.yml").read_text())
         vault_tasks = yaml.safe_load((REPO / "ansible/roles/vault_agent/tasks/main.yml").read_text())


### PR DESCRIPTION
## Summary
- Flush Vault Agent handlers before hyrule-cloud waits for Vault-rendered env files
- Cover the task order with a Vault/IaC contract test

## Why
The production cloud apply for launch app promotion failed after installing the Monero Vault templates because the Vault Agent was still running with an old/invalid token. The apply then waited for new Monero files that could not render. Flushing handlers immediately after the shared vault_agent role lets the fresh wrapped SecretID and templates take effect before the render waits.

## Verification
- uv run pytest tests/iac/test_vault_and_runner_contracts.py
- scripts/ci/iac-static.sh