### PR TITLE
feat(loop): add dedicated engineering loop VM substrate

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -32,6 +32,7 @@ on:
           - ci-runner-key
           - knot
           - extmon
+          - engineering-loop
           - frr
           - rtr_routing
           - networkd_resolved

--- a/ansible/generated/loop/icinga_host.conf
+++ b/ansible/generated/loop/icinga_host.conf
@@ -1,0 +1,30 @@
+// /etc/icinga2/conf.d/hosts/ansible/loop.conf
+// Managed by ansible/roles/monitoring — do not edit by hand.
+// Source of truth: ansible/inventory/host_vars/loop.yml
+
+object Host "loop" {
+  address6 = "2a0c:b641:b50:2::f0"
+  display_name = "loop"
+
+  check_command = "ping6"
+
+  vars.os = "Debian"
+  vars.role = "loop"
+  vars.ssh_port = 22
+  vars.engineering_loop = true
+
+  vars.prom_instance_node = "[2a0c:b641:b50:2::f0]:9100"
+
+  vars.disks["disk /"] = { mountpoint = "/" }
+}
+
+object Service "engineering-loop-timer" {
+  host_name = "loop"
+  check_command = "prom_systemd_unit"
+  check_interval = 2m
+  retry_interval = 1m
+  notes = "Engineering Loop hourly timer is active on the dedicated loop VM"
+  vars.prom_instance = "[2a0c:b641:b50:2::f0]:9100"
+  vars.systemd_unit = "hyrule-engineering-loop.timer"
+}
+

--- a/ansible/generated/loop/nftables.conf
+++ b/ansible/generated/loop/nftables.conf
@@ -1,0 +1,55 @@
+#!/usr/sbin/nft -f
+# /etc/nftables.conf — managed by ansible (roles/firewall)
+# Host: loop
+# Generated: do not edit by hand.
+
+flush ruleset
+
+table inet filter {
+    chain input {
+        type filter hook input priority filter; policy drop;
+
+        # Loopback always allowed.
+        iif lo accept
+
+        # Established/related — keep returning packets flowing.
+        ct state established,related accept
+        ct state invalid drop
+
+        # ICMPv6 — required for ND, RA, MTU discovery, ping.
+        meta l4proto ipv6-icmp accept
+
+        # ICMPv4 — keep ping working.
+        meta l4proto icmp accept
+
+        # Stray DHCP client broadcasts from the L2 segment are not useful on
+        # statically-addressed infra hosts. Drop before the final log rule so
+        # log-only mode does not drown real misses in 0.0.0.0:68 noise.
+        ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp sport 68 udp dport 67 counter drop comment "stray DHCP client broadcast"
+
+        # SSH from VPN clients, trusted automation, monitoring, and ops prefix.
+        ip6 saddr 2a02:a442:1016::/48 tcp dport 22 counter accept comment "ssh from 2a02:a442:1016::/48"
+        ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:3::/64"
+        ip6 saddr 2a0c:b641:b50:2::d0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::d0/128"
+        ip6 saddr 2a0c:b641:b50:2::a0/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::a0/128"
+        ip6 saddr 2a0c:b641:b50:2::50/128 tcp dport 22 counter accept comment "ssh from 2a0c:b641:b50:2::50/128"
+        ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
+
+        # Per-host service allowances.
+        ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
+
+
+        # End of input — log+counter what would have been dropped if policy were drop.
+        limit rate 10/second counter log prefix "fw-drop "
+    }
+
+    chain forward {
+        type filter hook forward priority filter; policy drop;
+        ct state established,related accept
+        ct state invalid drop
+    }
+
+    chain output {
+        type filter hook output priority filter; policy accept;
+    }
+}

--- a/ansible/generated/loop/vector-agent.toml
+++ b/ansible/generated/loop/vector-agent.toml
@@ -1,0 +1,60 @@
+# /etc/vector/vector.toml — managed by ansible (roles/logs)
+# Host: loop  Role: loop
+# Generated: do not edit by hand.
+#
+# Reads journald (Linux) or files (FreeBSD), normalizes labels, ships
+# vector-native protocol to log:6000.
+# See docs/application-logging.md for the contract apps follow.
+
+data_dir = "/var/lib/vector"
+
+# --- API (health probe + tap) ---
+[api]
+enabled = true
+address = "127.0.0.1:8686"
+
+# --- Sources -----------------------------------------------------------------
+
+[sources.journald]
+type = "journald"
+include_units = []   # all units
+# Without since_now, Vector replays the host's entire journald history on
+# first start. Loki then 500s with "timestamp too old" / "no schema config
+# found" for entries older than reject_old_samples_max_age. Forensics
+# pre-agent-install isn't queryable through Loki anyway, so cap at "now".
+since_now = true
+
+
+
+
+# --- Transforms --------------------------------------------------------------
+
+# Lift JSON-encoded MESSAGE bodies into structured fields. OS daemons that
+# emit plaintext fall through unchanged with .message preserved.
+[transforms.parse_json]
+type = "remap"
+inputs = ["journald"]
+source = '''
+parsed, err = parse_json(.message)
+if err == null && is_object(parsed) {
+    . = merge(., object!(parsed))
+}
+.service = string(.service) ?? string(._SYSTEMD_UNIT) ?? string(.SYSLOG_IDENTIFIER) ?? "unknown"
+.level = string(.level) ?? "info"
+.host = "loop"
+.role = "loop"
+'''
+
+# --- Sinks -------------------------------------------------------------------
+
+[sinks.aggregator]
+type = "vector"
+inputs = ["parse_json"]
+address = "[2a0c:b641:b50:2::b0]:6000"
+version = "2"
+compression = true
+
+[sinks.aggregator.buffer]
+type = "disk"
+max_size = 1073741824
+when_full = "block"

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -58,6 +58,7 @@ peers:
   vault:   { ipv6: "2a0c:b641:b50:2::c0" }
   ci:      { ipv6: "2a0c:b641:b50:2::d0" }
   netproxy: { ipv6: "2a0c:b641:b50:2::e0" }
+  loop:    { ipv6: "2a0c:b641:b50:2::f0" }
   # ci-pr — unprivileged PR runner, customer-isolated segment (not infra).
   # Key matches inventory_hostname (the monitoring template does
   # peers[inventory_hostname]); referenced via peers['ci-pr'] where needed.

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -1,0 +1,31 @@
+---
+# loop — dedicated Engineering Loop operations-lane VM.
+# Runs one budgeted, issue-driven agent cycle at a time. It is deliberately
+# not a deploy source for the infra fleet: no fleet SSH key, no production
+# Vault breadth, and no public listener beyond node_exporter for mon.
+
+monitoring_register: true
+monitoring_role: loop
+monitoring_check_vars:
+  engineering_loop: true
+
+monitoring_disks:
+  "disk /": { mountpoint: "/" }
+
+monitoring_extra_services:
+  - name: engineering-loop-timer
+    check_command: prom_systemd_unit
+    interval: 2m
+    retry: 1m
+    notes: "Engineering Loop hourly timer is active on the dedicated loop VM"
+    vars:
+      prom_instance: "[{{ peers.loop.ipv6 }}]:9100"
+      systemd_unit: hyrule-engineering-loop.timer
+
+firewall_extra_rules:
+  # node_exporter scrape from mon only.
+  - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }
+
+# --- Logs --- (ships journald to log VM via Vector)
+logs_register: true
+logs_role: loop

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -33,6 +33,8 @@ all:
           ansible_host: 2a0c:b641:b50:2::d0
         netproxy:
           ansible_host: 2a0c:b641:b50:2::e0
+        loop:
+          ansible_host: 2a0c:b641:b50:2::f0
         # ci-pr — unprivileged PR runner on the CUSTOMER-isolated segment
         # (2a0c:b641:b51::/48, enX3). In `linux` for firewall+monitoring only.
         ci-pr:
@@ -93,6 +95,7 @@ all:
         vault:
         ci:
         netproxy:
+        loop:
 
     public_facing:
       hosts:

--- a/ansible/playbooks/engineering-loop.yml
+++ b/ansible/playbooks/engineering-loop.yml
@@ -1,0 +1,76 @@
+---
+# Engineering Loop rollout — installs the dedicated operations-lane daemon on
+# the loop VM. The daemon consumes human-approved GitHub issues and stops at a
+# draft PR. It never merges or applies production changes.
+#
+# Validate (no live changes; runs from controller):
+#   ansible-playbook playbooks/engineering-loop.yml --tags validate \
+#     --connection=local --limit loop --skip-tags=snapshot
+#
+# Apply (live deploy, timer remains disabled by default):
+#   ansible-playbook playbooks/engineering-loop.yml --tags apply \
+#     -e engineering_loop_apply=true --limit loop
+#
+# First bootstrap with Vault Agent requires:
+#   VAULT_ENGINEERING_LOOP_ROLE_ID=...
+#   VAULT_ENGINEERING_LOOP_SECRET_ID=...
+
+- name: engineering-loop — apply dedicated loop VM runtime
+  hosts: loop
+  serial: 1
+  gather_facts: true
+  become: true
+  pre_tasks:
+    - name: Pre-deploy Icinga snapshot
+      ansible.builtin.include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: pre
+      run_once: true
+      tags: [snapshot, always]
+  roles:
+    - role: firewall
+      vars:
+        firewall_apply: "{{ engineering_loop_apply | default(false) }}"
+      tags: [firewall]
+    - role: monitoring
+      vars:
+        monitoring_apply: "{{ engineering_loop_apply | default(false) }}"
+      tags: [monitoring]
+    - role: logs
+      vars:
+        logs_apply: "{{ engineering_loop_apply | default(false) }}"
+      tags: [logs]
+    - role: engineering_loop
+      tags: [engineering_loop]
+    - role: vault_agent
+      vars:
+        vault_agent_name: engineering-loop
+        vault_agent_role_id: "{{ lookup('env', 'VAULT_ENGINEERING_LOOP_ROLE_ID') | default('', true) }}"
+        vault_agent_secret_id: "{{ lookup('env', 'VAULT_ENGINEERING_LOOP_SECRET_ID') | default('', true) }}"
+        vault_agent_env_destination: "{{ engineering_loop_env_file }}"
+        vault_agent_reload_command: /bin/true
+        vault_agent_env_reload_command: /bin/true
+        vault_agent_templates:
+          - src: engineering-loop.env.ctmpl.j2
+            name: engineering-loop.env.ctmpl
+            destination: "{{ engineering_loop_env_file }}"
+            group: "{{ engineering_loop_group }}"
+            reload_command: /bin/true
+        vault_agent_extra_dirs: []
+      when: (lookup('env', 'ENGINEERING_LOOP_SECRET_BACKEND') | default('vault', true)) == 'vault'
+      tags: [vault_agent]
+  post_tasks:
+    - name: Flush handlers before post-deploy snapshot
+      ansible.builtin.meta: flush_handlers
+      tags: [apply, always]
+    - name: Post-deploy Icinga snapshot
+      ansible.builtin.include_role:
+        name: firewall
+        tasks_from: snapshot
+      vars:
+        snapshot_phase: post
+      run_once: true
+      tags: [snapshot, always]
+  tags: [engineering_loop]

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -1,0 +1,74 @@
+---
+# Dedicated Engineering Loop operations-lane deployment.
+# Default is validate/render only; live mutation requires
+# -e engineering_loop_apply=true from apply.yml.
+
+engineering_loop_apply: false
+
+engineering_loop_user: loop
+engineering_loop_group: loop
+
+engineering_loop_install_dir: /opt/engineering-loop
+engineering_loop_env_file: "{{ engineering_loop_install_dir }}/.env"
+engineering_loop_state_dir: /var/lib/engineering-loop
+engineering_loop_workspace_dir: "{{ engineering_loop_state_dir }}/workspace"
+engineering_loop_runs_dir: "{{ engineering_loop_state_dir }}/runs"
+engineering_loop_daemon_state_dir: "{{ engineering_loop_state_dir }}/state"
+engineering_loop_git_askpass_path: /usr/local/lib/engineering-loop/git-askpass
+
+engineering_loop_repo: https://github.com/AS215932/engineering-loop.git
+engineering_loop_version: main
+
+# GitHub issue/PR intake scope for first production rollout.
+engineering_loop_repos:
+  - AS215932/engineering-loop
+  - AS215932/network-operations
+  - AS215932/hyrule-cloud
+  - AS215932/hyrule-web
+  - AS215932/hyrule-mcp
+  - AS215932/noc-agent
+  - AS215932/hyrule-network-proxy
+
+# Local workspace checkout names. network-operations intentionally lands at
+# hyrule-infra to match the existing sibling checkout convention used by the
+# loop and app repos; noc-agent lands at hyrule-noc-agent for the same reason.
+engineering_loop_workspace_repositories:
+  - repo: https://github.com/AS215932/engineering-loop.git
+    dest: engineering-loop
+    version: main
+  - repo: https://github.com/AS215932/network-operations.git
+    dest: hyrule-infra
+    version: main
+  - repo: https://github.com/AS215932/hyrule-cloud.git
+    dest: hyrule-cloud
+    version: main
+  - repo: https://github.com/AS215932/hyrule-web.git
+    dest: hyrule-web
+    version: main
+  - repo: https://github.com/AS215932/hyrule-mcp.git
+    dest: hyrule-mcp
+    version: main
+  - repo: https://github.com/AS215932/noc-agent.git
+    dest: hyrule-noc-agent
+    version: main
+  - repo: https://github.com/AS215932/hyrule-network-proxy.git
+    dest: hyrule-network-proxy
+    version: main
+
+engineering_loop_allowed_paths:
+  - docs
+engineering_loop_max_runs_per_day: 2
+engineering_loop_max_cost_usd_per_day: 10
+engineering_loop_timer_enabled: false
+engineering_loop_memory_dir: "{{ engineering_loop_workspace_dir }}/hyrule-infra/memory"
+
+engineering_loop_git_user_name: "hyrule-engineering-loop[bot]"
+engineering_loop_git_user_email: "engineering-loop@as215932.net"
+
+engineering_loop_packages:
+  - python3
+  - python3-venv
+  - git
+  - ca-certificates
+  - curl
+  - gh

--- a/ansible/roles/engineering_loop/handlers/main.yml
+++ b/ansible/roles/engineering_loop/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart engineering-loop timer
+  ansible.builtin.systemd:
+    name: hyrule-engineering-loop.timer
+    state: "{{ 'restarted' if engineering_loop_timer_enabled | bool else 'stopped' }}"
+    enabled: "{{ engineering_loop_timer_enabled | bool }}"
+    daemon_reload: true

--- a/ansible/roles/engineering_loop/meta/main.yml
+++ b/ansible/roles/engineering_loop/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  role_name: engineering_loop
+  description: Dedicated AS215932 Engineering Loop operations-lane runtime
+  license: MIT
+  min_ansible_version: "2.14"
+
+dependencies: []

--- a/ansible/roles/engineering_loop/tasks/apply.yml
+++ b/ansible/roles/engineering_loop/tasks/apply.yml
@@ -1,0 +1,134 @@
+---
+- name: Ensure Engineering Loop packages are installed
+  ansible.builtin.apt:
+    name: "{{ engineering_loop_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install uv (Python package manager)
+  ansible.builtin.shell: |
+    set -euo pipefail
+    curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
+  args:
+    creates: /usr/local/bin/uv
+    executable: /bin/bash
+
+- name: Ensure Engineering Loop group exists
+  ansible.builtin.group:
+    name: "{{ engineering_loop_group }}"
+    state: present
+    system: true
+
+- name: Ensure Engineering Loop user exists
+  ansible.builtin.user:
+    name: "{{ engineering_loop_user }}"
+    group: "{{ engineering_loop_group }}"
+    home: "{{ engineering_loop_state_dir }}"
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+
+- name: Ensure Engineering Loop directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(engineering_loop_user) }}"
+    group: "{{ item.group | default(engineering_loop_group) }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ engineering_loop_install_dir }}", mode: "0755" }
+    - { path: "{{ engineering_loop_state_dir }}", mode: "0750" }
+    - { path: "{{ engineering_loop_workspace_dir }}", mode: "0750" }
+    - { path: "{{ engineering_loop_runs_dir }}", mode: "0750" }
+    - { path: "{{ engineering_loop_daemon_state_dir }}", mode: "0750" }
+    - { path: "{{ engineering_loop_git_askpass_path | dirname }}", owner: root, group: "{{ engineering_loop_group }}", mode: "0750" }
+
+- name: Checkout Engineering Loop runtime
+  ansible.builtin.git:
+    repo: "{{ engineering_loop_repo }}"
+    dest: "{{ engineering_loop_install_dir }}"
+    version: "{{ engineering_loop_version }}"
+    update: true
+    force: true
+  become: true
+  become_user: "{{ engineering_loop_user }}"
+  notify: restart engineering-loop timer
+
+- name: Sync Engineering Loop runtime dependencies
+  ansible.builtin.command: /usr/local/bin/uv sync --frozen
+  args:
+    chdir: "{{ engineering_loop_install_dir }}"
+  register: engineering_loop_uv_sync
+  changed_when: >-
+    engineering_loop_uv_sync.stdout != '' or
+    'Resolved' in engineering_loop_uv_sync.stderr or
+    '+' in engineering_loop_uv_sync.stderr
+  become: true
+  become_user: "{{ engineering_loop_user }}"
+  notify: restart engineering-loop timer
+
+- name: Checkout core AS215932 workspaces for daemon runs
+  ansible.builtin.git:
+    repo: "{{ item.repo }}"
+    dest: "{{ engineering_loop_workspace_dir }}/{{ item.dest }}"
+    version: "{{ item.version | default('main') }}"
+    update: true
+    force: false
+  loop: "{{ engineering_loop_workspace_repositories }}"
+  loop_control:
+    label: "{{ item.dest }}"
+  become: true
+  become_user: "{{ engineering_loop_user }}"
+
+- name: Configure git identity for loop-authored draft PR branches
+  ansible.builtin.command:
+    argv:
+      - git
+      - config
+      - --global
+      - "{{ item.key }}"
+      - "{{ item.value }}"
+  loop:
+    - { key: user.name, value: "{{ engineering_loop_git_user_name }}" }
+    - { key: user.email, value: "{{ engineering_loop_git_user_email }}" }
+  changed_when: false
+  become: true
+  become_user: "{{ engineering_loop_user }}"
+
+- name: Install Engineering Loop Git askpass helper
+  ansible.builtin.template:
+    src: git-askpass.sh.j2
+    dest: "{{ engineering_loop_git_askpass_path }}"
+    owner: root
+    group: "{{ engineering_loop_group }}"
+    mode: "0750"
+
+- name: Install Engineering Loop systemd service
+  ansible.builtin.template:
+    src: hyrule-engineering-loop.service.j2
+    dest: /etc/systemd/system/hyrule-engineering-loop.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart engineering-loop timer
+
+- name: Install Engineering Loop systemd timer
+  ansible.builtin.template:
+    src: hyrule-engineering-loop.timer.j2
+    dest: /etc/systemd/system/hyrule-engineering-loop.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart engineering-loop timer
+
+- name: Set Engineering Loop timer state
+  ansible.builtin.systemd:
+    name: hyrule-engineering-loop.timer
+    enabled: "{{ engineering_loop_timer_enabled | bool }}"
+    state: "{{ 'started' if engineering_loop_timer_enabled | bool else 'stopped' }}"
+    daemon_reload: true

--- a/ansible/roles/engineering_loop/tasks/main.yml
+++ b/ansible/roles/engineering_loop/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Validate Engineering Loop deployment inputs
+  ansible.builtin.assert:
+    that:
+      - engineering_loop_user | length > 0
+      - engineering_loop_group | length > 0
+      - engineering_loop_install_dir.startswith('/')
+      - engineering_loop_state_dir.startswith('/')
+      - engineering_loop_workspace_dir.startswith('/')
+      - engineering_loop_runs_dir.startswith('/')
+      - engineering_loop_daemon_state_dir.startswith('/')
+      - engineering_loop_repos | length == 7
+      - engineering_loop_workspace_repositories | length == 7
+      - engineering_loop_max_runs_per_day | int <= 2
+      - engineering_loop_max_cost_usd_per_day | float <= 10
+    fail_msg: >-
+      Engineering Loop production rollout must stay on the approved
+      seven-repo, low-and-slow budget profile unless a later PR explicitly
+      widens it.
+  tags: [validate, always]
+
+- name: Apply Engineering Loop runtime
+  ansible.builtin.import_tasks: apply.yml
+  when: engineering_loop_apply | bool
+  tags: [apply]

--- a/ansible/roles/engineering_loop/templates/git-askpass.sh.j2
+++ b/ansible/roles/engineering_loop/templates/git-askpass.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Managed by ansible/roles/engineering_loop.
+# GitHub HTTPS credential helper for the Engineering Loop daemon. The token is
+# supplied by the systemd EnvironmentFile rendered by Vault Agent; it is never
+# embedded into remote URLs or written to disk by this helper.
+
+case "$1" in
+  *Username*)
+    printf '%s\n' "x-access-token"
+    ;;
+  *Password*)
+    printf '%s\n' "${ENGINEERING_LOOP_GITHUB_TOKEN:-${GH_TOKEN:-}}"
+    ;;
+  *)
+    printf '\n'
+    ;;
+esac

--- a/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.service.j2
+++ b/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.service.j2
@@ -1,0 +1,47 @@
+# /etc/systemd/system/hyrule-engineering-loop.service
+# Managed by ansible/roles/engineering_loop. One timer fire runs exactly one
+# budgeted Engineering Loop cycle over the human-approved loop:approved queue.
+# Do not deploy this on ci/hyrule-infra runners; the backend executes generated
+# code in guarded worktrees.
+
+[Unit]
+Description=AS215932 Engineering Loop operations lane (one budgeted cycle)
+After=network-online.target vault-agent-engineering-loop.service
+Wants=network-online.target vault-agent-engineering-loop.service
+ConditionEnvironment=!GITHUB_ACTIONS
+
+[Service]
+Type=oneshot
+User={{ engineering_loop_user }}
+Group={{ engineering_loop_group }}
+WorkingDirectory={{ engineering_loop_install_dir }}
+Environment=HOME={{ engineering_loop_state_dir }}
+Environment=HYRULE_MODEL_POLICY_FILE={{ engineering_loop_install_dir }}/configs/loop/model-policy.production.yml
+EnvironmentFile={{ engineering_loop_env_file }}
+ExecStart={{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop daemon --once \
+{% for repo in engineering_loop_repos %}
+    --repo {{ repo }} \
+{% endfor %}
+    --workspace-root {{ engineering_loop_workspace_dir }} \
+    --output-root {{ engineering_loop_runs_dir }} \
+    --state-dir-path {{ engineering_loop_daemon_state_dir }} \
+    --memory-dir {{ engineering_loop_memory_dir }} \
+    --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
+    --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}
+TimeoutStartSec=3600
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=engineering-loop
+
+# Security hardening. The backend gets the repository worktrees and normal
+# toolchain only; production credentials are scrubbed before backend execution.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths={{ engineering_loop_install_dir }} {{ engineering_loop_state_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.timer.j2
+++ b/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.timer.j2
@@ -1,0 +1,15 @@
+# /etc/systemd/system/hyrule-engineering-loop.timer
+# Managed by ansible/roles/engineering_loop. Disabled by default until the
+# operator runs the manual canary and flips engineering_loop_timer_enabled.
+
+[Unit]
+Description=Schedule the AS215932 Engineering Loop operations lane
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=300
+Persistent=true
+Unit=hyrule-engineering-loop.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/vault_agent/templates/engineering-loop.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/engineering-loop.env.ctmpl.j2
@@ -1,0 +1,25 @@
+# /opt/engineering-loop/.env
+# Rendered by Vault Agent from kv/data/engineering-loop. Do not edit by hand.
+# Secret scope: GitHub draft-PR/issue token, model-provider keys, and run
+# notifications only. Do not add fleet SSH, Vault, XO, registrar, or app
+# runtime credentials here.
+
+{% raw %}{{ with secret "kv/data/engineering-loop" -}}
+GH_TOKEN={{ .Data.data.github_token }}
+ENGINEERING_LOOP_GITHUB_TOKEN={{ .Data.data.github_token }}
+HYRULE_CREATE_GITHUB_PR=1
+
+HYRULE_DISCORD_WEBHOOK={{ or .Data.data.discord_webhook "" }}
+HYRULE_ICINGA_URL={{ or .Data.data.icinga_url "" }}
+HYRULE_ICINGA_USER={{ or .Data.data.icinga_user "" }}
+HYRULE_ICINGA_PASSWORD={{ or .Data.data.icinga_password "" }}
+HYRULE_ICINGA_CHECK={{ or .Data.data.icinga_check "loop!engineering-loop" }}
+
+OPENROUTER_API_KEY={{ or .Data.data.openrouter_api_key "" }}
+ANTHROPIC_API_KEY={{ or .Data.data.anthropic_api_key "" }}
+OPENAI_API_KEY={{ or .Data.data.openai_api_key "" }}
+
+GIT_ASKPASS=/usr/local/lib/engineering-loop/git-askpass
+GIT_TERMINAL_PROMPT=0
+HYRULE_MODEL_POLICY_FILE=/opt/engineering-loop/configs/loop/model-policy.production.yml
+{{- end }}{% endraw %}

--- a/configs/0.5.b.0.1.4.6.b.c.0.a.2.ip6.arpa.zone
+++ b/configs/0.5.b.0.1.4.6.b.c.0.a.2.ip6.arpa.zone
@@ -19,7 +19,7 @@ $ORIGIN 0.5.b.0.1.4.6.b.c.0.a.2.ip6.arpa.
 $TTL 3600
 
 @       IN  SOA   ns1.servify.network. admin.servify.network. (
-                  2026061301 ; serial
+                  2026061401 ; serial
                   3600       ; refresh
                   900        ; retry
                   604800     ; expire
@@ -73,6 +73,9 @@ $TTL 3600
 
 ; --- :2::e0 — netproxy ---
 0.e.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0  IN  PTR  netproxy.as215932.net.
+
+; --- :2::f0 — loop ---
+0.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0  IN  PTR  loop.as215932.net.
 
 ; --- ::a — cr1-nl1 loopback ---
 a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0  IN  PTR  cr1-nl1.as215932.net.

--- a/configs/as215932.net.zone
+++ b/configs/as215932.net.zone
@@ -8,7 +8,7 @@ $ORIGIN as215932.net.
 $TTL 3600
 
 @       IN  SOA   ns1.servify.network. admin.servify.network. (
-                  2026061301 ; serial (YYYYMMDDNN)
+                  2026061401 ; serial (YYYYMMDDNN)
                   3600       ; refresh (1h)
                   900        ; retry (15m)
                   604800     ; expire (7d)
@@ -48,6 +48,7 @@ noc     IN  AAAA  2a0c:b641:b50:2::a0
 log     IN  AAAA  2a0c:b641:b50:2::b0
 ci      IN  AAAA  2a0c:b641:b50:2::d0
 netproxy IN AAAA  2a0c:b641:b50:2::e0
+loop    IN  AAAA  2a0c:b641:b50:2::f0
 
 ; --- Core routers — overlay loopback addresses ---
 cr1-nl1 IN  AAAA  2a0c:b641:b50::a

--- a/configs/servify.network.zone
+++ b/configs/servify.network.zone
@@ -5,7 +5,7 @@ $ORIGIN servify.network.
 $TTL 3600
 
 @       IN  SOA   ns1.servify.network. admin.servify.network. (
-                  2026061301 ; serial (YYYYMMDDNN)
+                  2026061401 ; serial (YYYYMMDDNN)
                   3600       ; refresh (1h)
                   900        ; retry (15m)
                   604800     ; expire (7d)
@@ -40,6 +40,7 @@ rtr     IN  AAAA  2a0c:b641:b50:2::1
 web     IN  AAAA  2a0c:b641:b50:2::30
 proxy   IN  AAAA  2a0c:b641:b50:2::40
 netproxy IN AAAA  2a0c:b641:b50:2::e0
+loop    IN  AAAA  2a0c:b641:b50:2::f0
 xoa     IN  AAAA  2a0c:b641:b50:2::70
 
 ; Xen Orchestra UI — via Caddy reverse proxy on proxy VM

--- a/configs/vault/policies/engineering-loop.hcl
+++ b/configs/vault/policies/engineering-loop.hcl
@@ -1,0 +1,15 @@
+# Vault policy for the dedicated Engineering Loop VM.
+# Bound to AppRole role `engineering-loop`; Vault Agent renders
+# /opt/engineering-loop/.env from kv/data/engineering-loop.
+#
+# Scope is deliberately narrow: GitHub issue/PR credentials, model-provider
+# keys, Discord/Icinga notification credentials. No fleet SSH, app runtime,
+# Vault, XO, registrar, or deployment secrets belong here.
+
+path "kv/data/engineering-loop" {
+  capabilities = ["read"]
+}
+
+path "kv/metadata/engineering-loop" {
+  capabilities = ["read"]
+}

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -212,7 +212,7 @@ listener beyond node_exporter for mon.
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
 | mon | TCP | 9100 | node_exporter scrape |
-| ops-prefix, vpn-clients | TCP | 22 | SSH (operator canary/bootstrap only) |
+| ops-prefix, vpn-clients, ci, noc, mon | TCP | 22 | SSH (standard infra-host access set for operator/bootstrap, CI apply, and diagnostics) |
 
 Outbound (cross-cutting): loop → github.com TCP/443 (issues, checkouts, branch
 pushes, draft PRs), loop → model provider APIs TCP/443 (through the selected

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -30,6 +30,7 @@ Last sync: 2026-06-09 (verified live with `nft list ruleset` / `pfctl -sr`).
 | vault | Debian 13 | `2a0c:b641:b50:2::c0` | — | Vault secret plane (proxied as `vault.as215932.net`) |
 | ci | Debian 13 | `2a0c:b641:b50:2::d0` | — | Self-hosted GitHub Actions runner (privileged) |
 | netproxy | Debian 13 | `2a0c:b641:b50:2::e0` | — | Hyrule Network Proxy sidecar (:8450 API, :8451 metrics/health) |
+| loop | Debian 13 | `2a0c:b641:b50:2::f0` | — | Engineering Loop operations-lane VM (draft PR automation, no fleet SSH) |
 | ci-pr | Debian 13 | `2a0c:b641:b51::c1` (customer-isolated) | — | Unprivileged PR runner (PR-Agent/Semgrep/PR CI) |
 | ns2 | Debian 13 | (off-net) `2001:41d0:304:300::7bfb` | `54.38.14.218` | secondary nameserver (OVH GRA11) |
 | cr1-nl1 | FreeBSD 14.3 | loopback `2a0c:b641:b50::a` | — | core router (Servperso NL transit) |
@@ -46,7 +47,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 |------|---------|
 | `2a0c:b641:b50::/44` | AS215932 prefix (announced) |
 | `2a0c:b641:b50::/64` | Router loopbacks (`::a` cr1-nl1, `::b` cr1-de1, `::c` cr1-ch1, `::d` rtr) |
-| `2a0c:b641:b50:2::/64` | Infra subnet (rtr `::1`, VMs `::10`–`::e0`) |
+| `2a0c:b641:b50:2::/64` | Infra subnet (rtr `::1`, VMs `::10`–`::f0`) |
 | `2a0c:b641:b50:3::/64` | VPN clients (routed via vpn VM) |
 | `2a0c:b641:b50:ffXX::/127` | WireGuard tunnel /127s (mesh links) |
 | `2a0c:b641:b51::/48` | Customer VM allocations (also `::c1` = ci-pr, the unprivileged PR runner) |
@@ -201,6 +202,24 @@ Outbound (cross-cutting): netproxy → public Internet/Tor/I2P/Yggdrasil egress
 for `direct`, `tor`, `i2p`, and `yggdrasil` request modes, subject to sidecar
 SSRF/IP policy.
 
+### loop (`2a0c:b641:b50:2::f0`)
+
+Dedicated Engineering Loop operations-lane VM. It consumes human-approved
+`loop:approved` GitHub issues and stops at draft PRs. It is not an infra deploy
+source: no fleet SSH key, no app runtime secrets, no Vault breadth, and no public
+listener beyond node_exporter for mon.
+
+| From | Proto | Port | Purpose |
+|------|-------|------|---------|
+| mon | TCP | 9100 | node_exporter scrape |
+| ops-prefix, vpn-clients | TCP | 22 | SSH (operator canary/bootstrap only) |
+
+Outbound (cross-cutting): loop → github.com TCP/443 (issues, checkouts, branch
+pushes, draft PRs), loop → model provider APIs TCP/443 (through the selected
+backend/provider auth), loop → mon TCP/5665 (Icinga passive check submission),
+loop → log TCP/6000 (Vector agent), loop → vault TCP/8200 (Vault Agent render).
+It does **not** SSH to the infra fleet.
+
 ### ci-pr (`2a0c:b641:b51::c1`) — unprivileged PR runner, customer-isolated
 
 Unprivileged self-hosted GitHub Actions runner for **untrusted PR code**
@@ -229,7 +248,7 @@ on mon is the only read path.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| every infra host (rtr, dns, api, web, proxy, mon, vpn, xoa, irc, noc, ci) | TCP | 6000 | Vector→Vector ingest from agents |
+| every infra host (rtr, dns, api, web, proxy, mon, vpn, xoa, irc, noc, ci, netproxy, loop) | TCP | 6000 | Vector→Vector ingest from agents |
 | rtr underlay (`2001:41d0:303:48a::2`) | TCP | 6000 | Vector→Vector ingest from rtr default-VRF processes; kernel routes this path via underlay |
 | mail (`2a0c:b641:b50:2::90`) | TCP | 6514 | Syslog ingest from OpenBSD `syslogd(8)` `@@host` (TCP, no UDP) |
 | cr1-nl1, cr1-de1, cr1-ch1 (loopbacks) | TCP | 6514 | Syslog ingest from FreeBSD `syslogd(8)` `@@host` (TCP, no UDP) — issue #17 |
@@ -342,7 +361,7 @@ exceptions are:
 | ns2 → log | out | 6000 tcp | Off-net Vector agent → aggregator over public IPv6 |
 | dom0 → log | out | 6000 tcp | Hypervisor Vector agent → aggregator over mgmt v4 |
 | mon → log | out | 3100, 8686 tcp | Grafana query + Vector metrics scrape |
-| noc, mon, api, web, ci → vault | out | 8200 tcp | vault-agent / health checks → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
+| noc, mon, api, web, ci, loop → vault | out | 8200 tcp | vault-agent / health checks → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
 | mon → routers | out | 22 tcp (by_ssh) | icinga2 by_ssh checks, logged in as the dedicated `monitoring` system user. Privileged plugins (jool stats) are wrapped in `sudo`/`doas`, scoped to `/usr/local/lib/nagios/plugins/*` by the role-rendered drop. |
 
 ---

--- a/scripts/ci/test-snapshot-bracket.sh
+++ b/scripts/ci/test-snapshot-bracket.sh
@@ -33,6 +33,7 @@ declare -A test_limits=(
   [logs]=noc
   [noc]=noc
   [vault]=vault
+  [engineering-loop]=loop
   [knot]=dns
   [networkd_resolved]=noc
   [mail_openbsd]=mail


### PR DESCRIPTION
## Summary

- adds a dedicated `loop` VM at `2a0c:b641:b50:2::f0` for the Engineering Loop operations lane
- adds `ansible/playbooks/engineering-loop.yml` and a new `engineering_loop` role
- wires Vault Agent rendering for `/opt/engineering-loop/.env` from `kv/data/engineering-loop`
- scopes loop secrets to GitHub/model/notification credentials only; no fleet SSH or app runtime secrets
- registers monitoring/logging/firewall/DNS/network-flow records for the new host
- adds `engineering-loop` to `apply.yml` and snapshot bracket coverage

## Dependency

Deploy after AS215932/engineering-loop#2 merges, because the loop VM service selects `configs/loop/model-policy.production.yml` from the deployed engineering-loop checkout.

## Safety / rollout

- Timer is disabled by default (`engineering_loop_timer_enabled: false`) until the operator runs the manual daemon canary.
- The loop host is not added to `ssh_allow_sources_v6`; it is not an infra deploy source.
- No app pins are changed.
- No production apply occurs from this PR alone; `apply.yml` still requires explicit dispatch and the production environment gate for live apply.

## Validation

- `scripts/ci/iac-static.sh` — passed
- `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check` — passed
- `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot` — passed

## Rollback

If the deployed loop VM misbehaves:

```bash
systemctl disable --now hyrule-engineering-loop.timer
systemctl stop hyrule-engineering-loop.service
```

Then revert this PR or run `apply.yml` with the previous known-good branch/state.
