### PR TITLE
Fix Monero wallet RPC restore bootstrap

### DIFF
--- a/ansible/roles/hyrule_cloud/tasks/runtime.yml
+++ b/ansible/roles/hyrule_cloud/tasks/runtime.yml
@@ -51,6 +51,15 @@
     mode: "0750"
   when: hyrule_cloud_monero_wallet_rpc_enabled | bool
 
+- name: Install Monero wallet RPC restore helper
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../configs/hyrule-cloud-monero-restore-wallet"
+    dest: /usr/local/sbin/hyrule-cloud-monero-restore-wallet
+    owner: root
+    group: root
+    mode: "0755"
+  when: hyrule_cloud_monero_wallet_rpc_enabled | bool
+
 - name: Install /etc/systemd/system/monero-wallet-rpc.service
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../../configs/monero-wallet-rpc.service"

--- a/configs/hyrule-cloud-monero-restore-wallet
+++ b/configs/hyrule-cloud-monero-restore-wallet
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def required_env(name):
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"{name} is required")
+    return value
+
+
+def main():
+    wallet = Path(required_env("MONERO_WALLET_RPC_WALLET_FILE"))
+    if wallet.exists():
+        return 0
+
+    password_file = Path(required_env("MONERO_WALLET_RPC_WALLET_PASSWORD_FILE"))
+    restore_height_raw = os.environ.get("MONERO_WALLET_RPC_RESTORE_HEIGHT", "0")
+    try:
+        restore_height = int(restore_height_raw)
+    except ValueError as exc:
+        raise SystemExit(f"MONERO_WALLET_RPC_RESTORE_HEIGHT must be an integer: {restore_height_raw}") from exc
+
+    payload = {
+        "version": 1,
+        "filename": str(wallet),
+        "password": password_file.read_text().rstrip("\n"),
+        "address": required_env("MONERO_WALLET_RPC_WALLET_ADDRESS"),
+        "viewkey": required_env("MONERO_WALLET_RPC_VIEW_KEY"),
+        "scan_from_height": restore_height,
+    }
+
+    wallet.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+    fd, restore_json = tempfile.mkstemp(prefix=".restore-", suffix=".json", dir=wallet.parent, text=True)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+            handle.write("\n")
+        subprocess.run(["/usr/bin/monero-wallet-cli", "--generate-from-json", restore_json], check=True)
+    finally:
+        try:
+            os.unlink(restore_json)
+        except FileNotFoundError:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/monero-wallet-rpc.service
+++ b/configs/monero-wallet-rpc.service
@@ -12,7 +12,7 @@ User=hyrule
 Group=hyrule
 EnvironmentFile=/etc/hyrule-cloud/monero-wallet-rpc.env
 ExecStartPre=+/bin/sh -c 'install -d -o hyrule -g hyrule -m 0750 "$(dirname "$MONERO_WALLET_RPC_WALLET_FILE")"'
-ExecStartPre=/bin/sh -c 'test -f "$MONERO_WALLET_RPC_WALLET_FILE" || /usr/bin/monero-wallet-cli --generate-from-view-key "$MONERO_WALLET_RPC_WALLET_FILE" --address "$MONERO_WALLET_RPC_WALLET_ADDRESS" --view-key "$MONERO_WALLET_RPC_VIEW_KEY" --password-file "$MONERO_WALLET_RPC_WALLET_PASSWORD_FILE" --restore-height "$MONERO_WALLET_RPC_RESTORE_HEIGHT" --non-interactive'
+ExecStartPre=/usr/local/sbin/hyrule-cloud-monero-restore-wallet
 ExecStartPre=+/bin/sh -c 'chown hyrule:hyrule "$MONERO_WALLET_RPC_WALLET_FILE"* && chmod 0600 "$MONERO_WALLET_RPC_WALLET_FILE"*'
 ExecStart=/usr/bin/monero-wallet-rpc \
   --wallet-file ${MONERO_WALLET_RPC_WALLET_FILE} \

--- a/tests/iac/test_vault_and_runner_contracts.py
+++ b/tests/iac/test_vault_and_runner_contracts.py
@@ -149,6 +149,39 @@ class VaultAndRunnerContractsTest(unittest.TestCase):
         self.assertLess(setup_index, flush_index)
         self.assertLess(flush_index, wait_index)
 
+    def test_monero_wallet_rpc_restore_uses_json_helper(self):
+        unit = (REPO / "configs/monero-wallet-rpc.service").read_text()
+        helper = (REPO / "configs/hyrule-cloud-monero-restore-wallet").read_text()
+        runtime_tasks = yaml.safe_load((REPO / "ansible/roles/hyrule_cloud/tasks/runtime.yml").read_text())
+        names = [task.get("name") for task in runtime_tasks]
+
+        helper_index = names.index("Install Monero wallet RPC restore helper")
+        service_index = names.index("Install /etc/systemd/system/monero-wallet-rpc.service")
+        helper_task = _task_by_name(runtime_tasks, "Install Monero wallet RPC restore helper")
+
+        self.assertIn("ExecStartPre=/usr/local/sbin/hyrule-cloud-monero-restore-wallet", unit)
+        self.assertNotIn("--generate-from-view-key", unit)
+        for unsupported_flag in ("--address", "--view-key", "--non-interactive"):
+            self.assertNotRegex(unit, re.compile(rf"(?:^|\s){re.escape(unsupported_flag)}(?:\s|$)", re.MULTILINE))
+
+        self.assertIn("--generate-from-json", helper)
+        self.assertIn("json.dump(payload, handle)", helper)
+        self.assertIn('"password": password_file.read_text().rstrip("\\n")', helper)
+        self.assertIn('"scan_from_height": restore_height', helper)
+        self.assertNotIn('"restore_height": restore_height', helper)
+        self.assertIn('required_env("MONERO_WALLET_RPC_WALLET_ADDRESS")', helper)
+        self.assertIn('required_env("MONERO_WALLET_RPC_VIEW_KEY")', helper)
+        self.assertIn("os.unlink(restore_json)", helper)
+
+        self.assertEqual(
+            helper_task["ansible.builtin.copy"]["src"],
+            "{{ playbook_dir }}/../../configs/hyrule-cloud-monero-restore-wallet",
+        )
+        self.assertEqual(helper_task["ansible.builtin.copy"]["dest"], "/usr/local/sbin/hyrule-cloud-monero-restore-wallet")
+        self.assertEqual(helper_task["ansible.builtin.copy"]["mode"], "0755")
+        self.assertEqual(helper_task["when"], "hyrule_cloud_monero_wallet_rpc_enabled | bool")
+        self.assertLess(helper_index, service_index)
+
     def test_github_runner_vault_token_sink_is_runner_readable(self):
         defaults = yaml.safe_load((REPO / "ansible/roles/vault_agent/defaults/main.yml").read_text())
         vault_tasks = yaml.safe_load((REPO / "ansible/roles/vault_agent/tasks/main.yml").read_text())


### PR DESCRIPTION
## Summary

- replace the unsupported `monero-wallet-cli --generate-from-view-key --address --view-key --non-interactive` systemd pre-start invocation with a local restore helper
- have the helper generate a temporary restore JSON and call `monero-wallet-cli --generate-from-json`, which matches the installed Monero v0.18.4.0 CLI surface on `api`
- install the helper only when Monero wallet RPC is enabled and cover the runtime/unit contract in IaC tests

## Production failure addressed

The cloud apply reached rendered Vault Agent files successfully, then failed starting `monero-wallet-rpc.service` because the installed `monero-wallet-cli` rejected `--address` during the view-only wallet restore pre-start step.

## Verification

- `uv run pytest tests/iac/test_vault_and_runner_contracts.py`
- `scripts/ci/iac-static.sh`
