### PR TITLE
Promote hyrule-cloud schema pin

### DIFF
--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -1,7 +1,7 @@
 ---
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
-hyrule_cloud_version: 8e802175ad6ff11af13430cdfcca687e05cae55c
+hyrule_cloud_version: 270b65d764dbab7155fa98f08ab4370f7c605b19
 hyrule_cloud_monero_wallet_rpc_enabled: true
 
 firewall_extra_rules:


### PR DESCRIPTION
## Summary

- promote `hyrule_cloud_version` to `270b65d764dbab7155fa98f08ab4370f7c605b19`
- align the production deploy pin with the live database's Alembic `011` revision

## Production failure addressed

The cloud apply after #217 successfully installed and started `monero-wallet-rpc`, then failed restarting `hyrule-cloud.service` because Alembic could not locate revision `011` in the previously pinned app commit (`8e80217`). The promoted app commit contains `010_network_intelligence_bgp_mx_mail.py` and `011_diagnostic_job_primitives.py`.

## Verification

- `uv run pytest tests/iac/test_app_version_pins.py tests/iac/test_vault_and_runner_contracts.py`
- `scripts/ci/iac-static.sh`
