### PR TITLE
Add FRR NETCONF/YANG audit foundation

### DIFF
--- a/.github/workflows/frr-yang-audit.yml
+++ b/.github/workflows/frr-yang-audit.yml
@@ -1,0 +1,121 @@
+---
+name: frr-yang-audit
+
+# Read-only production audit for FRR YANG/NETCONF capability evidence.
+# This workflow never opens NETCONF ports and never writes router config.
+
+on:
+  schedule:
+    - cron: '43 3 * * *'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: Ansible --limit pattern
+        type: string
+        required: true
+        default: routers
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frr-yang-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    timeout-minutes: 30
+    env:
+      ANSIBLE_FORCE_COLOR: "true"
+      ANSIBLE_PRIVATE_KEY_FILE: /var/lib/github-runner/.ssh/id_ci
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Runner preflight
+        run: scripts/ci/deploy-preflight.sh --runner
+
+      - name: Run read-only FRR YANG audit
+        working-directory: ansible
+        env:
+          LIMIT: ${{ inputs.limit || 'routers' }}
+        run: |
+          set -euo pipefail
+          ansible-playbook playbooks/frr-yang.yml \
+            --tags audit \
+            --limit "$LIMIT" \
+            -e ansible_user=ci
+
+      - name: Summarize FRR YANG audit
+        if: always()
+        run: |
+          set -euo pipefail
+          snapshots_root="ansible/generated/frr-yang-snapshots"
+          if [ ! -d "$snapshots_root" ]; then
+            echo "No FRR YANG snapshots produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          latest="$(ls -1dt "$snapshots_root"/*/ 2>/dev/null | head -1 || true)"
+          if [ -z "$latest" ]; then
+            echo "No FRR YANG snapshots produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          python3 - "$latest" >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+
+          def by_name(results, name):
+              for result in results or []:
+                  item = result.get('item') or {}
+                  if item.get('name') == name:
+                      return result
+              return {}
+
+          def has_text(result):
+              return bool((result.get('stdout') or '').strip())
+
+          print('## FRR YANG audit')
+          print()
+          print(f'Latest snapshot: `{root}`')
+          print()
+          print('| Host | Expected FRR | Observed FRR | mgmtd | sysrepoctl | Netopeer2 | TCP/830 listener | Write enabled |')
+          print('| --- | --- | --- | --- | --- | --- | --- | --- |')
+
+          for audit_file in sorted(root.glob('*/audit.json')):
+              data = json.loads(audit_file.read_text())
+              host = data.get('host', audit_file.parent.name)
+              expected = data.get('frr_version_expected') or ''
+              version_result = by_name(data.get('vtysh_results'), 'version')
+              observed = ''
+              for line in (version_result.get('stdout') or '').splitlines():
+                  if 'FRRouting' in line or line.lower().startswith('frr version'):
+                      observed = line.strip()
+                      break
+              mgmtd = 'yes' if by_name(data.get('vtysh_results'), 'mgmt_backend_adapter_all').get('rc') == 0 else 'no/unsupported'
+              executable_paths = by_name(data.get('capability_results'), 'executable_paths').get('stdout') or ''
+              sysrepoctl = 'yes' if 'sysrepoctl\t' in executable_paths and 'sysrepoctl\tnot-found' not in executable_paths else 'no'
+              netopeer2 = 'yes' if 'netopeer2-server\t' in executable_paths and 'netopeer2-server\tnot-found' not in executable_paths else 'no'
+              package_results = data.get('package_results') or []
+              listener_result = {}
+              for result in package_results:
+                  name = (result.get('item') or {}).get('name', '')
+                  if name.endswith('_netconf_listeners'):
+                      listener_result = result
+                      break
+              listener = 'yes' if has_text(listener_result) else 'no'
+              write_enabled = 'yes' if data.get('frr_netconf_write_enabled') else 'no'
+              print(f'| `{host}` | `{expected}` | `{observed}` | {mgmtd} | {sysrepoctl} | {netopeer2} | {listener} | {write_enabled} |')
+          PY
+
+      - name: Upload FRR YANG audit snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frr-yang-audit-snapshots
+          path: ansible/generated/frr-yang-snapshots/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/iac-tests.yml
+++ b/.github/workflows/iac-tests.yml
@@ -6,6 +6,7 @@ name: iac-tests
 #   Tier 0  static-iac, ansible-idempotency   unprivileged ci-pr   required (via iac-gate)
 #   Tier 1  batfish                            privileged   ci      trusted-only (dispatch/nightly/var)
 #   Tier 2  containerlab-frr                   privileged   ci      trusted-only (dispatch/nightly/var)
+#   Tier 2  netconf-yang-lab                   privileged   ci      trusted-only (dispatch/nightly/var)
 #
 # Tier 0 runs untrusted PR code, so it lives on the unprivileged hyrule-public-pr
 # runner. Tiers 1-2 spin up Batfish / Containerlab (heavy lab infra + Docker) on
@@ -183,11 +184,34 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # ---- Tier 2: Containerlab NETCONF/YANG (privileged, trusted-only) ----
+  netconf-yang-lab:
+    runs-on: [self-hosted, linux, x64, hyrule-infra]
+    needs: [changes, static-iac]
+    if: ${{ needs.changes.outputs.iac_changed == 'true' && (github.event_name == 'workflow_dispatch' || vars.ENABLE_NETCONF_YANG_TESTS == 'true') }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Containerlab NETCONF/YANG smoke test
+        run: scripts/ci/containerlab-netconf-yang-test.sh
+
+      - name: Upload NETCONF/YANG lab artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4.6.0
+        with:
+          name: netconf-yang-lab-artifacts
+          path: |
+            tests/iac/containerlab/_artifacts/netconf-yang/**
+            clab-as215932-netconf/**
+          if-no-files-found: ignore
+          retention-days: 14
+
   # ---- Aggregating gate: the single REQUIRED context --------------------
   iac-gate:
     name: iac-gate
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    needs: [changes, static-iac, ansible-idempotency, batfish, containerlab-frr]
+    needs: [changes, static-iac, ansible-idempotency, batfish, containerlab-frr, netconf-yang-lab]
     if: always()
     timeout-minutes: 5
     steps:
@@ -199,6 +223,7 @@ jobs:
           ANSIBLE_IDEMPOTENCY: ${{ needs.ansible-idempotency.result }}
           BATFISH: ${{ needs.batfish.result }}
           CONTAINERLAB: ${{ needs.containerlab-frr.result }}
+          NETCONF_YANG_LAB: ${{ needs.netconf-yang-lab.result }}
         run: |
           set -euo pipefail
           echo "Tier results:"
@@ -208,6 +233,7 @@ jobs:
           echo "  ansible-idempotency = ${ANSIBLE_IDEMPOTENCY}"
           echo "  batfish (trusted)   = ${BATFISH}"
           echo "  containerlab (trust)= ${CONTAINERLAB}"
+          echo "  netconf-yang (trust)= ${NETCONF_YANG_LAB}"
           fail=0
 
           if [ "${CHANGES}" != "success" ]; then
@@ -229,7 +255,7 @@ jobs:
           fi
 
           # Trusted lab tiers may be skipped on PRs, but must never fail.
-          for pair in "batfish:${BATFISH}" "containerlab-frr:${CONTAINERLAB}"; do
+          for pair in "batfish:${BATFISH}" "containerlab-frr:${CONTAINERLAB}" "netconf-yang-lab:${NETCONF_YANG_LAB}"; do
             name="${pair%%:*}"; res="${pair##*:}"
             if [ "${res}" != "success" ] && [ "${res}" != "skipped" ]; then
               echo "::error::lab tier ${name} reported a failure (${res})"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ ansible/generated/**/knot.conf
 # Deploy-bracket Icinga snapshots are runtime state captured on the runner during
 # an apply (network-operations#149), not desired state — never commit them.
 ansible/generated/snapshots/
+
+# FRR NETCONF/YANG audit snapshots are observed router state, not desired state.
+ansible/generated/frr-yang-snapshots/

--- a/ansible/generated/cr1-ch1/frr-policy.conf
+++ b/ansible/generated/cr1-ch1/frr-policy.conf
@@ -1,0 +1,52 @@
+! Generated FRR policy parity artifact for cr1-ch1
+! Source: configs/frr-policy-intent.yml
+! Not deployed directly; configs/<host>/frr.conf remains canonical.
+!
+ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44
+!
+bgp as-path access-list 1 seq 5 deny _215932_
+bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_
+bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_
+bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_
+bgp as-path access-list 1 seq 25 deny _6553[0-5]_
+bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_
+bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_
+bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_
+bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_
+bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_
+bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_
+bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_
+bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_
+bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_
+bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
+bgp as-path access-list 1 seq 100 permit ^.{0,200}$
+!
+route-map IXP-IN permit 10
+ match as-path 1
+ set local-preference 200
+exit
+!
+route-map IXP-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+route-map TRANSIT-IN permit 10
+ match as-path 1
+exit
+!
+route-map TRANSIT-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+! Neighbor route-map attachments for address-family ipv6 unicast
+neighbor 2001:7f8:d9:1::1 route-map IXP-IN in
+neighbor 2001:7f8:d9:1::1 route-map IXP-OUT out
+neighbor 2001:7f8:d9:1::2 route-map IXP-IN in
+neighbor 2001:7f8:d9:1::2 route-map IXP-OUT out
+neighbor 2001:7f8:d9:1::3 route-map IXP-IN in
+neighbor 2001:7f8:d9:1::3 route-map IXP-OUT out
+neighbor 2001:7f8:d9:1::4 route-map IXP-IN in
+neighbor 2001:7f8:d9:1::4 route-map IXP-OUT out
+neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-IN in
+neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-OUT out
+!

--- a/ansible/generated/cr1-ch1/frr-policy.json
+++ b/ansible/generated/cr1-ch1/frr-policy.json
@@ -1,0 +1,167 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "pattern": "_215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "pattern": "_655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "pattern": "_6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "pattern": "_[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "pattern": "_4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "pattern": "^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "host": "cr1-ch1",
+  "ipv6_prefix_lists": {
+    "AS215932v6-out": [
+      {
+        "action": "permit",
+        "seq": 5,
+        "value": "2a0c:b641:b50::/44"
+      }
+    ]
+  },
+  "neighbor_route_maps": {
+    "2001:7f8:d9:1::1": {
+      "in": "IXP-IN",
+      "out": "IXP-OUT"
+    },
+    "2001:7f8:d9:1::2": {
+      "in": "IXP-IN",
+      "out": "IXP-OUT"
+    },
+    "2001:7f8:d9:1::3": {
+      "in": "IXP-IN",
+      "out": "IXP-OUT"
+    },
+    "2001:7f8:d9:1::4": {
+      "in": "IXP-IN",
+      "out": "IXP-OUT"
+    },
+    "2a09:4c0:100:2d88::8bfa": {
+      "in": "TRANSIT-IN",
+      "out": "TRANSIT-OUT"
+    }
+  },
+  "route_maps": {
+    "IXP-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": [
+          "local-preference 200"
+        ]
+      }
+    ],
+    "IXP-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ]
+  },
+  "schema_version": 1
+}

--- a/ansible/generated/cr1-ch1/frr-semantic.json
+++ b/ansible/generated/cr1-ch1/frr-semantic.json
@@ -1,0 +1,657 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_215932_",
+        "raw": "bgp as-path access-list 1 seq 5 deny _215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_655[0-2][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_6553[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 25 deny _6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_[1-3][0-9]{10}_",
+        "raw": "bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4[01][0-9]{9}_",
+        "raw": "bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "raw": "bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "raw": "bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "raw": "bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "raw": "bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "raw": "bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "raw": "bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949672[0-8][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496729[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 75 deny _429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "name": "1",
+        "pattern": "^.{0,200}$",
+        "raw": "bgp as-path access-list 1 seq 100 permit ^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "bgp": {
+    "instances": [
+      {
+        "address_families": {
+          "ipv6 unicast": {
+            "neighbors": {
+              "2001:7f8:d9:1::1": {
+                "activate": true,
+                "address": "2001:7f8:d9:1::1",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2001:7f8:d9:1::1 activate",
+                  "neighbor 2001:7f8:d9:1::1 route-map IXP-IN in",
+                  "neighbor 2001:7f8:d9:1::1 route-map IXP-OUT out",
+                  "neighbor 2001:7f8:d9:1::1 soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "IXP-IN",
+                  "out": "IXP-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2001:7f8:d9:1::2": {
+                "activate": true,
+                "address": "2001:7f8:d9:1::2",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2001:7f8:d9:1::2 activate",
+                  "neighbor 2001:7f8:d9:1::2 route-map IXP-IN in",
+                  "neighbor 2001:7f8:d9:1::2 route-map IXP-OUT out",
+                  "neighbor 2001:7f8:d9:1::2 soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "IXP-IN",
+                  "out": "IXP-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2001:7f8:d9:1::3": {
+                "activate": true,
+                "address": "2001:7f8:d9:1::3",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2001:7f8:d9:1::3 activate",
+                  "neighbor 2001:7f8:d9:1::3 route-map IXP-IN in",
+                  "neighbor 2001:7f8:d9:1::3 route-map IXP-OUT out",
+                  "neighbor 2001:7f8:d9:1::3 soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "IXP-IN",
+                  "out": "IXP-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2001:7f8:d9:1::4": {
+                "activate": true,
+                "address": "2001:7f8:d9:1::4",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2001:7f8:d9:1::4 activate",
+                  "neighbor 2001:7f8:d9:1::4 route-map IXP-IN in",
+                  "neighbor 2001:7f8:d9:1::4 route-map IXP-OUT out",
+                  "neighbor 2001:7f8:d9:1::4 soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "IXP-IN",
+                  "out": "IXP-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a09:4c0:100:2d88::8bfa": {
+                "activate": true,
+                "address": "2a09:4c0:100:2d88::8bfa",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2a09:4c0:100:2d88::8bfa activate",
+                  "neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-IN in",
+                  "neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-OUT out",
+                  "neighbor 2a09:4c0:100:2d88::8bfa soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "TRANSIT-IN",
+                  "out": "TRANSIT-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::a": {
+                "activate": true,
+                "address": "2a0c:b641:b50::a",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::a activate",
+                  "neighbor 2a0c:b641:b50::a next-hop-self",
+                  "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::b": {
+                "activate": true,
+                "address": "2a0c:b641:b50::b",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::b activate",
+                  "neighbor 2a0c:b641:b50::b next-hop-self",
+                  "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::d": {
+                "activate": true,
+                "address": "2a0c:b641:b50::d",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::d activate",
+                  "neighbor 2a0c:b641:b50::d next-hop-self",
+                  "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              }
+            },
+            "networks": [
+              "2a0c:b641:b50::/44"
+            ],
+            "raw_commands": [
+              "neighbor 2001:7f8:d9:1::1 activate",
+              "neighbor 2001:7f8:d9:1::1 route-map IXP-IN in",
+              "neighbor 2001:7f8:d9:1::1 route-map IXP-OUT out",
+              "neighbor 2001:7f8:d9:1::1 soft-reconfiguration inbound",
+              "neighbor 2001:7f8:d9:1::2 activate",
+              "neighbor 2001:7f8:d9:1::2 route-map IXP-IN in",
+              "neighbor 2001:7f8:d9:1::2 route-map IXP-OUT out",
+              "neighbor 2001:7f8:d9:1::2 soft-reconfiguration inbound",
+              "neighbor 2001:7f8:d9:1::3 activate",
+              "neighbor 2001:7f8:d9:1::3 route-map IXP-IN in",
+              "neighbor 2001:7f8:d9:1::3 route-map IXP-OUT out",
+              "neighbor 2001:7f8:d9:1::3 soft-reconfiguration inbound",
+              "neighbor 2001:7f8:d9:1::4 activate",
+              "neighbor 2001:7f8:d9:1::4 route-map IXP-IN in",
+              "neighbor 2001:7f8:d9:1::4 route-map IXP-OUT out",
+              "neighbor 2001:7f8:d9:1::4 soft-reconfiguration inbound",
+              "neighbor 2a09:4c0:100:2d88::8bfa activate",
+              "neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-IN in",
+              "neighbor 2a09:4c0:100:2d88::8bfa route-map TRANSIT-OUT out",
+              "neighbor 2a09:4c0:100:2d88::8bfa soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::a activate",
+              "neighbor 2a0c:b641:b50::a next-hop-self",
+              "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::b activate",
+              "neighbor 2a0c:b641:b50::b next-hop-self",
+              "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::d activate",
+              "neighbor 2a0c:b641:b50::d next-hop-self",
+              "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound",
+              "network 2a0c:b641:b50::/44"
+            ]
+          }
+        },
+        "asn": 215932,
+        "flags": [
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "neighbors": {
+          "2001:7f8:d9:1::1": {
+            "address": "2001:7f8:d9:1::1",
+            "description": "SBIX-RS1",
+            "enforce_first_as": false,
+            "raw_commands": [
+              "neighbor 2001:7f8:d9:1::1 description SBIX-RS1",
+              "neighbor 2001:7f8:d9:1::1 remote-as 56755",
+              "no neighbor 2001:7f8:d9:1::1 enforce-first-as"
+            ],
+            "remote_as": 56755,
+            "update_source": null
+          },
+          "2001:7f8:d9:1::2": {
+            "address": "2001:7f8:d9:1::2",
+            "description": "SBIX-RS2",
+            "enforce_first_as": false,
+            "raw_commands": [
+              "neighbor 2001:7f8:d9:1::2 description SBIX-RS2",
+              "neighbor 2001:7f8:d9:1::2 remote-as 56755",
+              "no neighbor 2001:7f8:d9:1::2 enforce-first-as"
+            ],
+            "remote_as": 56755,
+            "update_source": null
+          },
+          "2001:7f8:d9:1::3": {
+            "address": "2001:7f8:d9:1::3",
+            "description": "SBIX-RS3",
+            "enforce_first_as": false,
+            "raw_commands": [
+              "neighbor 2001:7f8:d9:1::3 description SBIX-RS3",
+              "neighbor 2001:7f8:d9:1::3 remote-as 56755",
+              "no neighbor 2001:7f8:d9:1::3 enforce-first-as"
+            ],
+            "remote_as": 56755,
+            "update_source": null
+          },
+          "2001:7f8:d9:1::4": {
+            "address": "2001:7f8:d9:1::4",
+            "description": "SBIX-RS4",
+            "enforce_first_as": false,
+            "raw_commands": [
+              "neighbor 2001:7f8:d9:1::4 description SBIX-RS4",
+              "neighbor 2001:7f8:d9:1::4 remote-as 56755",
+              "no neighbor 2001:7f8:d9:1::4 enforce-first-as"
+            ],
+            "remote_as": 56755,
+            "update_source": null
+          },
+          "2a09:4c0:100:2d88::8bfa": {
+            "address": "2a09:4c0:100:2d88::8bfa",
+            "description": "Securebit-Transit-v6",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a09:4c0:100:2d88::8bfa description Securebit-Transit-v6",
+              "neighbor 2a09:4c0:100:2d88::8bfa remote-as 58057",
+              "neighbor 2a09:4c0:100:2d88::8bfa update-source 2a09:4c0:100:2d88::8898"
+            ],
+            "remote_as": 58057,
+            "update_source": "2a09:4c0:100:2d88::8898"
+          },
+          "2a0c:b641:b50::a": {
+            "address": "2a0c:b641:b50::a",
+            "description": "cr1.nl1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::a description cr1.nl1",
+              "neighbor 2a0c:b641:b50::a remote-as 215932",
+              "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::c"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::c"
+          },
+          "2a0c:b641:b50::b": {
+            "address": "2a0c:b641:b50::b",
+            "description": "cr1.de1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::b description cr1.de1",
+              "neighbor 2a0c:b641:b50::b remote-as 215932",
+              "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::c"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::c"
+          },
+          "2a0c:b641:b50::d": {
+            "address": "2a0c:b641:b50::d",
+            "description": "rtr.ovh1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+              "neighbor 2a0c:b641:b50::d remote-as 215932",
+              "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::c"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::c"
+          }
+        },
+        "raw_commands": [
+          "bgp router-id 3.3.3.3",
+          "neighbor 2001:7f8:d9:1::1 description SBIX-RS1",
+          "neighbor 2001:7f8:d9:1::1 remote-as 56755",
+          "neighbor 2001:7f8:d9:1::2 description SBIX-RS2",
+          "neighbor 2001:7f8:d9:1::2 remote-as 56755",
+          "neighbor 2001:7f8:d9:1::3 description SBIX-RS3",
+          "neighbor 2001:7f8:d9:1::3 remote-as 56755",
+          "neighbor 2001:7f8:d9:1::4 description SBIX-RS4",
+          "neighbor 2001:7f8:d9:1::4 remote-as 56755",
+          "neighbor 2a09:4c0:100:2d88::8bfa description Securebit-Transit-v6",
+          "neighbor 2a09:4c0:100:2d88::8bfa remote-as 58057",
+          "neighbor 2a09:4c0:100:2d88::8bfa update-source 2a09:4c0:100:2d88::8898",
+          "neighbor 2a0c:b641:b50::a description cr1.nl1",
+          "neighbor 2a0c:b641:b50::a remote-as 215932",
+          "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::c",
+          "neighbor 2a0c:b641:b50::b description cr1.de1",
+          "neighbor 2a0c:b641:b50::b remote-as 215932",
+          "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::c",
+          "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+          "neighbor 2a0c:b641:b50::d remote-as 215932",
+          "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::c",
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check",
+          "no neighbor 2001:7f8:d9:1::1 enforce-first-as",
+          "no neighbor 2001:7f8:d9:1::2 enforce-first-as",
+          "no neighbor 2001:7f8:d9:1::3 enforce-first-as",
+          "no neighbor 2001:7f8:d9:1::4 enforce-first-as"
+        ],
+        "router_id": "3.3.3.3",
+        "vrf": "default"
+      }
+    ]
+  },
+  "frr_version": "10.5.3",
+  "host": "cr1-ch1",
+  "hostname": "cr1-ch1.as215932.net",
+  "interfaces": {
+    "lo0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50::c/128"
+      ],
+      "name": "lo0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [],
+        "passive": true
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50::c/128",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 passive"
+      ],
+      "vrf": "default"
+    },
+    "wg0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff06::/127"
+      ],
+      "name": "wg0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff06::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg1": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff07::1/127"
+      ],
+      "name": "wg1",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff07::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg2": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff08::1/127"
+      ],
+      "name": "wg2",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff08::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    }
+  },
+  "logging": [
+    "log syslog informational"
+  ],
+  "ospf6": {
+    "instances": [
+      {
+        "raw_commands": [
+          "ospf6 router-id 3.3.3.3"
+        ],
+        "redistribute": [],
+        "router_id": "3.3.3.3",
+        "vrf": "default"
+      }
+    ]
+  },
+  "prefix_lists": {
+    "ipv4": {},
+    "ipv6": {
+      "AS215932v6-out": [
+        {
+          "action": "permit",
+          "name": "AS215932v6-out",
+          "raw": "ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44",
+          "seq": 5,
+          "value": "2a0c:b641:b50::/44"
+        }
+      ]
+    }
+  },
+  "route_maps": {
+    "IXP-IN": {
+      "name": "IXP-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1",
+            "set local-preference 200"
+          ],
+          "seq": 10,
+          "sets": [
+            "local-preference 200"
+          ]
+        }
+      }
+    },
+    "IXP-OUT": {
+      "name": "IXP-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-IN": {
+      "name": "TRANSIT-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-OUT": {
+      "name": "TRANSIT-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "services": [
+    "service integrated-vtysh-config"
+  ],
+  "source": "configs/cr1-ch1/frr.conf",
+  "static_routes": {
+    "default": [
+      {
+        "afi": "ipv6",
+        "next_hop": "2a09:4c0:100:2d88::8bfe",
+        "prefix": "2001:41d0:303:48a::2/128",
+        "raw": "ipv6 route 2001:41d0:303:48a::2/128 2a09:4c0:100:2d88::8bfe"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a09:4c0:100:2d88::8bfe",
+        "prefix": "2a0c:b640:10::213/128",
+        "raw": "ipv6 route 2a0c:b640:10::213/128 2a09:4c0:100:2d88::8bfe"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a09:4c0:100:2d88::8bfe",
+        "prefix": "2a0c:b640:8:69::1/128",
+        "raw": "ipv6 route 2a0c:b640:8:69::1/128 2a09:4c0:100:2d88::8bfe"
+      },
+      {
+        "afi": "ipv6",
+        "distance_or_table": "254",
+        "next_hop": "Null0",
+        "prefix": "2a0c:b641:b50::/44",
+        "raw": "ipv6 route 2a0c:b641:b50::/44 Null0 254"
+      }
+    ]
+  },
+  "vrfs": {}
+}

--- a/ansible/generated/cr1-de1/frr-policy.conf
+++ b/ansible/generated/cr1-de1/frr-policy.conf
@@ -1,0 +1,57 @@
+! Generated FRR policy parity artifact for cr1-de1
+! Source: configs/frr-policy-intent.yml
+! Not deployed directly; configs/<host>/frr.conf remains canonical.
+!
+ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44
+!
+bgp as-path access-list 1 seq 5 deny _215932_
+bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_
+bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_
+bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_
+bgp as-path access-list 1 seq 25 deny _6553[0-5]_
+bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_
+bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_
+bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_
+bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_
+bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_
+bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_
+bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_
+bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_
+bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_
+bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
+bgp as-path access-list 1 seq 100 permit ^.{0,200}$
+bgp as-path access-list 24961 permit _24961_
+!
+route-map IXP-IN permit 10
+ match as-path 1
+exit
+!
+route-map IXP-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+route-map TRANSIT-IN permit 5
+ match as-path 24961
+ set local-preference 80
+ on-match next
+exit
+!
+route-map TRANSIT-IN permit 10
+ match as-path 1
+exit
+!
+route-map TRANSIT-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+route-map TRANSIT-OUT-PREPEND-3X permit 10
+ match ipv6 address prefix-list AS215932v6-out
+ set as-path prepend 215932 215932 215932
+exit
+!
+! Neighbor route-map attachments for address-family ipv6 unicast
+neighbor 2a0c:b640:10::ffff route-map TRANSIT-IN in
+neighbor 2a0c:b640:10::ffff route-map TRANSIT-OUT-PREPEND-3X out
+neighbor 2a0c:b641:870::ffff route-map TRANSIT-IN in
+neighbor 2a0c:b641:870::ffff route-map TRANSIT-OUT-PREPEND-3X out
+!

--- a/ansible/generated/cr1-de1/frr-policy.json
+++ b/ansible/generated/cr1-de1/frr-policy.json
@@ -1,0 +1,185 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "pattern": "_215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "pattern": "_655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "pattern": "_6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "pattern": "_[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "pattern": "_4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "pattern": "^.{0,200}$",
+        "seq": 100
+      }
+    ],
+    "24961": [
+      {
+        "action": "permit",
+        "pattern": "_24961_"
+      }
+    ]
+  },
+  "host": "cr1-de1",
+  "ipv6_prefix_lists": {
+    "AS215932v6-out": [
+      {
+        "action": "permit",
+        "seq": 5,
+        "value": "2a0c:b641:b50::/44"
+      }
+    ]
+  },
+  "neighbor_route_maps": {
+    "2a0c:b640:10::ffff": {
+      "in": "TRANSIT-IN",
+      "out": "TRANSIT-OUT-PREPEND-3X"
+    },
+    "2a0c:b641:870::ffff": {
+      "in": "TRANSIT-IN",
+      "out": "TRANSIT-OUT-PREPEND-3X"
+    }
+  },
+  "route_maps": {
+    "IXP-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "IXP-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 24961"
+        ],
+        "on_match": [
+          "next"
+        ],
+        "seq": 5,
+        "sets": [
+          "local-preference 80"
+        ]
+      },
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-OUT-PREPEND-3X": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": [
+          "as-path prepend 215932 215932 215932"
+        ]
+      }
+    ]
+  },
+  "schema_version": 1
+}

--- a/ansible/generated/cr1-de1/frr-semantic.json
+++ b/ansible/generated/cr1-de1/frr-semantic.json
@@ -1,0 +1,588 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_215932_",
+        "raw": "bgp as-path access-list 1 seq 5 deny _215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_655[0-2][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_6553[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 25 deny _6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_[1-3][0-9]{10}_",
+        "raw": "bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4[01][0-9]{9}_",
+        "raw": "bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "raw": "bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "raw": "bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "raw": "bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "raw": "bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "raw": "bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "raw": "bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949672[0-8][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496729[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 75 deny _429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "name": "1",
+        "pattern": "^.{0,200}$",
+        "raw": "bgp as-path access-list 1 seq 100 permit ^.{0,200}$",
+        "seq": 100
+      }
+    ],
+    "24961": [
+      {
+        "action": "permit",
+        "name": "24961",
+        "pattern": "_24961_",
+        "raw": "bgp as-path access-list 24961 permit _24961_",
+        "seq": null
+      }
+    ]
+  },
+  "bgp": {
+    "instances": [
+      {
+        "address_families": {
+          "ipv6 unicast": {
+            "neighbors": {
+              "2a0c:b640:10::ffff": {
+                "activate": true,
+                "address": "2a0c:b640:10::ffff",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2a0c:b640:10::ffff activate",
+                  "neighbor 2a0c:b640:10::ffff route-map TRANSIT-IN in",
+                  "neighbor 2a0c:b640:10::ffff route-map TRANSIT-OUT-PREPEND-3X out",
+                  "neighbor 2a0c:b640:10::ffff soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "TRANSIT-IN",
+                  "out": "TRANSIT-OUT-PREPEND-3X"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:870::ffff": {
+                "activate": true,
+                "address": "2a0c:b641:870::ffff",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:870::ffff activate",
+                  "neighbor 2a0c:b641:870::ffff route-map TRANSIT-IN in",
+                  "neighbor 2a0c:b641:870::ffff route-map TRANSIT-OUT-PREPEND-3X out",
+                  "neighbor 2a0c:b641:870::ffff soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "TRANSIT-IN",
+                  "out": "TRANSIT-OUT-PREPEND-3X"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::a": {
+                "activate": true,
+                "address": "2a0c:b641:b50::a",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::a activate",
+                  "neighbor 2a0c:b641:b50::a next-hop-self",
+                  "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::c": {
+                "activate": true,
+                "address": "2a0c:b641:b50::c",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::c activate",
+                  "neighbor 2a0c:b641:b50::c next-hop-self",
+                  "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::d": {
+                "activate": true,
+                "address": "2a0c:b641:b50::d",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::d activate",
+                  "neighbor 2a0c:b641:b50::d next-hop-self",
+                  "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              }
+            },
+            "networks": [
+              "2a0c:b641:b50::/44"
+            ],
+            "raw_commands": [
+              "neighbor 2a0c:b640:10::ffff activate",
+              "neighbor 2a0c:b640:10::ffff route-map TRANSIT-IN in",
+              "neighbor 2a0c:b640:10::ffff route-map TRANSIT-OUT-PREPEND-3X out",
+              "neighbor 2a0c:b640:10::ffff soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:870::ffff activate",
+              "neighbor 2a0c:b641:870::ffff route-map TRANSIT-IN in",
+              "neighbor 2a0c:b641:870::ffff route-map TRANSIT-OUT-PREPEND-3X out",
+              "neighbor 2a0c:b641:870::ffff soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::a activate",
+              "neighbor 2a0c:b641:b50::a next-hop-self",
+              "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::c activate",
+              "neighbor 2a0c:b641:b50::c next-hop-self",
+              "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::d activate",
+              "neighbor 2a0c:b641:b50::d next-hop-self",
+              "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound",
+              "network 2a0c:b641:b50::/44"
+            ]
+          }
+        },
+        "asn": 215932,
+        "flags": [
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "neighbors": {
+          "2a0c:b640:10::ffff": {
+            "address": "2a0c:b640:10::ffff",
+            "description": "Primary-Transit-AS34872",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b640:10::ffff description Primary-Transit-AS34872",
+              "neighbor 2a0c:b640:10::ffff remote-as 34872",
+              "neighbor 2a0c:b640:10::ffff update-source 2a0c:b640:10::213"
+            ],
+            "remote_as": 34872,
+            "update_source": "2a0c:b640:10::213"
+          },
+          "2a0c:b641:870::ffff": {
+            "address": "2a0c:b641:870::ffff",
+            "description": "Extra-Transit-AS210233",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:870::ffff description Extra-Transit-AS210233",
+              "neighbor 2a0c:b641:870::ffff remote-as 210233"
+            ],
+            "remote_as": 210233,
+            "update_source": null
+          },
+          "2a0c:b641:b50::a": {
+            "address": "2a0c:b641:b50::a",
+            "description": "cr1.nl1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::a description cr1.nl1",
+              "neighbor 2a0c:b641:b50::a remote-as 215932",
+              "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::b"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::b"
+          },
+          "2a0c:b641:b50::c": {
+            "address": "2a0c:b641:b50::c",
+            "description": "cr1.ch1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::c description cr1.ch1",
+              "neighbor 2a0c:b641:b50::c remote-as 215932",
+              "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::b"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::b"
+          },
+          "2a0c:b641:b50::d": {
+            "address": "2a0c:b641:b50::d",
+            "description": "rtr.ovh1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+              "neighbor 2a0c:b641:b50::d remote-as 215932",
+              "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::b"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::b"
+          }
+        },
+        "raw_commands": [
+          "bgp router-id 2.2.2.2",
+          "neighbor 2a0c:b640:10::ffff description Primary-Transit-AS34872",
+          "neighbor 2a0c:b640:10::ffff remote-as 34872",
+          "neighbor 2a0c:b640:10::ffff update-source 2a0c:b640:10::213",
+          "neighbor 2a0c:b641:870::ffff description Extra-Transit-AS210233",
+          "neighbor 2a0c:b641:870::ffff remote-as 210233",
+          "neighbor 2a0c:b641:b50::a description cr1.nl1",
+          "neighbor 2a0c:b641:b50::a remote-as 215932",
+          "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::b",
+          "neighbor 2a0c:b641:b50::c description cr1.ch1",
+          "neighbor 2a0c:b641:b50::c remote-as 215932",
+          "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::b",
+          "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+          "neighbor 2a0c:b641:b50::d remote-as 215932",
+          "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::b",
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "router_id": "2.2.2.2",
+        "vrf": "default"
+      }
+    ]
+  },
+  "frr_version": "10.4.1",
+  "host": "cr1-de1",
+  "hostname": "cr1-de1.servify.network",
+  "interfaces": {
+    "lo0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50::b/128"
+      ],
+      "name": "lo0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [],
+        "passive": true
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50::b/128",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 passive"
+      ],
+      "vrf": "default"
+    },
+    "wg0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff00::1/127"
+      ],
+      "name": "wg0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff00::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg1": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff05::/127"
+      ],
+      "name": "wg1",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff05::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg2": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff08::/127"
+      ],
+      "name": "wg2",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff08::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    }
+  },
+  "logging": [
+    "log syslog informational"
+  ],
+  "ospf6": {
+    "instances": [
+      {
+        "raw_commands": [
+          "ospf6 router-id 2.2.2.2"
+        ],
+        "redistribute": [],
+        "router_id": "2.2.2.2",
+        "vrf": "default"
+      }
+    ]
+  },
+  "prefix_lists": {
+    "ipv4": {},
+    "ipv6": {
+      "AS215932v6-out": [
+        {
+          "action": "permit",
+          "name": "AS215932v6-out",
+          "raw": "ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44",
+          "seq": 5,
+          "value": "2a0c:b641:b50::/44"
+        }
+      ]
+    }
+  },
+  "route_maps": {
+    "IXP-IN": {
+      "name": "IXP-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "IXP-OUT": {
+      "name": "IXP-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-IN": {
+      "name": "TRANSIT-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        },
+        "5": {
+          "action": "permit",
+          "matches": [
+            "as-path 24961"
+          ],
+          "on_match": [
+            "next"
+          ],
+          "raw_commands": [
+            "match as-path 24961",
+            "on-match next",
+            "set local-preference 80"
+          ],
+          "seq": 5,
+          "sets": [
+            "local-preference 80"
+          ]
+        }
+      }
+    },
+    "TRANSIT-OUT": {
+      "name": "TRANSIT-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-OUT-PREPEND-3X": {
+      "name": "TRANSIT-OUT-PREPEND-3X",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out",
+            "set as-path prepend 215932 215932 215932"
+          ],
+          "seq": 10,
+          "sets": [
+            "as-path prepend 215932 215932 215932"
+          ]
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "services": [
+    "service integrated-vtysh-config"
+  ],
+  "source": "configs/cr1-de1/frr.conf",
+  "static_routes": {
+    "default": [
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:10::ffff",
+        "prefix": "2001:41d0:303:48a::2/128",
+        "raw": "ipv6 route 2001:41d0:303:48a::2/128 2a0c:b640:10::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:10::ffff",
+        "prefix": "2a09:4c0:100:2d88::8898/128",
+        "raw": "ipv6 route 2a09:4c0:100:2d88::8898/128 2a0c:b640:10::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:10::ffff",
+        "prefix": "2a0c:b640:8:69::1/128",
+        "raw": "ipv6 route 2a0c:b640:8:69::1/128 2a0c:b640:10::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "distance_or_table": "254",
+        "next_hop": "Null0",
+        "prefix": "2a0c:b641:b50::/44",
+        "raw": "ipv6 route 2a0c:b641:b50::/44 Null0 254"
+      }
+    ]
+  },
+  "vrfs": {}
+}

--- a/ansible/generated/cr1-nl1/frr-policy.conf
+++ b/ansible/generated/cr1-nl1/frr-policy.conf
@@ -1,0 +1,43 @@
+! Generated FRR policy parity artifact for cr1-nl1
+! Source: configs/frr-policy-intent.yml
+! Not deployed directly; configs/<host>/frr.conf remains canonical.
+!
+ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44
+!
+bgp as-path access-list 1 seq 5 deny _215932_
+bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_
+bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_
+bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_
+bgp as-path access-list 1 seq 25 deny _6553[0-5]_
+bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_
+bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_
+bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_
+bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_
+bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_
+bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_
+bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_
+bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_
+bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_
+bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
+bgp as-path access-list 1 seq 100 permit ^.{0,200}$
+!
+route-map IXP-IN permit 10
+ match as-path 1
+exit
+!
+route-map IXP-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+route-map TRANSIT-IN permit 10
+ match as-path 1
+exit
+!
+route-map TRANSIT-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!
+! Neighbor route-map attachments for address-family ipv6 unicast
+neighbor 2a0c:b640:8::ffff route-map TRANSIT-IN in
+neighbor 2a0c:b640:8::ffff route-map TRANSIT-OUT out
+!

--- a/ansible/generated/cr1-nl1/frr-policy.json
+++ b/ansible/generated/cr1-nl1/frr-policy.json
@@ -1,0 +1,149 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "pattern": "_215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "pattern": "_655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "pattern": "_6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "pattern": "_[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "pattern": "_4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "pattern": "^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "host": "cr1-nl1",
+  "ipv6_prefix_lists": {
+    "AS215932v6-out": [
+      {
+        "action": "permit",
+        "seq": 5,
+        "value": "2a0c:b641:b50::/44"
+      }
+    ]
+  },
+  "neighbor_route_maps": {
+    "2a0c:b640:8::ffff": {
+      "in": "TRANSIT-IN",
+      "out": "TRANSIT-OUT"
+    }
+  },
+  "route_maps": {
+    "IXP-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "IXP-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ]
+  },
+  "schema_version": 1
+}

--- a/ansible/generated/cr1-nl1/frr-semantic.json
+++ b/ansible/generated/cr1-nl1/frr-semantic.json
@@ -1,0 +1,504 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_215932_",
+        "raw": "bgp as-path access-list 1 seq 5 deny _215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_655[0-2][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_6553[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 25 deny _6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_[1-3][0-9]{10}_",
+        "raw": "bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4[01][0-9]{9}_",
+        "raw": "bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "raw": "bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "raw": "bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "raw": "bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "raw": "bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "raw": "bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "raw": "bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949672[0-8][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496729[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 75 deny _429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "name": "1",
+        "pattern": "^.{0,200}$",
+        "raw": "bgp as-path access-list 1 seq 100 permit ^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "bgp": {
+    "instances": [
+      {
+        "address_families": {
+          "ipv6 unicast": {
+            "neighbors": {
+              "2a0c:b640:8::ffff": {
+                "activate": true,
+                "address": "2a0c:b640:8::ffff",
+                "next_hop_self": false,
+                "raw_commands": [
+                  "neighbor 2a0c:b640:8::ffff activate",
+                  "neighbor 2a0c:b640:8::ffff route-map TRANSIT-IN in",
+                  "neighbor 2a0c:b640:8::ffff route-map TRANSIT-OUT out",
+                  "neighbor 2a0c:b640:8::ffff soft-reconfiguration inbound"
+                ],
+                "route_maps": {
+                  "in": "TRANSIT-IN",
+                  "out": "TRANSIT-OUT"
+                },
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::b": {
+                "activate": true,
+                "address": "2a0c:b641:b50::b",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::b activate",
+                  "neighbor 2a0c:b641:b50::b next-hop-self",
+                  "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::c": {
+                "activate": true,
+                "address": "2a0c:b641:b50::c",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::c activate",
+                  "neighbor 2a0c:b641:b50::c next-hop-self",
+                  "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::d": {
+                "activate": true,
+                "address": "2a0c:b641:b50::d",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::d activate",
+                  "neighbor 2a0c:b641:b50::d next-hop-self",
+                  "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              }
+            },
+            "networks": [
+              "2a0c:b641:b50::/44"
+            ],
+            "raw_commands": [
+              "neighbor 2a0c:b640:8::ffff activate",
+              "neighbor 2a0c:b640:8::ffff route-map TRANSIT-IN in",
+              "neighbor 2a0c:b640:8::ffff route-map TRANSIT-OUT out",
+              "neighbor 2a0c:b640:8::ffff soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::b activate",
+              "neighbor 2a0c:b641:b50::b next-hop-self",
+              "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::c activate",
+              "neighbor 2a0c:b641:b50::c next-hop-self",
+              "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::d activate",
+              "neighbor 2a0c:b641:b50::d next-hop-self",
+              "neighbor 2a0c:b641:b50::d soft-reconfiguration inbound",
+              "network 2a0c:b641:b50::/44"
+            ]
+          }
+        },
+        "asn": 215932,
+        "flags": [
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "neighbors": {
+          "2a0c:b640:8::ffff": {
+            "address": "2a0c:b640:8::ffff",
+            "description": "Servperso-NL",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b640:8::ffff description Servperso-NL",
+              "neighbor 2a0c:b640:8::ffff remote-as 34872"
+            ],
+            "remote_as": 34872,
+            "update_source": null
+          },
+          "2a0c:b641:b50::b": {
+            "address": "2a0c:b641:b50::b",
+            "description": "cr1.de1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::b description cr1.de1",
+              "neighbor 2a0c:b641:b50::b remote-as 215932",
+              "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::a"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::a"
+          },
+          "2a0c:b641:b50::c": {
+            "address": "2a0c:b641:b50::c",
+            "description": "cr1.ch1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::c description cr1.ch1",
+              "neighbor 2a0c:b641:b50::c remote-as 215932",
+              "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::a"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::a"
+          },
+          "2a0c:b641:b50::d": {
+            "address": "2a0c:b641:b50::d",
+            "description": "rtr.ovh1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+              "neighbor 2a0c:b641:b50::d remote-as 215932",
+              "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::a"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::a"
+          }
+        },
+        "raw_commands": [
+          "bgp router-id 1.1.1.1",
+          "neighbor 2a0c:b640:8::ffff description Servperso-NL",
+          "neighbor 2a0c:b640:8::ffff remote-as 34872",
+          "neighbor 2a0c:b641:b50::b description cr1.de1",
+          "neighbor 2a0c:b641:b50::b remote-as 215932",
+          "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::a",
+          "neighbor 2a0c:b641:b50::c description cr1.ch1",
+          "neighbor 2a0c:b641:b50::c remote-as 215932",
+          "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::a",
+          "neighbor 2a0c:b641:b50::d description rtr.ovh1",
+          "neighbor 2a0c:b641:b50::d remote-as 215932",
+          "neighbor 2a0c:b641:b50::d update-source 2a0c:b641:b50::a",
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "router_id": "1.1.1.1",
+        "vrf": "default"
+      }
+    ]
+  },
+  "frr_version": "10.4.1",
+  "host": "cr1-nl1",
+  "hostname": "cr1-nl1.servify.nl",
+  "interfaces": {
+    "lo0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50::a/128"
+      ],
+      "name": "lo0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [],
+        "passive": true
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50::a/128",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 passive"
+      ],
+      "vrf": "default"
+    },
+    "wg0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff00::/127"
+      ],
+      "name": "wg0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff00::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg3": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff02::/127"
+      ],
+      "name": "wg3",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff02::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    },
+    "wg4": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff07::/127"
+      ],
+      "name": "wg4",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff07::/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "default"
+    }
+  },
+  "logging": [
+    "log syslog informational"
+  ],
+  "ospf6": {
+    "instances": [
+      {
+        "raw_commands": [
+          "ospf6 router-id 1.1.1.1"
+        ],
+        "redistribute": [],
+        "router_id": "1.1.1.1",
+        "vrf": "default"
+      }
+    ]
+  },
+  "prefix_lists": {
+    "ipv4": {},
+    "ipv6": {
+      "AS215932v6-out": [
+        {
+          "action": "permit",
+          "name": "AS215932v6-out",
+          "raw": "ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44",
+          "seq": 5,
+          "value": "2a0c:b641:b50::/44"
+        }
+      ]
+    }
+  },
+  "route_maps": {
+    "IXP-IN": {
+      "name": "IXP-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "IXP-OUT": {
+      "name": "IXP-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-IN": {
+      "name": "TRANSIT-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-OUT": {
+      "name": "TRANSIT-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "services": [
+    "service integrated-vtysh-config"
+  ],
+  "source": "configs/cr1-nl1/frr.conf",
+  "static_routes": {
+    "default": [
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:8::ffff",
+        "prefix": "2001:41d0:303:48a::2/128",
+        "raw": "ipv6 route 2001:41d0:303:48a::2/128 2a0c:b640:8::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:8::ffff",
+        "prefix": "2a09:4c0:100:2d88::8898/128",
+        "raw": "ipv6 route 2a09:4c0:100:2d88::8898/128 2a0c:b640:8::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b640:8::ffff",
+        "prefix": "2a0c:b640:10::213/128",
+        "raw": "ipv6 route 2a0c:b640:10::213/128 2a0c:b640:8::ffff"
+      },
+      {
+        "afi": "ipv6",
+        "distance_or_table": "254",
+        "next_hop": "Null0",
+        "prefix": "2a0c:b641:b50::/44",
+        "raw": "ipv6 route 2a0c:b641:b50::/44 Null0 254"
+      }
+    ]
+  },
+  "vrfs": {}
+}

--- a/ansible/generated/rtr/frr-policy.conf
+++ b/ansible/generated/rtr/frr-policy.conf
@@ -1,0 +1,36 @@
+! Generated FRR policy parity artifact for rtr
+! Source: configs/frr-policy-intent.yml
+! Not deployed directly; configs/<host>/frr.conf remains canonical.
+!
+ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44
+ipv6 prefix-list LOOPBACK-ONLY seq 5 permit 2a0c:b641:b50::d/128
+!
+bgp as-path access-list 1 seq 5 deny _215932_
+bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_
+bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_
+bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_
+bgp as-path access-list 1 seq 25 deny _6553[0-5]_
+bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_
+bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_
+bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_
+bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_
+bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_
+bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_
+bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_
+bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_
+bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_
+bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
+bgp as-path access-list 1 seq 100 permit ^.{0,200}$
+!
+route-map OSPF6-REDIST permit 10
+ match ipv6 address prefix-list LOOPBACK-ONLY
+exit
+!
+route-map TRANSIT-IN permit 10
+ match as-path 1
+exit
+!
+route-map TRANSIT-OUT permit 10
+ match ipv6 address prefix-list AS215932v6-out
+exit
+!

--- a/ansible/generated/rtr/frr-policy.json
+++ b/ansible/generated/rtr/frr-policy.json
@@ -1,0 +1,140 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "pattern": "_215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "pattern": "_655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "pattern": "_6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "pattern": "_[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "pattern": "_4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "pattern": "_42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "pattern": "_429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "pattern": "^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "host": "rtr",
+  "ipv6_prefix_lists": {
+    "AS215932v6-out": [
+      {
+        "action": "permit",
+        "seq": 5,
+        "value": "2a0c:b641:b50::/44"
+      }
+    ],
+    "LOOPBACK-ONLY": [
+      {
+        "action": "permit",
+        "seq": 5,
+        "value": "2a0c:b641:b50::d/128"
+      }
+    ]
+  },
+  "neighbor_route_maps": {},
+  "route_maps": {
+    "OSPF6-REDIST": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list LOOPBACK-ONLY"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-IN": [
+      {
+        "action": "permit",
+        "matches": [
+          "as-path 1"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ],
+    "TRANSIT-OUT": [
+      {
+        "action": "permit",
+        "matches": [
+          "ipv6 address prefix-list AS215932v6-out"
+        ],
+        "on_match": [],
+        "seq": 10,
+        "sets": []
+      }
+    ]
+  },
+  "schema_version": 1
+}

--- a/ansible/generated/rtr/frr-semantic.json
+++ b/ansible/generated/rtr/frr-semantic.json
@@ -1,0 +1,521 @@
+{
+  "as_path_access_lists": {
+    "1": [
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_215932_",
+        "raw": "bgp as-path access-list 1 seq 5 deny _215932_",
+        "seq": 5
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_64[5-9][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 10 deny _64[5-9][0-9]{2}_",
+        "seq": 10
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_65[0-4][0-9]{2}_",
+        "raw": "bgp as-path access-list 1 seq 15 deny _65[0-4][0-9]{2}_",
+        "seq": 15
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_655[0-2][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 20 deny _655[0-2][0-9]_",
+        "seq": 20
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_6553[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 25 deny _6553[0-5]_",
+        "seq": 25
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_[1-3][0-9]{10}_",
+        "raw": "bgp as-path access-list 1 seq 30 deny _[1-3][0-9]{10}_",
+        "seq": 30
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4[01][0-9]{9}_",
+        "raw": "bgp as-path access-list 1 seq 35 deny _4[01][0-9]{9}_",
+        "seq": 35
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42[0-8][0-9]{8}_",
+        "raw": "bgp as-path access-list 1 seq 40 deny _42[0-8][0-9]{8}_",
+        "seq": 40
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429[0-3][0-9]{7}_",
+        "raw": "bgp as-path access-list 1 seq 45 deny _429[0-3][0-9]{7}_",
+        "seq": 45
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294[0-8][0-9]{6}_",
+        "raw": "bgp as-path access-list 1 seq 50 deny _4294[0-8][0-9]{6}_",
+        "seq": 50
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949[0-5][0-9]{5}_",
+        "raw": "bgp as-path access-list 1 seq 55 deny _42949[0-5][0-9]{5}_",
+        "seq": 55
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496[0-6][0-9]{4}_",
+        "raw": "bgp as-path access-list 1 seq 60 deny _429496[0-6][0-9]{4}_",
+        "seq": 60
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_4294967[01][0-9]{3}_",
+        "raw": "bgp as-path access-list 1 seq 65 deny _4294967[01][0-9]{3}_",
+        "seq": 65
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_42949672[0-8][0-9]_",
+        "raw": "bgp as-path access-list 1 seq 70 deny _42949672[0-8][0-9]_",
+        "seq": 70
+      },
+      {
+        "action": "deny",
+        "name": "1",
+        "pattern": "_429496729[0-5]_",
+        "raw": "bgp as-path access-list 1 seq 75 deny _429496729[0-5]_",
+        "seq": 75
+      },
+      {
+        "action": "permit",
+        "name": "1",
+        "pattern": "^.{0,200}$",
+        "raw": "bgp as-path access-list 1 seq 100 permit ^.{0,200}$",
+        "seq": 100
+      }
+    ]
+  },
+  "bgp": {
+    "instances": [
+      {
+        "address_families": {
+          "ipv6 unicast": {
+            "neighbors": {
+              "2a0c:b641:b50::a": {
+                "activate": true,
+                "address": "2a0c:b641:b50::a",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::a activate",
+                  "neighbor 2a0c:b641:b50::a next-hop-self",
+                  "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::b": {
+                "activate": true,
+                "address": "2a0c:b641:b50::b",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::b activate",
+                  "neighbor 2a0c:b641:b50::b next-hop-self",
+                  "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              },
+              "2a0c:b641:b50::c": {
+                "activate": true,
+                "address": "2a0c:b641:b50::c",
+                "next_hop_self": true,
+                "raw_commands": [
+                  "neighbor 2a0c:b641:b50::c activate",
+                  "neighbor 2a0c:b641:b50::c next-hop-self",
+                  "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound"
+                ],
+                "route_maps": {},
+                "soft_reconfiguration": [
+                  "inbound"
+                ]
+              }
+            },
+            "networks": [
+              "2a0c:b641:b50:2::/64",
+              "2a0c:b641:b50:3::/64",
+              "2a0c:b641:b50::/44",
+              "2a0c:b641:b51::/48"
+            ],
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::a activate",
+              "neighbor 2a0c:b641:b50::a next-hop-self",
+              "neighbor 2a0c:b641:b50::a soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::b activate",
+              "neighbor 2a0c:b641:b50::b next-hop-self",
+              "neighbor 2a0c:b641:b50::b soft-reconfiguration inbound",
+              "neighbor 2a0c:b641:b50::c activate",
+              "neighbor 2a0c:b641:b50::c next-hop-self",
+              "neighbor 2a0c:b641:b50::c soft-reconfiguration inbound",
+              "network 2a0c:b641:b50:2::/64",
+              "network 2a0c:b641:b50:3::/64",
+              "network 2a0c:b641:b50::/44",
+              "network 2a0c:b641:b51::/48"
+            ]
+          }
+        },
+        "asn": 215932,
+        "flags": [
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "neighbors": {
+          "2a0c:b641:b50::a": {
+            "address": "2a0c:b641:b50::a",
+            "description": "cr1.nl1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::a description cr1.nl1",
+              "neighbor 2a0c:b641:b50::a remote-as 215932",
+              "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::d"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::d"
+          },
+          "2a0c:b641:b50::b": {
+            "address": "2a0c:b641:b50::b",
+            "description": "cr1.de1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::b description cr1.de1",
+              "neighbor 2a0c:b641:b50::b remote-as 215932",
+              "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::d"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::d"
+          },
+          "2a0c:b641:b50::c": {
+            "address": "2a0c:b641:b50::c",
+            "description": "cr1.ch1",
+            "enforce_first_as": true,
+            "raw_commands": [
+              "neighbor 2a0c:b641:b50::c description cr1.ch1",
+              "neighbor 2a0c:b641:b50::c remote-as 215932",
+              "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::d"
+            ],
+            "remote_as": 215932,
+            "update_source": "2a0c:b641:b50::d"
+          }
+        },
+        "raw_commands": [
+          "bgp router-id 0.0.0.13",
+          "neighbor 2a0c:b641:b50::a description cr1.nl1",
+          "neighbor 2a0c:b641:b50::a remote-as 215932",
+          "neighbor 2a0c:b641:b50::a update-source 2a0c:b641:b50::d",
+          "neighbor 2a0c:b641:b50::b description cr1.de1",
+          "neighbor 2a0c:b641:b50::b remote-as 215932",
+          "neighbor 2a0c:b641:b50::b update-source 2a0c:b641:b50::d",
+          "neighbor 2a0c:b641:b50::c description cr1.ch1",
+          "neighbor 2a0c:b641:b50::c remote-as 215932",
+          "neighbor 2a0c:b641:b50::c update-source 2a0c:b641:b50::d",
+          "no bgp default ipv4-unicast",
+          "no bgp ebgp-requires-policy",
+          "no bgp network import-check"
+        ],
+        "router_id": "0.0.0.13",
+        "vrf": "overlay"
+      }
+    ]
+  },
+  "frr_version": "10.6.0",
+  "host": "rtr",
+  "hostname": "rtr",
+  "interfaces": {
+    "enX2": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:2::1/64"
+      ],
+      "name": "enX2",
+      "ospf6": {
+        "areas": [],
+        "networks": [],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:2::1/64"
+      ],
+      "vrf": "overlay"
+    },
+    "enX3": {
+      "ipv6_addresses": [
+        "2a0c:b641:b51::1/48"
+      ],
+      "name": "enX3",
+      "ospf6": {
+        "areas": [],
+        "networks": [],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b51::1/48"
+      ],
+      "vrf": "overlay"
+    },
+    "lo-overlay": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50::d/128"
+      ],
+      "name": "lo-overlay",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": true
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50::d/128",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point",
+        "ipv6 ospf6 passive"
+      ],
+      "vrf": "overlay"
+    },
+    "wg0": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff02::1/127"
+      ],
+      "name": "wg0",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff02::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "overlay"
+    },
+    "wg1": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff05::1/127"
+      ],
+      "name": "wg1",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff05::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "overlay"
+    },
+    "wg2": {
+      "ipv6_addresses": [
+        "2a0c:b641:b50:ff06::1/127"
+      ],
+      "name": "wg2",
+      "ospf6": {
+        "areas": [
+          "0"
+        ],
+        "networks": [
+          "point-to-point"
+        ],
+        "passive": false
+      },
+      "raw_commands": [
+        "ipv6 address 2a0c:b641:b50:ff06::1/127",
+        "ipv6 ospf6 area 0",
+        "ipv6 ospf6 network point-to-point"
+      ],
+      "vrf": "overlay"
+    }
+  },
+  "logging": [
+    "log syslog informational"
+  ],
+  "ospf6": {
+    "instances": [
+      {
+        "raw_commands": [
+          "ospf6 router-id 0.0.0.13",
+          "redistribute connected route-map OSPF6-REDIST"
+        ],
+        "redistribute": [
+          "connected route-map OSPF6-REDIST"
+        ],
+        "router_id": "0.0.0.13",
+        "vrf": "overlay"
+      }
+    ]
+  },
+  "prefix_lists": {
+    "ipv4": {},
+    "ipv6": {
+      "AS215932v6-out": [
+        {
+          "action": "permit",
+          "name": "AS215932v6-out",
+          "raw": "ipv6 prefix-list AS215932v6-out seq 5 permit 2a0c:b641:b50::/44",
+          "seq": 5,
+          "value": "2a0c:b641:b50::/44"
+        }
+      ],
+      "LOOPBACK-ONLY": [
+        {
+          "action": "permit",
+          "name": "LOOPBACK-ONLY",
+          "raw": "ipv6 prefix-list LOOPBACK-ONLY seq 5 permit 2a0c:b641:b50::d/128",
+          "seq": 5,
+          "value": "2a0c:b641:b50::d/128"
+        }
+      ]
+    }
+  },
+  "route_maps": {
+    "OSPF6-REDIST": {
+      "name": "OSPF6-REDIST",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list LOOPBACK-ONLY"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list LOOPBACK-ONLY"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-IN": {
+      "name": "TRANSIT-IN",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "as-path 1"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match as-path 1"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    },
+    "TRANSIT-OUT": {
+      "name": "TRANSIT-OUT",
+      "sequences": {
+        "10": {
+          "action": "permit",
+          "matches": [
+            "ipv6 address prefix-list AS215932v6-out"
+          ],
+          "on_match": [],
+          "raw_commands": [
+            "match ipv6 address prefix-list AS215932v6-out"
+          ],
+          "seq": 10,
+          "sets": []
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "services": [
+    "service integrated-vtysh-config"
+  ],
+  "source": "configs/rtr/frr.conf",
+  "static_routes": {
+    "default": [],
+    "overlay": [
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b641:b50:2::60",
+        "prefix": "2a0c:b641:b50:3::/64",
+        "raw": "ipv6 route 2a0c:b641:b50:3::/64 2a0c:b641:b50:2::60"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "blackhole",
+        "prefix": "2a0c:b641:b50::/44",
+        "raw": "ipv6 route 2a0c:b641:b50::/44 blackhole"
+      },
+      {
+        "afi": "ipv6",
+        "next_hop": "2a0c:b641:b51::c1",
+        "prefix": "2a0c:b641:b51:c1::/64",
+        "raw": "ipv6 route 2a0c:b641:b51:c1::/64 2a0c:b641:b51::c1"
+      }
+    ]
+  },
+  "vrfs": {
+    "overlay": {
+      "name": "overlay",
+      "static_routes": [
+        {
+          "afi": "ipv6",
+          "next_hop": "blackhole",
+          "prefix": "2a0c:b641:b50::/44",
+          "raw": "ipv6 route 2a0c:b641:b50::/44 blackhole"
+        },
+        {
+          "afi": "ipv6",
+          "next_hop": "2a0c:b641:b50:2::60",
+          "prefix": "2a0c:b641:b50:3::/64",
+          "raw": "ipv6 route 2a0c:b641:b50:3::/64 2a0c:b641:b50:2::60"
+        },
+        {
+          "afi": "ipv6",
+          "next_hop": "2a0c:b641:b51::c1",
+          "prefix": "2a0c:b641:b51:c1::/64",
+          "raw": "ipv6 route 2a0c:b641:b51:c1::/64 2a0c:b641:b51::c1"
+        }
+      ]
+    }
+  }
+}

--- a/ansible/inventory/group_vars/routers.yml
+++ b/ansible/inventory/group_vars/routers.yml
@@ -2,3 +2,15 @@
 firewall_enable_forwarding: true
 firewall_allow_bgp: true
 firewall_allow_ospf6_on_wg: true
+
+# --- FRR NETCONF/YANG adoption metadata ---
+# Read-only audit is enabled for routers. NETCONF endpoint provisioning and
+# writes are separate, future-gated capabilities and default disabled.
+frr_yang_audit_enabled: true
+frr_netconf_endpoint_enabled: false
+frr_netconf_write_enabled: false
+frr_netconf_port: 830
+frr_netconf_allowed_sources_v6:
+  - "{{ peers.ci.ipv6 }}/128"
+  - "{{ peers.noc.ipv6 }}/128"
+  - "{{ ops_prefix_v6 }}"

--- a/ansible/inventory/host_vars/cr1-ch1.yml
+++ b/ansible/inventory/host_vars/cr1-ch1.yml
@@ -6,6 +6,11 @@
 
 ansible_python_interpreter: /usr/local/bin/python3.11
 
+# --- FRR NETCONF/YANG audit metadata ---
+frr_version_expected: "10.5.3"
+frr_yang_profile: "freebsd-frr10-10.5-stock-readonly"
+frr_vrf_context: default
+
 pf_ext_if: "vmx0"
 pf_extra_ifs:
   - { name: "ixp_4ixp", dev: "vmx1" }

--- a/ansible/inventory/host_vars/cr1-de1.yml
+++ b/ansible/inventory/host_vars/cr1-de1.yml
@@ -5,6 +5,11 @@
 
 ansible_python_interpreter: /usr/local/bin/python3.11
 
+# --- FRR NETCONF/YANG audit metadata ---
+frr_version_expected: "10.4.1"
+frr_yang_profile: "freebsd-frr10-10.4-stock-readonly"
+frr_vrf_context: default
+
 pf_ext_if: "vtnet0"
 pf_extra_ifs:
   - { name: "transit2_if", dev: "vtnet1" }

--- a/ansible/inventory/host_vars/cr1-nl1.yml
+++ b/ansible/inventory/host_vars/cr1-nl1.yml
@@ -5,6 +5,11 @@
 
 ansible_python_interpreter: /usr/local/bin/python3.11
 
+# --- FRR NETCONF/YANG audit metadata ---
+frr_version_expected: "10.4.1"
+frr_yang_profile: "freebsd-frr10-10.4-stock-readonly"
+frr_vrf_context: default
+
 pf_ext_if: "vtnet0"
 pf_extra_ifs:
   - { name: "ixp_nl", dev: "vtnet1" }

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -3,6 +3,11 @@
 # Bridges: enX0 (mgmt), enX2 (infra), enX3 (vm/customer), enX4 (wan/underlay).
 # Carries IPv4 NAT/DNAT for legacy v4 service ingress + customer VM isolation.
 
+# --- FRR NETCONF/YANG audit metadata ---
+frr_version_expected: "10.6.0"
+frr_yang_profile: "debian-frr-10.6-stock-readonly"
+frr_vrf_context: overlay
+
 # --- networkd_resolved role override: drop-in goes on the overlay infra interface,
 #     not the mgmt link-local one (enX0 has no DNS to advertise).
 networkd_primary_unit: "10-enX2"

--- a/ansible/playbooks/frr-yang.yml
+++ b/ansible/playbooks/frr-yang.yml
@@ -1,0 +1,11 @@
+---
+- name: FRR YANG — read-only audit
+  hosts: routers
+  # Facts come from group_vars (ansible_os_family preset), matching the other
+  # router playbooks. The role is read-only and writes artifacts on the
+  # controller under ansible/generated/frr-yang-snapshots/.
+  gather_facts: false
+  become: true
+  roles:
+    - frr_yang
+  tags: [frr_yang]

--- a/ansible/roles/firewall/templates/nftables-rtr.conf.j2
+++ b/ansible/roles/firewall/templates/nftables-rtr.conf.j2
@@ -73,6 +73,7 @@ table inet filter {
 
         # Per-host service allowances.
 {% include 'partials/_extra_rules.j2' %}
+{% include 'partials/_netconf_endpoint_nft.j2' %}
 
 {% if firewall_extra_raw_nft %}
         # --- raw escape hatch ---

--- a/ansible/roles/firewall/templates/nftables.conf.j2
+++ b/ansible/roles/firewall/templates/nftables.conf.j2
@@ -13,6 +13,7 @@ table inet filter {
 
         # Per-host service allowances.
 {% include 'partials/_extra_rules.j2' %}
+{% include 'partials/_netconf_endpoint_nft.j2' %}
 
 {% if firewall_extra_raw_nft %}
         # --- raw escape hatch ---

--- a/ansible/roles/firewall/templates/partials/_netconf_endpoint_nft.j2
+++ b/ansible/roles/firewall/templates/partials/_netconf_endpoint_nft.j2
@@ -1,0 +1,10 @@
+{# Disabled-by-default FRR NETCONF/YANG endpoint allowance.
+   The server itself must bind only overlay/loopback addresses. This firewall
+   scaffold opens TCP/830 only to approved management sources when a host opts
+   in with frr_netconf_endpoint_enabled=true. #}
+{% if frr_netconf_endpoint_enabled | default(false) | bool %}
+{% set netconf_sources = frr_netconf_allowed_sources_v6 | default([]) %}
+{% if netconf_sources | length > 0 %}
+        ip6 saddr { {{ netconf_sources | join(', ') }} } tcp dport {{ frr_netconf_port | default(830) }} counter accept comment "FRR NETCONF/YANG from approved management sources"
+{% endif %}
+{% endif %}

--- a/ansible/roles/firewall/templates/partials/_netconf_endpoint_pf.j2
+++ b/ansible/roles/firewall/templates/partials/_netconf_endpoint_pf.j2
@@ -1,0 +1,12 @@
+{# Disabled-by-default FRR NETCONF/YANG endpoint allowance.
+   The server itself must bind only overlay/loopback addresses. This firewall
+   scaffold is rendered only when a host opts in with
+   frr_netconf_endpoint_enabled=true. #}
+{% if frr_netconf_endpoint_enabled | default(false) | bool %}
+{% set netconf_sources = frr_netconf_allowed_sources_v6 | default([]) %}
+{% if netconf_sources | length > 0 %}
+# --- FRR NETCONF/YANG endpoint (disabled by default) ---
+pass in quick on wg inet6 proto tcp from { {{ netconf_sources | join(', ') }} } to any port = {{ frr_netconf_port | default(830) }} flags S/SA keep state label "NETCONF_RULE: FRR NETCONF/YANG approved sources"
+
+{% endif %}
+{% endif %}

--- a/ansible/roles/firewall/templates/pf.conf.j2
+++ b/ansible/roles/firewall/templates/pf.conf.j2
@@ -102,6 +102,7 @@ pass in quick on $ext_if {{ fam }} proto {{ proto }} {{ src_clause }} to any por
 {% endfor %}
 
 {% endif %}
+{% include 'partials/_netconf_endpoint_pf.j2' %}
 {% if firewall_extra_raw_pf %}
 # --- raw escape hatch ---
 {{ firewall_extra_raw_pf }}

--- a/ansible/roles/frr_yang/README.md
+++ b/ansible/roles/frr_yang/README.md
@@ -1,0 +1,56 @@
+# frr_yang role
+
+Read-only FRRouting YANG/NETCONF capability audit.
+
+This role does **not** configure FRR, sysrepo, Netopeer2, or NETCONF endpoints.
+Production desired state remains the committed `configs/<host>/frr.conf` files
+and the existing `frr` role remains the apply path. Endpoint inventory knobs are
+present only as disabled-by-default scaffolding for a later, explicitly gated
+change.
+
+## What it collects
+
+On routers with `frr_yang_audit_enabled: true`, the role captures:
+
+- FRR version and selected running-config JSON views via `vtysh`;
+- BGP IPv6 summary, plus a VRF-specific summary when `frr_vrf_context` is not
+  `default`;
+- `mgmtd` backend-adapter evidence when supported;
+- OS package evidence for FRR/sysrepo/Netopeer2/libyang;
+- sysrepo module evidence when `sysrepoctl` exists;
+- TCP/830 listener evidence;
+- FRR YANG/module path evidence.
+
+All commands are read-only and use `failed_when: false` so unsupported features
+are captured as audit evidence.
+
+## Artifacts
+
+Artifacts are written on the controller under:
+
+```text
+ansible/generated/frr-yang-snapshots/<timestamp>/<host>/
+```
+
+That path is ignored by Git because it contains observed runtime state, not
+desired state.
+
+## Disabled endpoint scaffolding
+
+Routers inherit:
+
+- `frr_netconf_endpoint_enabled: false`
+- `frr_netconf_write_enabled: false`
+- `frr_netconf_port: 830`
+- `frr_netconf_allowed_sources_v6` limited to CI, NOC, and ops sources.
+
+When a future PR explicitly enables `frr_netconf_endpoint_enabled` for one host,
+the firewall templates can render a restricted TCP/830 allow. This role still
+will not install or start Netopeer2/sysrepo.
+
+## Usage
+
+```bash
+cd ansible
+ansible-playbook playbooks/frr-yang.yml --tags audit --limit rtr
+```

--- a/ansible/roles/frr_yang/defaults/main.yml
+++ b/ansible/roles/frr_yang/defaults/main.yml
@@ -1,0 +1,69 @@
+---
+# Read-only FRR YANG/NETCONF capability audit defaults.
+# Production source of truth remains configs/<host>/frr.conf; this role only
+# observes router state and writes local evidence artifacts.
+
+frr_yang_audit_enabled: false
+
+# Runtime snapshots are intentionally ignored by Git. They are uploaded by the
+# audit workflow and used for drift/debugging only.
+frr_yang_snapshot_root: "{{ playbook_dir }}/../generated/frr-yang-snapshots"
+
+# Standard NETCONF endpoint knobs. They are inventory metadata for now; endpoint
+# provisioning is a later, explicitly-gated step and defaults disabled.
+frr_netconf_endpoint_enabled: false
+frr_netconf_write_enabled: false
+frr_netconf_port: 830
+frr_netconf_allowed_sources_v6: []
+
+# Per-host metadata; host_vars should set exact values.
+frr_version_expected: ""
+frr_yang_profile: "stock-frr-readonly"
+frr_vrf_context: default
+
+# Commands explicitly requested by the adoption plan. All are read-only and run
+# with failed_when=false so unsupported daemons/capabilities are captured as
+# evidence instead of hiding partial results.
+frr_yang_vtysh_audit_commands:
+  - name: version
+    argv: ["vtysh", "-c", "show version"]
+  - name: bgp_ipv6_summary_json
+    argv: ["vtysh", "-c", "show bgp ipv6 summary json"]
+  - name: configuration_running_bgpd_json
+    argv: ["vtysh", "-c", "show configuration running json bgpd"]
+  - name: configuration_running_staticd_json
+    argv: ["vtysh", "-c", "show configuration running json staticd"]
+  - name: configuration_running_zebra_json
+    argv: ["vtysh", "-c", "show configuration running json zebra"]
+  - name: configuration_running_ospf6d_json
+    argv: ["vtysh", "-c", "show configuration running json ospf6d"]
+  - name: mgmt_backend_adapter_all
+    argv: ["vtysh", "-c", "show mgmt backend-adapter all"]
+
+# Cross-platform shell snippets for local capability evidence.
+frr_yang_capability_audit_commands:
+  - name: executable_paths
+    shell: |
+      for bin in vtysh mgmtd sysrepoctl sysrepocfg netopeer2-server sshd; do
+        if command -v "$bin" >/dev/null 2>&1; then
+          printf '%s\t%s\n' "$bin" "$(command -v "$bin")"
+        else
+          printf '%s\tnot-found\n' "$bin"
+        fi
+      done
+  - name: frr_yang_and_module_paths
+    shell: |
+      for path in \
+        /usr/share/yang \
+        /usr/local/share/yang \
+        /usr/share/frr \
+        /usr/local/share/frr \
+        /usr/lib/frr/modules \
+        /usr/lib/*/frr/modules \
+        /usr/local/lib/frr/modules; do
+        if [ -e "$path" ]; then
+          echo "### $path"
+          find "$path" -type f 2>/dev/null | sort | sed -n '1,200p'
+        fi
+      done
+      true

--- a/ansible/roles/frr_yang/meta/main.yml
+++ b/ansible/roles/frr_yang/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  role_name: frr_yang
+  author: AS215932
+  description: >-
+    Read-only FRRouting YANG/NETCONF capability audit. Collects evidence from
+    routers and writes local snapshots without changing router state.
+  license: BSD-2-Clause
+  min_ansible_version: "2.14"

--- a/ansible/roles/frr_yang/tasks/main.yml
+++ b/ansible/roles/frr_yang/tasks/main.yml
@@ -1,0 +1,173 @@
+---
+# Read-only FRR YANG/NETCONF capability audit.
+# This role never changes router state. It executes observation commands and
+# writes evidence to the controller under ansible/generated/frr-yang-snapshots/.
+
+- name: Skip routers not opted in to FRR YANG audit
+  meta: end_host
+  when: not (frr_yang_audit_enabled | default(false) | bool)
+  tags: [always]
+
+- name: Load OS-specific vars
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags: [always]
+
+- name: Choose FRR YANG audit snapshot id
+  delegate_to: localhost
+  delegate_facts: true
+  become: false
+  set_fact:
+    frr_yang_snapshot_id: "{{ frr_yang_snapshot_id | default(lookup('pipe', 'date -u +%Y%m%dT%H%M%SZ')) }}"
+  run_once: true
+  changed_when: false
+  tags: [audit]
+
+- name: Set FRR YANG audit local paths
+  set_fact:
+    _frr_yang_snapshot_id: "{{ hostvars['localhost'].frr_yang_snapshot_id }}"
+    _frr_yang_snapshot_dir: "{{ frr_yang_snapshot_root }}/{{ hostvars['localhost'].frr_yang_snapshot_id }}/{{ inventory_hostname }}"
+  changed_when: false
+  tags: [audit]
+
+- name: Build FRR YANG vtysh audit command list
+  set_fact:
+    _frr_yang_vtysh_audit_commands: >-
+      {{ frr_yang_vtysh_audit_commands
+         + ([{'name': 'bgp_ipv6_summary_' ~ (frr_vrf_context | default('default')) ~ '_json',
+              'argv': ['vtysh', '-c', 'show bgp vrf ' ~ (frr_vrf_context | default('default')) ~ ' ipv6 summary json']}]
+            if (frr_vrf_context | default('default')) != 'default' else []) }}
+  changed_when: false
+  tags: [audit]
+
+- name: Ensure local FRR YANG snapshot directory exists
+  delegate_to: localhost
+  connection: local
+  become: false
+  file:
+    path: "{{ _frr_yang_snapshot_dir }}"
+    state: directory
+    mode: "0755"
+  changed_when: false
+  tags: [audit]
+
+- name: Run read-only vtysh audit commands
+  command:
+    argv: "{{ item.argv }}"
+  loop: "{{ _frr_yang_vtysh_audit_commands }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: _frr_yang_vtysh_results
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  tags: [audit]
+
+- name: Run read-only package and NETCONF capability probes
+  shell: "{{ item.shell }}"
+  args:
+    executable: /bin/sh
+  loop: "{{ frr_yang_package_audit_commands | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: _frr_yang_package_results
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  tags: [audit]
+
+- name: Run read-only FRR YANG capability probes
+  shell: "{{ item.shell }}"
+  args:
+    executable: /bin/sh
+  loop: "{{ frr_yang_capability_audit_commands }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: _frr_yang_capability_results
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  tags: [audit]
+
+- name: Write FRR YANG audit metadata JSON locally
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: |
+      {{ {
+        'snapshot_id': _frr_yang_snapshot_id,
+        'captured_at_utc': lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ'),
+        'host': inventory_hostname,
+        'ansible_host': ansible_host | default(inventory_hostname),
+        'ansible_os_family': ansible_os_family | default('unknown'),
+        'frr_version_expected': frr_version_expected | default(''),
+        'frr_yang_profile': frr_yang_profile | default(''),
+        'frr_vrf_context': frr_vrf_context | default('default'),
+        'frr_netconf_endpoint_enabled': frr_netconf_endpoint_enabled | default(false) | bool,
+        'frr_netconf_write_enabled': frr_netconf_write_enabled | default(false) | bool,
+        'frr_netconf_port': frr_netconf_port | default(830),
+        'frr_netconf_allowed_sources_v6': frr_netconf_allowed_sources_v6 | default([]),
+        'vtysh_results': _frr_yang_vtysh_results.results | default([]),
+        'package_results': _frr_yang_package_results.results | default([]),
+        'capability_results': _frr_yang_capability_results.results | default([])
+      } | to_nice_json }}
+    dest: "{{ _frr_yang_snapshot_dir }}/audit.json"
+    mode: "0644"
+  changed_when: false
+  tags: [audit]
+
+- name: Write vtysh stdout artifacts locally
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: "{{ item.stdout | default('') }}\n"
+    dest: "{{ _frr_yang_snapshot_dir }}/vtysh-{{ item.item.name }}.stdout"
+    mode: "0644"
+  loop: "{{ _frr_yang_vtysh_results.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  changed_when: false
+  tags: [audit]
+
+- name: Write vtysh stderr artifacts locally
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: "{{ item.stderr | default('') }}\n"
+    dest: "{{ _frr_yang_snapshot_dir }}/vtysh-{{ item.item.name }}.stderr"
+    mode: "0644"
+  loop: "{{ _frr_yang_vtysh_results.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  changed_when: false
+  tags: [audit]
+
+- name: Write package/capability stdout artifacts locally
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: "{{ item.stdout | default('') }}\n"
+    dest: "{{ _frr_yang_snapshot_dir }}/{{ item.item.name }}.stdout"
+    mode: "0644"
+  loop: "{{ (_frr_yang_package_results.results | default([])) + (_frr_yang_capability_results.results | default([])) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  changed_when: false
+  tags: [audit]
+
+- name: Write package/capability stderr artifacts locally
+  delegate_to: localhost
+  connection: local
+  become: false
+  copy:
+    content: "{{ item.stderr | default('') }}\n"
+    dest: "{{ _frr_yang_snapshot_dir }}/{{ item.item.name }}.stderr"
+    mode: "0644"
+  loop: "{{ (_frr_yang_package_results.results | default([])) + (_frr_yang_capability_results.results | default([])) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  changed_when: false
+  tags: [audit]

--- a/ansible/roles/frr_yang/vars/Debian.yml
+++ b/ansible/roles/frr_yang/vars/Debian.yml
@@ -1,0 +1,26 @@
+---
+# Debian router package/capability probes. All commands are read-only and
+# tolerate absent optional packages so the audit can report missing NETCONF
+# support without failing the run.
+
+frr_yang_package_audit_commands:
+  - name: debian_frr_packages
+    shell: |
+      dpkg-query -W -f='${binary:Package}\t${Version}\n' \
+        frr frr-pythontools frr-grpc sysrepo netopeer2 libyang3 2>&1 || true
+  - name: debian_sysrepo_modules
+    shell: |
+      if command -v sysrepoctl >/dev/null 2>&1; then
+        sysrepoctl -l
+      else
+        echo 'sysrepoctl not found'
+      fi
+  - name: debian_netconf_listeners
+    shell: |
+      if command -v ss >/dev/null 2>&1; then
+        ss -H -lnpt "( sport = :{{ frr_netconf_port }} )" 2>&1 || true
+      elif command -v netstat >/dev/null 2>&1; then
+        netstat -lntp 2>&1 | grep -E '(:|\.){{ frr_netconf_port }}\b' || true
+      else
+        echo 'ss/netstat not found'
+      fi

--- a/ansible/roles/frr_yang/vars/FreeBSD.yml
+++ b/ansible/roles/frr_yang/vars/FreeBSD.yml
@@ -1,0 +1,25 @@
+---
+# FreeBSD router package/capability probes. All commands are read-only and
+# tolerate absent optional packages so the audit can report missing NETCONF
+# support without failing the run.
+
+frr_yang_package_audit_commands:
+  - name: freebsd_frr_packages
+    shell: |
+      pkg info -x '^(frr|sysrepo|netopeer|libyang)' 2>&1 || true
+  - name: freebsd_sysrepo_modules
+    shell: |
+      if command -v sysrepoctl >/dev/null 2>&1; then
+        sysrepoctl -l
+      else
+        echo 'sysrepoctl not found'
+      fi
+  - name: freebsd_netconf_listeners
+    shell: |
+      if command -v sockstat >/dev/null 2>&1; then
+        sockstat -46 -l -P tcp 2>&1 | grep -E '(:|\.){{ frr_netconf_port }}\b' || true
+      elif command -v netstat >/dev/null 2>&1; then
+        netstat -an -p tcp 2>&1 | grep -E '(:|\.){{ frr_netconf_port }}\b' || true
+      else
+        echo 'sockstat/netstat not found'
+      fi

--- a/configs/frr-policy-intent.yml
+++ b/configs/frr-policy-intent.yml
@@ -1,0 +1,150 @@
+---
+schema_version: 1
+
+# Structured policy intent pilot for FRRouting. This file is not canonical for
+# production applies yet; parity tests compare it against committed frr.conf
+# before any generated section can be promoted.
+
+common:
+  ipv6_prefix_lists:
+    AS215932v6-out:
+      - { seq: 5, action: permit, value: "2a0c:b641:b50::/44" }
+
+  as_path_access_lists:
+    "1":
+      - { seq: 5, action: deny, pattern: "_215932_" }
+      - { seq: 10, action: deny, pattern: "_64[5-9][0-9]{2}_" }
+      - { seq: 15, action: deny, pattern: "_65[0-4][0-9]{2}_" }
+      - { seq: 20, action: deny, pattern: "_655[0-2][0-9]_" }
+      - { seq: 25, action: deny, pattern: "_6553[0-5]_" }
+      - { seq: 30, action: deny, pattern: "_[1-3][0-9]{10}_" }
+      - { seq: 35, action: deny, pattern: "_4[01][0-9]{9}_" }
+      - { seq: 40, action: deny, pattern: "_42[0-8][0-9]{8}_" }
+      - { seq: 45, action: deny, pattern: "_429[0-3][0-9]{7}_" }
+      - { seq: 50, action: deny, pattern: "_4294[0-8][0-9]{6}_" }
+      - { seq: 55, action: deny, pattern: "_42949[0-5][0-9]{5}_" }
+      - { seq: 60, action: deny, pattern: "_429496[0-6][0-9]{4}_" }
+      - { seq: 65, action: deny, pattern: "_4294967[01][0-9]{3}_" }
+      - { seq: 70, action: deny, pattern: "_42949672[0-8][0-9]_" }
+      - { seq: 75, action: deny, pattern: "_429496729[0-5]_" }
+      - { seq: 100, action: permit, pattern: "^.{0,200}$" }
+
+  route_maps:
+    TRANSIT-IN:
+      - seq: 10
+        action: permit
+        matches: ["as-path 1"]
+    TRANSIT-OUT:
+      - seq: 10
+        action: permit
+        matches: ["ipv6 address prefix-list AS215932v6-out"]
+    IXP-IN:
+      - seq: 10
+        action: permit
+        matches: ["as-path 1"]
+    IXP-OUT:
+      - seq: 10
+        action: permit
+        matches: ["ipv6 address prefix-list AS215932v6-out"]
+
+hosts:
+  rtr:
+    ipv6_prefix_lists:
+      LOOPBACK-ONLY:
+        - { seq: 5, action: permit, value: "2a0c:b641:b50::d/128" }
+    route_maps:
+      OSPF6-REDIST:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list LOOPBACK-ONLY"]
+      TRANSIT-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      TRANSIT-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+    neighbor_route_maps: {}
+
+  cr1-nl1:
+    route_maps:
+      TRANSIT-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      TRANSIT-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+      IXP-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      IXP-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+    neighbor_route_maps:
+      "2a0c:b640:8::ffff": { in: TRANSIT-IN, out: TRANSIT-OUT }
+
+  cr1-de1:
+    as_path_access_lists:
+      "24961":
+        - { action: permit, pattern: "_24961_" }
+    route_maps:
+      TRANSIT-IN:
+        - seq: 5
+          action: permit
+          matches: ["as-path 24961"]
+          sets: ["local-preference 80"]
+          on_match: ["next"]
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      TRANSIT-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+      TRANSIT-OUT-PREPEND-3X:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+          sets: ["as-path prepend 215932 215932 215932"]
+      IXP-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      IXP-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+    neighbor_route_maps:
+      "2a0c:b640:10::ffff": { in: TRANSIT-IN, out: TRANSIT-OUT-PREPEND-3X }
+      "2a0c:b641:870::ffff": { in: TRANSIT-IN, out: TRANSIT-OUT-PREPEND-3X }
+
+  cr1-ch1:
+    route_maps:
+      TRANSIT-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+      TRANSIT-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+      IXP-IN:
+        - seq: 10
+          action: permit
+          matches: ["as-path 1"]
+          sets: ["local-preference 200"]
+      IXP-OUT:
+        - seq: 10
+          action: permit
+          matches: ["ipv6 address prefix-list AS215932v6-out"]
+    neighbor_route_maps:
+      "2a09:4c0:100:2d88::8bfa": { in: TRANSIT-IN, out: TRANSIT-OUT }
+      "2001:7f8:d9:1::1": { in: IXP-IN, out: IXP-OUT }
+      "2001:7f8:d9:1::2": { in: IXP-IN, out: IXP-OUT }
+      "2001:7f8:d9:1::3": { in: IXP-IN, out: IXP-OUT }
+      "2001:7f8:d9:1::4": { in: IXP-IN, out: IXP-OUT }

--- a/docs/ci/workflows.md
+++ b/docs/ci/workflows.md
@@ -9,7 +9,7 @@ Workflows match the runner label set `self-hosted, linux, x64, hyrule-infra`.
 |----------|---------|---------|----|
 | `lint.yml` | `pull_request`, `push` to `main` | yamllint + ansible-lint + shellcheck + Jinja2 syntax + static IaC contracts | 0b |
 | `render-check.yml` | `pull_request` touching `ansible/**`, `configs/**` | render every playbook + deploy preflight + assert `ansible/generated/` is fresh | 0b |
-| `iac-tests.yml` | `pull_request`, `push` to `main`, manual | DNS/inventory/Vault/FRR tests, render idempotency; Batfish/Containerlab run manually or when repo vars enable them | current |
+| `iac-tests.yml` | `pull_request`, `push` to `main`, manual | DNS/inventory/Vault/FRR tests, render idempotency; Batfish, Containerlab, and NETCONF/YANG labs run manually or when repo vars enable them | current |
 | `drift-detection.yml` | nightly + manual | `ansible-playbook --check --diff`; alerts NOC, never auto-applies | current |
 | `apply.yml` | `workflow_dispatch` | manual gated apply with runner preflight, snapshots, postflight Goss, diff | 0e |
 

--- a/docs/netops/netconf-yang.md
+++ b/docs/netops/netconf-yang.md
@@ -1,0 +1,199 @@
+# NETCONF/YANG adoption for AS215932 FRRouting
+
+## Decision
+
+AS215932 will use NETCONF/YANG as a model-driven safety and visibility layer
+around FRRouting, not as the production source of truth. The committed
+`configs/<router>/frr.conf` files remain canonical until a later structured
+intent renderer proves parity and is explicitly promoted.
+
+Routers are observed state. They are never authoritative for desired routing
+policy.
+
+## Scope
+
+Initial adoption is read-only and validation-focused:
+
+- collect FRR/YANG/NETCONF capability evidence from routers;
+- build normalized, structured views of committed and running FRR config;
+- use those views for semantic diffing, CI checks, and drift reports;
+- prove standard NETCONF behavior in a trusted lab before any production write
+  path is considered.
+
+The existing Ansible `frr` role remains the production apply path. It already
+stages `frr.conf`, validates with `vtysh -C -f`, backs up current config,
+schedules an `at(1)` rollback watchdog, reloads via FRR integrated reload, and
+soft-clears BGP policy.
+
+## FRR YANG, NETCONF, and model choices
+
+FRRouting provides native FRR YANG models and the `mgmtd` management daemon.
+`mgmtd` maintains YANG-shaped candidate, running, and operational datastores and
+exposes local frontend/backend IPC sockets. By itself, `mgmtd` is not a remote
+standard NETCONF server.
+
+A standard NETCONF-over-SSH interface for FRR generally requires:
+
+1. FRR built with sysrepo northbound support, for example `--enable-sysrepo`;
+2. FRR YANG modules installed into sysrepo;
+3. a NETCONF server such as Netopeer2 connected to sysrepo;
+4. router daemons started with the required northbound plugin support.
+
+The preferred northbound target is standard NETCONF over SSH using
+Netopeer2/sysrepo **if stock packages make this feasible**. Production will not
+adopt custom FRR packages during the initial rollout. If packaged support is not
+available, production remains read-only via FRR CLI/YANG evidence while full
+NETCONF write behavior stays lab-only.
+
+Native FRR YANG models are the first practical target because they closely match
+FRR behavior. IETF/OpenConfig models may be useful later for translation or
+external interoperability, but full OpenConfig parity is out of scope for the
+first implementation.
+
+## Production source-of-truth rules
+
+1. `configs/<router>/frr.conf` is the production deployment record.
+2. Live router config, NETCONF running datastore, sysrepo contents, and FRR
+   operational state are evidence only.
+3. Any drift found in observed router state must be resolved by changing Git and
+   applying through the approved pipeline, or by reverting the router to Git.
+4. Structured Git intent may be introduced gradually for generated sections only
+   after byte-for-byte or explicitly normalized semantic parity is proven.
+5. The first eligible generated sections are policy primitives:
+   - prefix-lists;
+   - AS-path filters;
+   - route-maps;
+   - neighbor route-map attachments.
+
+Interfaces, VRFs, static routes, OSPF6, WireGuard, and base BGP neighbor
+structure remain handwritten until a later decision.
+
+## Production NETCONF access policy
+
+Any production NETCONF endpoint must be disabled by default. If later enabled
+for a specific host, it must follow these rules:
+
+- listen only on overlay/loopback addressing, never public underlay interfaces;
+- use TCP/830 only;
+- be firewall-restricted to approved management sources:
+  - `peers.ci.ipv6`;
+  - `peers.noc.ipv6`;
+  - `ops_prefix_v6`;
+- start as read-only access first;
+- require an explicit per-host PR to enable;
+- never bypass the existing Git/Ansible production gate.
+
+Production TCP/830 must remain closed unless a router explicitly sets
+`frr_netconf_endpoint_enabled: true` and the firewall role renders the matching
+restricted allow rule.
+
+## Production write gate
+
+NETCONF writes to production are blocked until all of the following are true:
+
+1. A trusted Containerlab NETCONF/YANG lab is green.
+2. The target package stack advertises the required NETCONF capabilities,
+   including candidate and validate behavior.
+3. Candidate lock, validate, commit, abort, and rollback behavior has been
+   demonstrated in lab.
+4. A NETCONF-applied lab change leaves BGP sessions established.
+5. The post-commit semantic diff matches the committed `frr.conf` intent.
+6. Persistence behavior is understood: reboot/restart must not lose or fork
+   intended FRR config.
+7. Rollback behavior is documented and tested for the target OS/package stack.
+8. Icinga pre/post snapshots are clean in the normal production apply bracket.
+9. A human approves the protected `production` environment gate.
+10. `frr_netconf_write_enabled` is explicitly enabled for the single target host
+    in the PR being applied.
+
+Until this gate is satisfied, NETCONF/YANG is used for read-only audit,
+validation, structured diffing, and lab experimentation only.
+
+## Explicit non-goals for first implementation
+
+- Making live routers authoritative.
+- Replacing `configs/<router>/frr.conf` as canonical desired state.
+- Installing custom FRR packages on production routers.
+- Exposing NETCONF on public underlay interfaces.
+- Enabling production NETCONF writes.
+- Full OpenConfig translation.
+- Replacing the existing Ansible `frr` role.
+- Managing WireGuard, OS interface config, FreeBSD `rc.conf`, Debian networkd,
+  nftables, or pf through NETCONF/YANG.
+
+## Implementation phases
+
+### Phase 1 — Read-only foundation
+
+- Add router YANG/capability inventory metadata.
+- Add a read-only `frr_yang` Ansible role and playbook.
+- Collect version, package, mgmtd, sysrepo, NETCONF, and FRR running-config
+  evidence.
+- Store runtime snapshots outside tracked generated artifacts.
+- Extend static tests to cover all routers and production write-disable
+  invariants.
+
+### Phase 2 — Structured diffing
+
+`scripts/netops/frr_semantic.py` parses committed FRR CLI config into stable
+JSON under `ansible/generated/<host>/frr-semantic.json`:
+
+```bash
+scripts/netops/frr_semantic.py --all
+scripts/netops/frr_semantic.py --diff configs/rtr/frr.conf configs/rtr/frr.conf
+```
+
+The normalized data covers BGP instances and address families, neighbors,
+route-map attachments, prefix-lists, AS-path lists, route-maps, interfaces,
+static routes, VRFs, and OSPF6. Optional read-only audit artifacts can be
+attached with `--audit-dir` for future committed-vs-observed drift reports.
+
+- Parse committed `frr.conf` files into stable JSON.
+- Normalize BGP, policy, interface, static route, OSPF6, and VRF-relevant data.
+- Compare committed intent to read-only observed running state.
+- Report semantic drift in CI/nightly audit without mutating routers.
+
+### Phase 3 — Trusted NETCONF/YANG lab
+
+The trusted lab lives under `tests/iac/containerlab/as215932-netconf.clab.yml`
+and is launched by `scripts/ci/containerlab-netconf-yang-test.sh`. It builds the
+lab-only image from `tests/iac/containerlab/netconf/Dockerfile`; that image is
+not a production packaging path.
+
+- Build a lab-only FRR image with sysrepo and Netopeer2.
+- Validate RFC-style NETCONF schema discovery and capability reporting.
+- Test candidate, validate, discard, commit, and cleanup flows.
+- Assert BGP remains established after lab candidate commits.
+
+### Phase 4 — Disabled production endpoint scaffolding
+
+- Add inventory knobs for read-only NETCONF endpoint enablement.
+- Add firewall scaffolding that only renders when explicitly enabled.
+- Keep defaults disabled everywhere.
+
+### Phase 5 — Structured intent pilots
+
+The policy intent pilot is `configs/frr-policy-intent.yml`; render it with:
+
+```bash
+scripts/netops/render_frr_policy.py
+```
+
+It writes `ansible/generated/<host>/frr-policy.{json,conf}`. Static tests compare
+that generated intent against committed `configs/<host>/frr.conf`; the generated
+artifacts are parity evidence only and are not deployed.
+
+- Introduce structured Git intent for policy primitives only.
+- Prove renderer parity against current committed policy blocks.
+- Promote generated sections only after review and passing parity tests.
+
+## Acceptance checklist
+
+- [ ] No production router config changes during initial implementation.
+- [ ] `configs/<router>/frr.conf` remains canonical.
+- [ ] All routers have static FRR policy coverage.
+- [ ] Read-only audit artifacts can be produced for each router.
+- [ ] Semantic drift can be reported without router mutation.
+- [ ] NETCONF/YANG write behavior is proven in lab before production use.
+- [ ] Production TCP/830 is closed unless explicitly enabled per host.
+- [ ] `frr_netconf_write_enabled` is false everywhere by default.

--- a/docs/netops/testing-strategy.md
+++ b/docs/netops/testing-strategy.md
@@ -13,6 +13,7 @@ the privileged `ci` runner on trusted triggers only.
 | 0 — static | `static-iac`, `ansible-idempotency` | `hyrule-public-pr` (unprivileged) | PRs with IaC path changes | **required** via `iac-gate` |
 | 1 — Batfish | `batfish` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_BATFISH_TESTS`, nightly | advisory / trusted-only |
 | 2 — Containerlab | `containerlab-frr` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_CONTAINERLAB_TESTS`, nightly | advisory / trusted-only |
+| 2 — NETCONF/YANG lab | `netconf-yang-lab` | `ci` (privileged) | `workflow_dispatch`, repo var `ENABLE_NETCONF_YANG_TESTS`, nightly | advisory / trusted-only |
 | 3 — deploy safety | `apply.yml` (manual, `production`, Icinga pre/post + Goss), `drift-detection.yml` (nightly check-mode) | `ci` (privileged) | manual / schedule | deploy-time |
 
 All of Tier 0 is in `.github/workflows/iac-tests.yml`. Tiers 1–2 also live there
@@ -57,7 +58,10 @@ session compatibility, iBGP full mesh across the three core routers, unique
 router-IDs, no undefined references, customer segment cannot reach infra
 management, authorized CI can reach management ports. Containerlab
 (`tests/iac/containerlab/`) deploys the core topology and checks FRR/BGP comes
-up. Deeper assertions (no unexpected eBGP, prefix-export hygiene,
+up. The trusted NETCONF/YANG lab builds a lab-only FRR image with sysrepo and
+Netopeer2, verifies NETCONF capability/schema discovery, exercises candidate
+validate/discard/commit/cleanup, and confirms BGP stays established afterwards.
+Deeper assertions (no unexpected eBGP, prefix-export hygiene,
 default-route/failover, topology-from-source-of-truth, advertise/withdraw sims)
 are tracked as a follow-up — they need the lab to develop and verify.
 

--- a/docs/plans/2026-06-14T16-47-37Z-as215932-netconf-yang-adoption-plan-for-frrouting.md
+++ b/docs/plans/2026-06-14T16-47-37Z-as215932-netconf-yang-adoption-plan-for-frrouting.md
@@ -1,0 +1,290 @@
+---
+created: 2026-06-14T16:47:37.890Z
+source: pi-plan-mode
+status: implemented
+---
+
+# AS215932 NETCONF/YANG Adoption Plan for FRRouting
+
+## Summary
+
+Use YANG immediately for model-driven validation, structured diffing, and read-only verification of AS215932 FRR routers. Treat production NETCONF writes as a later, gated capability: prove them in lab first, do not introduce custom FRR packages in production, and keep `configs/<host>/frr.conf` canonical until renderer parity is proven.
+
+## Locked Decisions
+
+- **Goal:** safer FRR provisioning and NetOps QoL.
+- **Source of truth:** committed `configs/<router>/frr.conf` remains canonical.
+- **Router state:** observed state only, never authoritative.
+- **Adoption:** lab first, then read-only production pilot.
+- **Northbound target:** standard NETCONF over SSH via Netopeer2/sysrepo if feasible.
+- **Production packages:** no custom FRR packages initially.
+- **Access:** any production NETCONF endpoint must be overlay-only TCP/830, firewall-restricted to `ci`, `noc`, and ops sources.
+- **Structured intent first area:** policy primitives: prefix-lists, AS-path filters, route-maps, and route-map neighbor attachments.
+
+## Key Research Findings
+
+- FRR has native YANG models and a management daemon, `mgmtd`.
+- `mgmtd` stores config in YANG-shaped candidate/running/operational datastores and exposes local frontend/backend Unix sockets, not a standard remote NETCONF server by itself.
+- Standard NETCONF for FRR generally requires FRR built with `--enable-sysrepo`, FRR YANG modules loaded into sysrepo, and a NETCONF server such as Netopeer2.
+- Public Debian/FreeBSD packaging inspected does not appear to enable the sysrepo plugin by default; verify live routers during implementation.
+- Current repo deploy path is already safe: Ansible stages `frr.conf`, validates, backs up, schedules rollback watchdog, reloads via FRR integrated reload, then soft-clears BGP.
+- `cr1-ch1` has `mgmtd` listed in committed `rc.conf`; no repo evidence of NETCONF/sysrepo/Netopeer2 on production routers.
+- No current firewall allowance exists for TCP/830.
+
+## Implementation Steps
+
+1. [x] Record the NETCONF/YANG architecture decision and production gates. See `docs/netops/netconf-yang.md`.
+2. [x] Add a router YANG/capability inventory and read-only audit role. See `ansible/roles/frr_yang/`, `ansible/playbooks/frr-yang.yml`, and router `frr_*` inventory metadata.
+3. [x] Add normalized FRR semantic extraction and structured diff tooling. See `scripts/netops/frr_semantic.py` and `ansible/generated/*/frr-semantic.json`.
+4. [x] Extend static tests to cover all four routers and policy invariants. See `tests/iac/test_frr_static.py` and router loopback coverage in `tests/iac/test_inventory_schema.py`.
+5. [x] Build a trusted Containerlab NETCONF/YANG lab. See `tests/iac/containerlab/as215932-netconf.clab.yml`, `tests/iac/containerlab/netconf/`, `tests/iac/containerlab/check_netconf_yang.py`, and `scripts/ci/containerlab-netconf-yang-test.sh`.
+6. [x] Add read-only production drift/audit workflow. See `.github/workflows/frr-yang-audit.yml`.
+7. [x] Add disabled-by-default production NETCONF endpoint scaffolding. See router `frr_netconf_*` defaults, firewall `_netconf_endpoint_*` partials, and disabled endpoint tests.
+8. [x] Introduce structured Git intent for policy primitives behind parity gates. See `configs/frr-policy-intent.yml`, `scripts/netops/render_frr_policy.py`, `ansible/generated/*/frr-policy.*`, and parity tests in `tests/iac/test_frr_static.py`.
+
+## Detailed Design
+
+### 1. Documentation and ADR
+
+Add `docs/netops/netconf-yang.md` covering:
+
+- FRR native YANG vs IETF/OpenConfig models.
+- Why production `frr.conf` remains canonical.
+- Why production NETCONF writes are blocked until lab proves:
+  - advertised NETCONF capabilities,
+  - candidate/validate/commit behavior,
+  - rollback behavior,
+  - persistence behavior,
+  - no BGP session disruption.
+- Explicitly out of scope for first implementation:
+  - making live routers authoritative,
+  - custom FRR production packages,
+  - public NETCONF exposure,
+  - full OpenConfig translation,
+  - replacing the existing `frr` Ansible role.
+
+### 2. Inventory Additions
+
+Add router metadata:
+
+- In `ansible/inventory/group_vars/routers.yml`:
+  - `frr_yang_audit_enabled: true`
+  - `frr_netconf_endpoint_enabled: false`
+  - `frr_netconf_write_enabled: false`
+  - `frr_netconf_port: 830`
+  - `frr_netconf_allowed_sources_v6`:
+    - `{{ peers.ci.ipv6 }}/128`
+    - `{{ peers.noc.ipv6 }}/128`
+    - `{{ ops_prefix_v6 }}`
+- In each router host var:
+  - `frr_version_expected`
+  - `frr_yang_profile`
+  - `frr_vrf_context`: `overlay` for `rtr`, `default` for `cr1-*`.
+
+### 3. Read-only Audit Role
+
+Add role `ansible/roles/frr_yang/`.
+
+Read-only audit tasks must run with `changed_when: false` and collect:
+
+- `vtysh -c 'show version'`
+- `vtysh -c 'show bgp ipv6 summary json'`
+- `vtysh -c 'show configuration running json bgpd'`
+- `vtysh -c 'show configuration running json staticd'`
+- `vtysh -c 'show configuration running json zebra'`
+- `vtysh -c 'show configuration running json ospf6d'`
+- `vtysh -c 'show mgmt backend-adapter all'`, allowed to fail if unsupported.
+- Package/capability evidence:
+  - Debian: `dpkg-query -W frr`
+  - FreeBSD: `pkg info -x frr`
+  - check for sysrepo plugin files/modules.
+
+Write live artifacts under:
+
+`ansible/generated/frr-yang-snapshots/<timestamp>/<host>/`
+
+Add this path to `.gitignore`.
+
+### 4. Structured Diff Tooling
+
+Add `scripts/netops/frr_semantic.py`.
+
+Inputs:
+
+- `configs/<host>/frr.conf`
+- optionally live audit JSON artifacts.
+
+Outputs stable normalized JSON:
+
+`ansible/generated/<host>/frr-semantic.json`
+
+Normalize:
+
+- hostname/version/router-id,
+- VRFs,
+- BGP ASN and AFs,
+- neighbors and route-map attachments,
+- prefix-lists,
+- AS-path access-lists,
+- route-maps,
+- advertised networks,
+- interface IPv6 addresses,
+- OSPF6 router IDs/passive/link config.
+
+Use this for structured diffs before attempting true NETCONF writes.
+
+### 5. Static Tests
+
+Update/add tests under `tests/iac/`:
+
+- Include `cr1-ch1` in FRR static coverage.
+- Derive router list from inventory instead of hardcoding three routers.
+- Assert all routers have unique router IDs.
+- Assert iBGP full mesh among `::a`, `::b`, `::c`, `::d`.
+- Assert all external eBGP neighbors have inbound and outbound route-maps.
+- Assert `AS215932v6-out` only permits `2a0c:b641:b50::/44`.
+- Assert route-maps reference existing prefix/as-path lists.
+- Assert host `frr_version_expected` matches the `frr version` line.
+- Assert no production host has `frr_netconf_write_enabled: true`.
+
+### 6. NETCONF/YANG Lab
+
+Add trusted-only lab files:
+
+- `tests/iac/containerlab/as215932-netconf.clab.yml`
+- `tests/iac/containerlab/netconf/Dockerfile`
+- `scripts/ci/containerlab-netconf-yang-test.sh`
+- `tests/iac/containerlab/check_netconf_yang.py`
+
+Lab image behavior:
+
+- Build FRR pinned to the selected lab version with:
+  - `--enable-sysrepo`
+  - `--enable-config-rollbacks`
+- Install FRR YANG modules into sysrepo.
+- Run Netopeer2 as NETCONF server.
+- Run `zebra`, `bgpd`, `ospf6d`, `staticd` with sysrepo support.
+- Keep this image lab-only.
+
+Lab assertions:
+
+- NETCONF `<hello>` succeeds.
+- RFC 6022 `/netconf-state/capabilities` is readable.
+- `get-schema` works for FRR YANG modules.
+- `get-config` returns BGP/policy data.
+- Candidate lock/validate/commit works in lab.
+- Abort/rollback restores original policy.
+- BGP sessions remain established after lab NETCONF candidate commit.
+
+Add optional workflow job gated by repo var:
+
+`ENABLE_NETCONF_YANG_TESTS=true`
+
+Do not run this on untrusted PRs.
+
+### 7. Production Read-only Workflow
+
+Add `.github/workflows/frr-yang-audit.yml`.
+
+Run on:
+
+- manual dispatch,
+- nightly after existing drift detection, or as a separate schedule.
+
+Behavior:
+
+- SSH from `ci` runner.
+- Run `ansible/playbooks/frr-yang.yml --tags audit`.
+- Upload artifacts.
+- Summarize:
+  - FRR versions,
+  - mgmtd availability,
+  - sysrepo availability,
+  - NETCONF availability,
+  - schema/profile mismatch,
+  - semantic drift between committed config and live running JSON.
+
+No production config writes, no daemon restarts, no port changes.
+
+### 8. Disabled Production NETCONF Endpoint Scaffolding
+
+Add scaffolding only; default remains disabled.
+
+When `frr_netconf_endpoint_enabled: true` for a host:
+
+- Configure NETCONF server to listen only on overlay/loopback address.
+- Open TCP/830 only from:
+  - `peers.ci.ipv6`,
+  - `peers.noc.ipv6`,
+  - `ops_prefix_v6`.
+- Never expose on underlay/public interfaces.
+- Add read-only NACM/sysrepo access first.
+- Require a separate PR to enable per host.
+
+Production write enablement remains blocked unless all are true:
+
+- lab NETCONF write test is green,
+- target advertises `:candidate` and `:validate`,
+- rollback/confirmed-commit strategy is proven,
+- semantic diff after commit equals committed `frr.conf`,
+- Icinga pre/post snapshots are clean,
+- human approves production gate.
+
+### 9. Structured Intent for Policy Primitives
+
+Add `ansible/inventory/group_vars/routers.yml` or a dedicated policy file for common policy intent.
+
+First generated sections:
+
+- `ipv6 prefix-list AS215932v6-out`
+- AS-path access-list `1`
+- cr1-de1 special AS24961 local-pref rule
+- `TRANSIT-IN`
+- `TRANSIT-OUT`
+- `TRANSIT-OUT-PREPEND-3X`
+- `IXP-IN`
+- `IXP-OUT`
+- neighbor route-map attachments
+
+Do not generate yet:
+
+- interfaces,
+- VRFs,
+- static routes,
+- OSPF6,
+- base BGP neighbor definitions,
+- WireGuard config.
+
+Parity gate:
+
+- Generator must reproduce current committed policy blocks byte-for-byte, modulo whitespace/comments explicitly normalized by tests.
+- Only after parity, add generated block markers to `frr.conf`.
+- Existing `frr` role remains deploy path.
+
+## Rollout Order
+
+1. Implement docs, metadata, static tests.
+2. Add read-only audit role and run against `rtr`.
+3. Extend to `cr1-ch1`, then `cr1-de1`, then `cr1-nl1`.
+4. Build and validate NETCONF/YANG lab.
+5. Add nightly read-only audit.
+6. Add disabled endpoint scaffolding.
+7. Enable read-only NETCONF endpoint on `rtr` only if package support exists without custom production FRR.
+8. Consider production writes only in a future PR after all gates pass.
+
+## Acceptance Criteria
+
+- No production router config changes occur during initial implementation.
+- `configs/<host>/frr.conf` remains canonical.
+- All four routers are covered by static FRR tests.
+- Read-only audit artifacts are produced for each router.
+- Drift report clearly shows canonical vs observed differences.
+- NETCONF lab proves schema discovery and candidate commit/rollback.
+- Production TCP/830 remains closed unless explicitly enabled per host.
+- `frr_netconf_write_enabled` is false everywhere.
+
+## Operational Notes
+
+- Continue using current `frr` Ansible role for production applies.
+- Treat NETCONF/YANG initially as validation, diff, and verification infrastructure.
+- If stock FRR packages cannot expose sysrepo/NETCONF safely, stop at read-only YANG audit plus lab NETCONF; do not introduce custom production packages.

--- a/scripts/ci/containerlab-netconf-yang-test.sh
+++ b/scripts/ci/containerlab-netconf-yang-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Trusted-only NETCONF/YANG lab for AS215932 FRR.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if ! command -v containerlab >/dev/null 2>&1; then
+  echo "containerlab is required for NETCONF/YANG lab tests" >&2
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for NETCONF/YANG lab tests" >&2
+  exit 1
+fi
+
+topology="tests/iac/containerlab/as215932-netconf.clab.yml"
+image="as215932/frr-netconf-yang:local"
+artifacts="tests/iac/containerlab/_artifacts/netconf-yang"
+
+collect_artifacts() {
+  mkdir -p "$artifacts"
+  sudo containerlab inspect -t "$topology" --format json >"$artifacts/inspect.json" 2>/dev/null || true
+  for node in rtr cr1-nl1 cr1-de1; do
+    docker logs "clab-as215932-netconf-${node}" >"$artifacts/${node}.docker.log" 2>&1 || true
+    docker exec "clab-as215932-netconf-${node}" vtysh -c 'show bgp ipv6 summary json' \
+      >"$artifacts/${node}.bgp-summary.json" 2>/dev/null || true
+  done
+}
+
+cleanup() {
+  collect_artifacts
+  sudo containerlab destroy -t "$topology" --cleanup >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+rm -rf "$artifacts"
+sudo containerlab destroy -t "$topology" --cleanup >/dev/null 2>&1 || true
+
+docker build -t "$image" tests/iac/containerlab/netconf
+sudo containerlab deploy -t "$topology"
+
+python3 tests/iac/containerlab/check_netconf_yang.py

--- a/scripts/netops/frr_semantic.py
+++ b/scripts/netops/frr_semantic.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Normalize FRRouting config into stable JSON for semantic diffing.
+
+Production desired state remains configs/<host>/frr.conf. This script parses
+that CLI config into a deterministic, YANG-adjacent structure that can be used
+by CI, reviews, and future NETCONF/YANG read-only audits before any write path
+is considered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_GENERATED_ROOT = REPO / "ansible" / "generated"
+
+
+def _tokens(value: str) -> list[str]:
+    return value.strip().split()
+
+
+def _default_vrf(vrf: str | None) -> str:
+    return vrf or "default"
+
+
+def _empty_ospf6_interface() -> dict[str, Any]:
+    return {"areas": [], "networks": [], "passive": False}
+
+
+def _empty_interface(name: str, vrf: str | None = None) -> dict[str, Any]:
+    return {
+        "name": name,
+        "vrf": _default_vrf(vrf),
+        "ipv6_addresses": [],
+        "ospf6": _empty_ospf6_interface(),
+        "raw_commands": [],
+    }
+
+
+def _empty_bgp_instance(asn: int, vrf: str | None = None) -> dict[str, Any]:
+    return {
+        "asn": asn,
+        "vrf": _default_vrf(vrf),
+        "router_id": None,
+        "flags": [],
+        "neighbors": {},
+        "address_families": {},
+        "raw_commands": [],
+    }
+
+
+def _empty_bgp_neighbor(address: str) -> dict[str, Any]:
+    return {
+        "address": address,
+        "remote_as": None,
+        "description": None,
+        "update_source": None,
+        "enforce_first_as": True,
+        "raw_commands": [],
+    }
+
+
+def _empty_bgp_af() -> dict[str, Any]:
+    return {"networks": [], "neighbors": {}, "raw_commands": []}
+
+
+def _empty_bgp_af_neighbor(address: str) -> dict[str, Any]:
+    return {
+        "address": address,
+        "activate": False,
+        "next_hop_self": False,
+        "soft_reconfiguration": [],
+        "route_maps": {},
+        "raw_commands": [],
+    }
+
+
+def _empty_ospf6_instance(vrf: str | None = None) -> dict[str, Any]:
+    return {
+        "vrf": _default_vrf(vrf),
+        "router_id": None,
+        "redistribute": [],
+        "raw_commands": [],
+    }
+
+
+def _parse_static_route(line: str) -> dict[str, Any]:
+    parts = _tokens(line)
+    route: dict[str, Any] = {"raw": line}
+    if len(parts) >= 3:
+        route["afi"] = parts[0]
+        route["prefix"] = parts[2]
+    if len(parts) >= 4:
+        route["next_hop"] = parts[3]
+    if len(parts) >= 5:
+        route["distance_or_table"] = " ".join(parts[4:])
+    return route
+
+
+def _parse_interface_header(line: str) -> tuple[str, str | None]:
+    parts = _tokens(line)
+    name = parts[1]
+    vrf = None
+    if "vrf" in parts:
+        idx = parts.index("vrf")
+        if idx + 1 < len(parts):
+            vrf = parts[idx + 1]
+    return name, vrf
+
+
+def _parse_bgp_header(line: str) -> tuple[int, str | None]:
+    parts = _tokens(line)
+    asn = int(parts[2])
+    vrf = None
+    if "vrf" in parts:
+        idx = parts.index("vrf")
+        if idx + 1 < len(parts):
+            vrf = parts[idx + 1]
+    return asn, vrf
+
+
+def _parse_ospf6_header(line: str) -> str | None:
+    parts = _tokens(line)
+    if "vrf" in parts:
+        idx = parts.index("vrf")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    return None
+
+
+def _route_map_entry(route_maps: dict[str, Any], name: str, action: str, seq: int) -> dict[str, Any]:
+    rm = route_maps.setdefault(name, {"name": name, "sequences": {}})
+    seq_key = str(seq)
+    return rm["sequences"].setdefault(
+        seq_key,
+        {
+            "action": action,
+            "seq": seq,
+            "matches": [],
+            "sets": [],
+            "on_match": [],
+            "raw_commands": [],
+        },
+    )
+
+
+def _sort_semantic(data: dict[str, Any]) -> dict[str, Any]:
+    for family in data["prefix_lists"].values():
+        for entries in family.values():
+            entries.sort(key=lambda item: (item.get("seq", -1), item.get("raw", "")))
+
+    for entries in data["as_path_access_lists"].values():
+        entries.sort(key=lambda item: (item.get("seq") is None, item.get("seq") or -1, item.get("raw", "")))
+
+    for routes in data["static_routes"].values():
+        routes.sort(key=lambda item: item.get("raw", ""))
+
+    for interface in data["interfaces"].values():
+        interface["ipv6_addresses"].sort()
+        interface["ospf6"]["areas"].sort()
+        interface["ospf6"]["networks"].sort()
+        interface["raw_commands"].sort()
+
+    data["bgp"]["instances"].sort(key=lambda item: (item["vrf"], item["asn"]))
+    for instance in data["bgp"]["instances"]:
+        instance["flags"].sort()
+        instance["raw_commands"].sort()
+        for neighbor in instance["neighbors"].values():
+            neighbor["raw_commands"].sort()
+        for af in instance["address_families"].values():
+            af["networks"].sort()
+            af["raw_commands"].sort()
+            for neighbor in af["neighbors"].values():
+                neighbor["soft_reconfiguration"].sort()
+                neighbor["raw_commands"].sort()
+
+    data["ospf6"]["instances"].sort(key=lambda item: item["vrf"])
+    for instance in data["ospf6"]["instances"]:
+        instance["raw_commands"].sort()
+
+    for rm in data["route_maps"].values():
+        for seq in rm["sequences"].values():
+            seq["matches"].sort()
+            seq["sets"].sort()
+            seq["on_match"].sort()
+            seq["raw_commands"].sort()
+
+    return data
+
+
+def source_label(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO))
+    except ValueError:
+        return str(path)
+
+
+def parse_frr_config(path: Path, *, host: str | None = None) -> dict[str, Any]:
+    text = path.read_text()
+    data: dict[str, Any] = {
+        "schema_version": 1,
+        "host": host or path.parent.name,
+        "source": source_label(path),
+        "frr_version": None,
+        "hostname": None,
+        "logging": [],
+        "services": [],
+        "vrfs": {},
+        "static_routes": {"default": []},
+        "interfaces": {},
+        "prefix_lists": {"ipv4": {}, "ipv6": {}},
+        "as_path_access_lists": {},
+        "route_maps": {},
+        "bgp": {"instances": []},
+        "ospf6": {"instances": []},
+    }
+
+    current: tuple[str, Any] | None = None
+    current_bgp: dict[str, Any] | None = None
+    current_af_name: str | None = None
+    current_route_map_seq: dict[str, Any] | None = None
+    current_interface: dict[str, Any] | None = None
+    current_ospf6: dict[str, Any] | None = None
+    current_vrf: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("!"):
+            continue
+
+        if line == "exit-address-family":
+            current_af_name = None
+            continue
+        if line in {"exit", "exit-vrf"}:
+            if current and current[0] == "bgp" and current_af_name:
+                current_af_name = None
+            else:
+                current = None
+                current_bgp = None
+                current_route_map_seq = None
+                current_interface = None
+                current_ospf6 = None
+                current_vrf = None
+            continue
+
+        if match := re.match(r"^frr version\s+(\S+)$", line):
+            data["frr_version"] = match.group(1)
+            continue
+        if match := re.match(r"^hostname\s+(.+)$", line):
+            data["hostname"] = match.group(1)
+            continue
+        if line.startswith("log "):
+            data["logging"].append(line)
+            continue
+        if line.startswith("service "):
+            data["services"].append(line)
+            continue
+
+        if match := re.match(r"^(ip|ipv6) prefix-list\s+(\S+)\s+seq\s+(\d+)\s+(permit|deny)\s+(.+)$", line):
+            afi = "ipv6" if match.group(1) == "ipv6" else "ipv4"
+            name = match.group(2)
+            data["prefix_lists"][afi].setdefault(name, []).append(
+                {
+                    "name": name,
+                    "seq": int(match.group(3)),
+                    "action": match.group(4),
+                    "value": match.group(5),
+                    "raw": line,
+                }
+            )
+            continue
+
+        if match := re.match(r"^bgp as-path access-list\s+(\S+)\s+(?:seq\s+(\d+)\s+)?(permit|deny)\s+(.+)$", line):
+            name = match.group(1)
+            data["as_path_access_lists"].setdefault(name, []).append(
+                {
+                    "name": name,
+                    "seq": int(match.group(2)) if match.group(2) else None,
+                    "action": match.group(3),
+                    "pattern": match.group(4),
+                    "raw": line,
+                }
+            )
+            continue
+
+        if line.startswith("vrf "):
+            current_vrf = _tokens(line)[1]
+            data["vrfs"].setdefault(current_vrf, {"name": current_vrf, "static_routes": []})
+            data["static_routes"].setdefault(current_vrf, [])
+            current = ("vrf", current_vrf)
+            continue
+
+        if line.startswith("interface "):
+            name, vrf = _parse_interface_header(line)
+            current_interface = data["interfaces"].setdefault(name, _empty_interface(name, vrf))
+            if vrf:
+                current_interface["vrf"] = vrf
+            current = ("interface", name)
+            continue
+
+        if line.startswith("router bgp "):
+            asn, vrf = _parse_bgp_header(line)
+            current_bgp = _empty_bgp_instance(asn, vrf)
+            data["bgp"]["instances"].append(current_bgp)
+            current = ("bgp", len(data["bgp"]["instances"]) - 1)
+            continue
+
+        if line.startswith("router ospf6"):
+            vrf = _parse_ospf6_header(line)
+            current_ospf6 = _empty_ospf6_instance(vrf)
+            data["ospf6"]["instances"].append(current_ospf6)
+            current = ("ospf6", len(data["ospf6"]["instances"]) - 1)
+            continue
+
+        if match := re.match(r"^route-map\s+(\S+)\s+(permit|deny)\s+(\d+)$", line):
+            current_route_map_seq = _route_map_entry(data["route_maps"], match.group(1), match.group(2), int(match.group(3)))
+            current = ("route-map", match.group(1), int(match.group(3)))
+            continue
+
+        if line.startswith("address-family ") and current_bgp is not None:
+            current_af_name = line.removeprefix("address-family ")
+            current_bgp["address_families"].setdefault(current_af_name, _empty_bgp_af())
+            continue
+
+        if line.startswith("ipv6 route "):
+            route = _parse_static_route(line)
+            vrf = current_vrf or "default"
+            data["static_routes"].setdefault(vrf, []).append(route)
+            if current_vrf:
+                data["vrfs"].setdefault(current_vrf, {"name": current_vrf, "static_routes": []})["static_routes"].append(route)
+            continue
+
+        if current and current[0] == "interface" and current_interface is not None:
+            current_interface["raw_commands"].append(line)
+            if line.startswith("ipv6 address "):
+                current_interface["ipv6_addresses"].append(line.removeprefix("ipv6 address "))
+            elif line.startswith("ipv6 ospf6 area "):
+                current_interface["ospf6"]["areas"].append(line.removeprefix("ipv6 ospf6 area "))
+            elif line == "ipv6 ospf6 passive":
+                current_interface["ospf6"]["passive"] = True
+            elif line.startswith("ipv6 ospf6 network "):
+                current_interface["ospf6"]["networks"].append(line.removeprefix("ipv6 ospf6 network "))
+            continue
+
+        if current and current[0] == "bgp" and current_bgp is not None:
+            if current_af_name:
+                af = current_bgp["address_families"].setdefault(current_af_name, _empty_bgp_af())
+                af["raw_commands"].append(line)
+                if line.startswith("network "):
+                    af["networks"].append(line.removeprefix("network "))
+                elif line.startswith("neighbor "):
+                    parts = _tokens(line)
+                    if len(parts) >= 3:
+                        address = parts[1]
+                        neighbor = af["neighbors"].setdefault(address, _empty_bgp_af_neighbor(address))
+                        neighbor["raw_commands"].append(line)
+                        command = parts[2]
+                        if command == "activate":
+                            neighbor["activate"] = True
+                        elif command == "next-hop-self":
+                            neighbor["next_hop_self"] = True
+                        elif command == "soft-reconfiguration":
+                            neighbor["soft_reconfiguration"].append(" ".join(parts[3:]) or "enabled")
+                        elif command == "route-map" and len(parts) >= 5:
+                            neighbor["route_maps"][parts[4]] = parts[3]
+                continue
+
+            current_bgp["raw_commands"].append(line)
+            if line.startswith("bgp router-id "):
+                current_bgp["router_id"] = line.removeprefix("bgp router-id ")
+            elif line.startswith("no bgp ") or line.startswith("bgp "):
+                current_bgp["flags"].append(line)
+            elif line.startswith("neighbor "):
+                parts = _tokens(line)
+                if len(parts) >= 3:
+                    address = parts[1]
+                    neighbor = current_bgp["neighbors"].setdefault(address, _empty_bgp_neighbor(address))
+                    neighbor["raw_commands"].append(line)
+                    command = parts[2]
+                    if command == "remote-as" and len(parts) >= 4:
+                        neighbor["remote_as"] = int(parts[3])
+                    elif command == "description" and len(parts) >= 4:
+                        neighbor["description"] = " ".join(parts[3:])
+                    elif command == "update-source" and len(parts) >= 4:
+                        neighbor["update_source"] = " ".join(parts[3:])
+            elif line.startswith("no neighbor "):
+                parts = _tokens(line)
+                if len(parts) >= 4:
+                    address = parts[2]
+                    neighbor = current_bgp["neighbors"].setdefault(address, _empty_bgp_neighbor(address))
+                    neighbor["raw_commands"].append(line)
+                    if parts[3:] == ["enforce-first-as"]:
+                        neighbor["enforce_first_as"] = False
+            continue
+
+        if current and current[0] == "ospf6" and current_ospf6 is not None:
+            current_ospf6["raw_commands"].append(line)
+            if line.startswith("ospf6 router-id "):
+                current_ospf6["router_id"] = line.removeprefix("ospf6 router-id ")
+            elif line.startswith("redistribute "):
+                current_ospf6["redistribute"].append(line.removeprefix("redistribute "))
+            continue
+
+        if current and current[0] == "route-map" and current_route_map_seq is not None:
+            current_route_map_seq["raw_commands"].append(line)
+            if line.startswith("match "):
+                current_route_map_seq["matches"].append(line.removeprefix("match "))
+            elif line.startswith("set "):
+                current_route_map_seq["sets"].append(line.removeprefix("set "))
+            elif line.startswith("on-match "):
+                current_route_map_seq["on_match"].append(line.removeprefix("on-match "))
+            continue
+
+    return _sort_semantic(data)
+
+
+def load_audit_dir(audit_dir: Path) -> dict[str, Any]:
+    audit: dict[str, Any] = {"path": str(audit_dir), "json_artifacts": {}, "text_artifacts": {}}
+    audit_json = audit_dir / "audit.json"
+    if audit_json.exists():
+        try:
+            audit["metadata"] = json.loads(audit_json.read_text())
+        except json.JSONDecodeError as exc:
+            audit["metadata_error"] = str(exc)
+
+    for artifact in sorted(audit_dir.glob("*.stdout")):
+        text = artifact.read_text()
+        key = artifact.name.removesuffix(".stdout")
+        try:
+            audit["json_artifacts"][key] = json.loads(text)
+        except json.JSONDecodeError:
+            audit["text_artifacts"][key] = text
+    return audit
+
+
+def semantic_json(data: dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def write_semantic(config: Path, output: Path, *, host: str | None = None, audit_dir: Path | None = None) -> None:
+    data = parse_frr_config(config, host=host)
+    if audit_dir is not None:
+        data["audit"] = load_audit_dir(audit_dir)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(semantic_json(data))
+
+
+def render_all() -> list[Path]:
+    configs = sorted((REPO / "configs").glob("*/frr.conf"))
+    outputs = []
+    for config in configs:
+        host = config.parent.name
+        output = DEFAULT_GENERATED_ROOT / host / "frr-semantic.json"
+        write_semantic(config, output, host=host)
+        outputs.append(output)
+    return outputs
+
+
+def diff_configs(left: Path, right: Path) -> int:
+    left_json = semantic_json(parse_frr_config(left))
+    right_json = semantic_json(parse_frr_config(right))
+    if left_json == right_json:
+        return 0
+    sys.stdout.writelines(
+        difflib.unified_diff(
+            left_json.splitlines(keepends=True),
+            right_json.splitlines(keepends=True),
+            fromfile=str(left),
+            tofile=str(right),
+        )
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true", help="render all configs/*/frr.conf files to ansible/generated/<host>/frr-semantic.json")
+    parser.add_argument("--config", type=Path, action="append", help="FRR config file to parse; may be passed multiple times")
+    parser.add_argument("--host", help="host name for a single --config render; defaults to config parent directory")
+    parser.add_argument("--output", type=Path, help="output path for a single --config render; defaults to ansible/generated/<host>/frr-semantic.json")
+    parser.add_argument("--audit-dir", type=Path, help="optional frr_yang audit artifact directory to attach to a single render")
+    parser.add_argument("--diff", nargs=2, type=Path, metavar=("LEFT", "RIGHT"), help="print a unified diff of normalized semantic JSON for two configs")
+    args = parser.parse_args(argv)
+
+    if args.diff:
+        return diff_configs(args.diff[0], args.diff[1])
+
+    if args.all or not args.config:
+        outputs = render_all()
+        for output in outputs:
+            print(output)
+        return 0
+
+    if args.audit_dir and len(args.config) != 1:
+        parser.error("--audit-dir is only supported with a single --config")
+    if args.host and len(args.config) != 1:
+        parser.error("--host is only supported with a single --config")
+    if args.output and len(args.config) != 1:
+        parser.error("--output is only supported with a single --config")
+
+    for config in args.config:
+        host = args.host or config.parent.name
+        output = args.output or DEFAULT_GENERATED_ROOT / host / "frr-semantic.json"
+        write_semantic(config, output, host=host, audit_dir=args.audit_dir)
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/netops/render_frr_policy.py
+++ b/scripts/netops/render_frr_policy.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Render the structured FRR policy intent pilot.
+
+The generated policy artifacts are a parity gate only. They do not replace the
+committed configs/<host>/frr.conf files and are not deployed directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_INTENT = REPO / "configs" / "frr-policy-intent.yml"
+DEFAULT_GENERATED_ROOT = REPO / "ansible" / "generated"
+
+
+def load_intent(path: Path = DEFAULT_INTENT) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _merge_mapping(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    result = deepcopy(base)
+    for key, value in overlay.items():
+        result[key] = deepcopy(value)
+    return result
+
+
+def effective_policy(intent: dict[str, Any], host: str) -> dict[str, Any]:
+    common = intent.get("common") or {}
+    host_intent = (intent.get("hosts") or {}).get(host) or {}
+    route_maps = host_intent.get("route_maps")
+    if route_maps is None:
+        route_maps = common.get("route_maps") or {}
+
+    policy = {
+        "schema_version": intent.get("schema_version", 1),
+        "host": host,
+        "ipv6_prefix_lists": _merge_mapping(
+            common.get("ipv6_prefix_lists") or {},
+            host_intent.get("ipv6_prefix_lists") or {},
+        ),
+        "as_path_access_lists": _merge_mapping(
+            common.get("as_path_access_lists") or {},
+            host_intent.get("as_path_access_lists") or {},
+        ),
+        "route_maps": deepcopy(route_maps),
+        "neighbor_route_maps": deepcopy(host_intent.get("neighbor_route_maps") or {}),
+    }
+    return normalize_policy(policy)
+
+
+def normalize_policy(policy: dict[str, Any]) -> dict[str, Any]:
+    for entries in policy["ipv6_prefix_lists"].values():
+        entries.sort(key=lambda item: (item.get("seq", -1), item.get("action", ""), item.get("value", "")))
+    for entries in policy["as_path_access_lists"].values():
+        entries.sort(key=lambda item: (item.get("seq") is None, item.get("seq") or -1, item.get("pattern", "")))
+    for sequences in policy["route_maps"].values():
+        for seq in sequences:
+            seq.setdefault("matches", [])
+            seq.setdefault("sets", [])
+            seq.setdefault("on_match", [])
+            seq["matches"].sort()
+            seq["sets"].sort()
+            seq["on_match"].sort()
+        sequences.sort(key=lambda item: (item.get("seq", -1), item.get("action", "")))
+    return policy
+
+
+def policy_json(policy: dict[str, Any]) -> str:
+    return json.dumps(policy, indent=2, sort_keys=True) + "\n"
+
+
+def render_policy_conf(policy: dict[str, Any]) -> str:
+    lines = [
+        f"! Generated FRR policy parity artifact for {policy['host']}",
+        "! Source: configs/frr-policy-intent.yml",
+        "! Not deployed directly; configs/<host>/frr.conf remains canonical.",
+        "!",
+    ]
+
+    for name, entries in sorted(policy["ipv6_prefix_lists"].items()):
+        for entry in entries:
+            lines.append(f"ipv6 prefix-list {name} seq {entry['seq']} {entry['action']} {entry['value']}")
+    lines.append("!")
+
+    for name, entries in sorted(policy["as_path_access_lists"].items()):
+        for entry in entries:
+            seq = f" seq {entry['seq']}" if entry.get("seq") is not None else ""
+            lines.append(f"bgp as-path access-list {name}{seq} {entry['action']} {entry['pattern']}")
+    lines.append("!")
+
+    for name, sequences in sorted(policy["route_maps"].items()):
+        for sequence in sequences:
+            lines.append(f"route-map {name} {sequence['action']} {sequence['seq']}")
+            for match in sequence.get("matches", []):
+                lines.append(f" match {match}")
+            for set_action in sequence.get("sets", []):
+                lines.append(f" set {set_action}")
+            for on_match in sequence.get("on_match", []):
+                lines.append(f" on-match {on_match}")
+            lines.append("exit")
+            lines.append("!")
+
+    if policy["neighbor_route_maps"]:
+        lines.append("! Neighbor route-map attachments for address-family ipv6 unicast")
+        for neighbor, attachments in sorted(policy["neighbor_route_maps"].items()):
+            for direction in ("in", "out"):
+                if direction in attachments:
+                    lines.append(f"neighbor {neighbor} route-map {attachments[direction]} {direction}")
+        lines.append("!")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_all(intent_path: Path = DEFAULT_INTENT, generated_root: Path = DEFAULT_GENERATED_ROOT) -> list[Path]:
+    intent = load_intent(intent_path)
+    outputs: list[Path] = []
+    for host in sorted((intent.get("hosts") or {})):
+        policy = effective_policy(intent, host)
+        host_dir = generated_root / host
+        host_dir.mkdir(parents=True, exist_ok=True)
+        json_path = host_dir / "frr-policy.json"
+        conf_path = host_dir / "frr-policy.conf"
+        json_path.write_text(policy_json(policy))
+        conf_path.write_text(render_policy_conf(policy))
+        outputs.extend([json_path, conf_path])
+    return outputs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--intent", type=Path, default=DEFAULT_INTENT)
+    parser.add_argument("--generated-root", type=Path, default=DEFAULT_GENERATED_ROOT)
+    args = parser.parse_args(argv)
+
+    for output in render_all(args.intent, args.generated_root):
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/iac/containerlab/as215932-netconf.clab.yml
+++ b/tests/iac/containerlab/as215932-netconf.clab.yml
@@ -1,0 +1,33 @@
+---
+name: as215932-netconf
+
+# Trusted-only lab for standard NETCONF/YANG behavior. The image is built by
+# scripts/ci/containerlab-netconf-yang-test.sh from netconf/Dockerfile and is
+# intentionally lab-only; production routers must keep stock FRR packages.
+
+topology:
+  kinds:
+    linux:
+      image: as215932/frr-netconf-yang:local
+      binds:
+        - /lib/modules:/lib/modules:ro
+        - ./configs/vtysh.conf:/etc/frr/vtysh.conf:ro
+
+  nodes:
+    rtr:
+      kind: linux
+      binds:
+        - ./configs/rtr/frr.conf:/etc/frr/frr.conf:ro
+    cr1-nl1:
+      kind: linux
+      binds:
+        - ./configs/cr1-nl1/frr.conf:/etc/frr/frr.conf:ro
+    cr1-de1:
+      kind: linux
+      binds:
+        - ./configs/cr1-de1/frr.conf:/etc/frr/frr.conf:ro
+
+  links:
+    - endpoints: ["rtr:eth1", "cr1-nl1:eth1"]
+    - endpoints: ["rtr:eth2", "cr1-de1:eth1"]
+    - endpoints: ["cr1-nl1:eth2", "cr1-de1:eth2"]

--- a/tests/iac/containerlab/check_netconf_yang.py
+++ b/tests/iac/containerlab/check_netconf_yang.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Dynamic NETCONF/YANG assertions for the trusted AS215932 FRR lab."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+
+
+NODES = ("rtr", "cr1-nl1", "cr1-de1")
+LAB_PREFIX = "clab-as215932-netconf"
+CONVERGENCE_TIMEOUT_SECONDS = 120
+POLL_INTERVAL_SECONDS = 3
+
+
+def docker_exec(node: str, *command: str) -> str:
+    return subprocess.check_output(["docker", "exec", f"{LAB_PREFIX}-{node}", *command], text=True)
+
+
+def vtysh_json(node: str, command: str) -> dict:
+    return json.loads(docker_exec(node, "vtysh", "-c", f"{command} json"))
+
+
+def bgp_summary(node: str) -> dict:
+    summary = vtysh_json(node, "show bgp ipv6 summary")
+    return summary.get("ipv6Unicast", summary)
+
+
+def non_established_peers(summary: dict) -> dict[str, str | None]:
+    peers = summary.get("peers", {})
+    return {peer: data.get("state") for peer, data in peers.items() if data.get("state") != "Established"}
+
+
+def check_all_bgp_established() -> list[str]:
+    errors = []
+    for node in NODES:
+        try:
+            summary = bgp_summary(node)
+        except Exception as exc:  # noqa: BLE001 - lab diagnostic path.
+            errors.append(f"{node}: failed to query BGP summary: {exc}")
+            continue
+        peers = summary.get("peers", {})
+        if not peers:
+            errors.append(f"{node}: no BGP peers visible in lab")
+            continue
+        for peer, state in non_established_peers(summary).items():
+            errors.append(f"{node}: BGP peer {peer} is {state}, expected Established")
+    return errors
+
+
+def wait_for_bgp() -> None:
+    deadline = time.monotonic() + CONVERGENCE_TIMEOUT_SECONDS
+    last_errors = []
+    while time.monotonic() < deadline:
+        last_errors = check_all_bgp_established()
+        if not last_errors:
+            return
+        time.sleep(POLL_INTERVAL_SECONDS)
+    raise AssertionError("BGP did not converge: " + "; ".join(last_errors))
+
+
+def run_netconf_smoke(node: str) -> dict:
+    output = docker_exec(node, "python3", "/usr/local/bin/as215932-netconf-smoke.py")
+    return json.loads(output)
+
+
+def main() -> int:
+    wait_for_bgp()
+    netconf_summary = run_netconf_smoke("rtr")
+    wait_for_bgp()
+
+    print(json.dumps({"netconf": netconf_summary, "nodes": list(NODES)}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - lab diagnostic path.
+        print(f"NETCONF/YANG lab failed: {exc}", file=sys.stderr)
+        raise

--- a/tests/iac/containerlab/netconf/Dockerfile
+++ b/tests/iac/containerlab/netconf/Dockerfile
@@ -1,0 +1,89 @@
+# Lab-only FRR NETCONF/YANG image.
+#
+# This intentionally builds FRR with sysrepo support for Containerlab tests. It
+# must not be used as a production packaging path for AS215932 routers.
+
+FROM debian:sid-slim
+
+ARG FRR_REF=stable/10.4
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      autoconf \
+      automake \
+      bison \
+      build-essential \
+      ca-certificates \
+      cmake \
+      flex \
+      git \
+      iproute2 \
+      jq \
+      libcap-dev \
+      libc-ares-dev \
+      libelf-dev \
+      libjson-c-dev \
+      libpcre2-dev \
+      libprotobuf-c-dev \
+      libreadline-dev \
+      libsqlite3-dev \
+      libsysrepo-dev \
+      libtool \
+      libyang3-dev \
+      make \
+      netopeer2 \
+      openssh-client \
+      pkg-config \
+      protobuf-c-compiler \
+      python3 \
+      python3-pip \
+      sqlite3 \
+      sysrepo \
+      sysrepo-modules \
+      sysrepo-plugind \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --system frr \
+ && groupadd --system frrvty \
+ && useradd --system --home-dir /var/run/frr --gid frr --groups frrvty --shell /usr/sbin/nologin frr \
+ && useradd --create-home --shell /bin/bash netconf \
+ && echo 'netconf:netconf' | chpasswd
+
+RUN git clone --depth=1 --branch "${FRR_REF}" https://github.com/FRRouting/frr.git /usr/src/frr
+
+WORKDIR /usr/src/frr
+RUN ./bootstrap.sh \
+ && ./configure \
+      --prefix=/usr \
+      --sbindir=/usr/lib/frr \
+      --sysconfdir=/etc/frr \
+      --localstatedir=/run/frr \
+      --with-moduledir=/usr/lib/frr/modules \
+      --with-yangmodelsdir=/usr/share/yang \
+      --enable-user=frr \
+      --enable-group=frr \
+      --enable-vty-group=frrvty \
+      --enable-vtysh \
+      --enable-configfile-mask=0640 \
+      --enable-logfile-mask=0640 \
+      --enable-config-rollbacks \
+      --enable-sysrepo \
+      --disable-doc \
+ && make -j"$(nproc)" \
+ && make install
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir ncclient
+
+COPY install-frr-yang-modules.sh /usr/local/sbin/install-frr-yang-modules.sh
+RUN chmod +x /usr/local/sbin/install-frr-yang-modules.sh \
+ && /usr/local/sbin/install-frr-yang-modules.sh
+
+COPY entrypoint.sh /usr/local/sbin/as215932-netconf-entrypoint.sh
+COPY netconf_smoke.py /usr/local/bin/as215932-netconf-smoke.py
+RUN chmod +x /usr/local/sbin/as215932-netconf-entrypoint.sh /usr/local/bin/as215932-netconf-smoke.py \
+ && mkdir -p /etc/frr /run/frr \
+ && chown -R frr:frr /etc/frr /run/frr
+
+EXPOSE 830/tcp
+ENTRYPOINT ["/usr/local/sbin/as215932-netconf-entrypoint.sh"]

--- a/tests/iac/containerlab/netconf/entrypoint.sh
+++ b/tests/iac/containerlab/netconf/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Lab-only startup for FRR + Netopeer2/sysrepo.
+
+set -euo pipefail
+
+mkdir -p /run/frr /var/log/frr /etc/frr
+chown -R frr:frr /run/frr /var/log/frr /etc/frr
+chmod 775 /run/frr
+
+# netopeer2/libssh needs host keys for the SSH transport.
+ssh-keygen -A >/dev/null 2>&1 || true
+
+# Re-assert module ownership in case the sysrepo datastore was mounted fresh.
+/usr/local/sbin/install-frr-yang-modules.sh >/var/log/frr/sysrepo-yang-install.log 2>&1 || {
+  cat /var/log/frr/sysrepo-yang-install.log >&2
+  exit 1
+}
+
+# Start FRR daemons directly so the sysrepo northbound module is definitely
+# loaded. Keep VTY on loopback; NETCONF is provided by Netopeer2 on TCP/830.
+/usr/lib/frr/zebra -d -f /etc/frr/frr.conf -A 127.0.0.1 -M sysrepo
+/usr/lib/frr/staticd -d -f /etc/frr/frr.conf -A 127.0.0.1 -M sysrepo
+/usr/lib/frr/bgpd -d -f /etc/frr/frr.conf -A 127.0.0.1 -M sysrepo
+/usr/lib/frr/ospf6d -d -f /etc/frr/frr.conf -A ::1 -M sysrepo || true
+
+# Start Netopeer2 in the background. The Debian package configures the base
+# NETCONF server modules; FRR modules were installed above.
+netopeer2-server -d -v 2 >/var/log/frr/netopeer2.log 2>&1 &
+
+sleep infinity

--- a/tests/iac/containerlab/netconf/install-frr-yang-modules.sh
+++ b/tests/iac/containerlab/netconf/install-frr-yang-modules.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Install the FRR YANG module set needed by the NETCONF/YANG lab into sysrepo.
+# This script is lab-only and runs inside the Containerlab image.
+
+set -euo pipefail
+
+YANG_DIR="${YANG_DIR:-/usr/share/yang}"
+cd "$YANG_DIR"
+
+install_module() {
+  local module_path="$1"
+  local module_name
+  module_name="$(basename "$module_path" .yang)"
+
+  if [ ! -f "$module_path" ]; then
+    echo "missing YANG module: $module_path" >&2
+    return 1
+  fi
+
+  if sysrepoctl -l 2>/dev/null | awk '{print $1}' | grep -qx "$module_name"; then
+    sysrepoctl -c "$module_name" -o frr -g frr >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  sysrepoctl -i "$module_path" -s "$YANG_DIR" -o frr -g frr
+}
+
+# IETF/sysrepo dependencies first.
+modules=(
+  ietf/ietf-interfaces.yang
+  ietf/ietf-routing-types.yang
+  ietf/ietf-bgp-types.yang
+  ietf/ietf-netconf-acm.yang
+  ietf/ietf-netconf.yang
+  ietf/ietf-netconf-with-defaults.yang
+  ietf/ietf-srv6-types.yang
+  frr-vrf.yang
+  frr-route-types.yang
+  frr-interface.yang
+  frr-routing.yang
+  frr-filter.yang
+  frr-route-map.yang
+  frr-nexthop.yang
+  frr-if-rmap.yang
+  frr-affinity-map.yang
+  frr-bfdd.yang
+  frr-bgp-types.yang
+  frr-bgp-filter.yang
+  frr-bgp-route-map.yang
+  frr-bgp.yang
+  frr-staticd.yang
+  frr-zebra-route-map.yang
+  frr-zebra.yang
+  frr-ospf-route-map.yang
+  frr-ospf6-route-map.yang
+)
+
+for module in "${modules[@]}"; do
+  install_module "$module"
+done
+
+sysrepoctl -l | grep -E '(^frr-(bgp|interface|route-map|zebra|staticd)\b|^ietf-netconf\b)'

--- a/tests/iac/containerlab/netconf/netconf_smoke.py
+++ b/tests/iac/containerlab/netconf/netconf_smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""NETCONF/YANG smoke checks executed inside the lab router container."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from ncclient import manager
+
+
+NETCONF_HOST = "127.0.0.1"
+NETCONF_PORT = 830
+NETCONF_USER = "netconf"
+NETCONF_PASSWORD = "netconf"
+MARKER = "as215932-netconf-lab-probe"
+
+INTERFACE_FILTER = """
+<lib xmlns="http://frrouting.org/yang/interface">
+  <interface>
+    <name>lo</name>
+  </interface>
+</lib>
+"""
+
+INTERFACE_DESCRIPTION_MERGE = f"""
+<config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <lib xmlns="http://frrouting.org/yang/interface">
+    <interface>
+      <name>lo</name>
+      <description>{MARKER}</description>
+    </interface>
+  </lib>
+</config>
+"""
+
+INTERFACE_DESCRIPTION_REMOVE = """
+<config xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <lib xmlns="http://frrouting.org/yang/interface">
+    <interface>
+      <name>lo</name>
+      <description nc:operation="remove"/>
+    </interface>
+  </lib>
+</config>
+"""
+
+NETCONF_STATE_FILTER = """
+<netconf-state xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring">
+  <capabilities/>
+  <schemas/>
+  <sessions/>
+</netconf-state>
+"""
+
+
+def require_capability(caps: list[str], needle: str) -> None:
+    if not any(needle in cap for cap in caps):
+        raise AssertionError(f"missing NETCONF capability containing {needle!r}")
+
+
+def running_interface_xml(conn: manager.Manager) -> str:
+    return str(conn.get_config(source="running", filter=("subtree", INTERFACE_FILTER)).data_xml)
+
+
+def main() -> int:
+    summary: dict[str, Any] = {}
+    with manager.connect(
+        host=NETCONF_HOST,
+        port=NETCONF_PORT,
+        username=NETCONF_USER,
+        password=NETCONF_PASSWORD,
+        hostkey_verify=False,
+        allow_agent=False,
+        look_for_keys=False,
+        timeout=15,
+    ) as conn:
+        caps = sorted(str(cap) for cap in conn.server_capabilities)
+        summary["capability_count"] = len(caps)
+        require_capability(caps, ":candidate")
+        require_capability(caps, ":validate")
+        require_capability(caps, "ietf-netconf-monitoring")
+
+        state = conn.get(filter=("subtree", NETCONF_STATE_FILTER))
+        summary["netconf_state_bytes"] = len(str(state.data_xml))
+
+        schemas = {}
+        for module in ("frr-interface", "frr-bgp"):
+            schema = conn.get_schema(module)
+            text = str(schema.data)
+            if module not in text:
+                raise AssertionError(f"get-schema({module}) did not return the expected module text")
+            schemas[module] = len(text)
+        summary["schemas"] = schemas
+
+        before = running_interface_xml(conn)
+        if MARKER in before:
+            raise AssertionError("lab marker unexpectedly present before candidate test")
+
+        conn.lock(target="candidate")
+        try:
+            conn.discard_changes()
+            conn.edit_config(target="candidate", config=INTERFACE_DESCRIPTION_MERGE)
+            conn.validate(source="candidate")
+            conn.discard_changes()
+        finally:
+            conn.unlock(target="candidate")
+
+        after_discard = running_interface_xml(conn)
+        if MARKER in after_discard:
+            raise AssertionError("candidate discard leaked into running datastore")
+
+        conn.lock(target="candidate")
+        try:
+            conn.edit_config(target="candidate", config=INTERFACE_DESCRIPTION_MERGE)
+            conn.validate(source="candidate")
+            conn.commit()
+        finally:
+            conn.unlock(target="candidate")
+
+        after_commit = running_interface_xml(conn)
+        if MARKER not in after_commit:
+            raise AssertionError("candidate commit did not update running datastore")
+
+        conn.lock(target="candidate")
+        try:
+            conn.edit_config(target="candidate", config=INTERFACE_DESCRIPTION_REMOVE)
+            conn.validate(source="candidate")
+            conn.commit()
+        finally:
+            conn.unlock(target="candidate")
+
+        after_cleanup = running_interface_xml(conn)
+        if MARKER in after_cleanup:
+            raise AssertionError("cleanup commit did not remove lab marker")
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - lab diagnostic path.
+        print(f"NETCONF/YANG smoke failed: {exc}", file=sys.stderr)
+        raise

--- a/tests/iac/test_frr_static.py
+++ b/tests/iac/test_frr_static.py
@@ -1,19 +1,39 @@
+import json
 import re
+import sys
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 REPO = Path(__file__).resolve().parents[2]
-FRR_FILES = {
-    "rtr": REPO / "configs/rtr/frr.conf",
-    "cr1-nl1": REPO / "configs/cr1-nl1/frr.conf",
-    "cr1-de1": REPO / "configs/cr1-de1/frr.conf",
-}
-CORE_LOOPBACKS = {
-    "rtr": "2a0c:b641:b50::d",
-    "cr1-nl1": "2a0c:b641:b50::a",
-    "cr1-de1": "2a0c:b641:b50::b",
-}
+INVENTORY = REPO / "ansible/inventory"
+HOST_VARS = INVENTORY / "host_vars"
+ROUTERS_VARS = INVENTORY / "group_vars/routers.yml"
+CONFIGS = REPO / "configs"
+GENERATED = REPO / "ansible/generated"
+POLICY_INTENT = REPO / "configs/frr-policy-intent.yml"
+
+sys.path.insert(0, str(REPO / "scripts/netops"))
+from frr_semantic import parse_frr_config, semantic_json  # noqa: E402
+from render_frr_policy import effective_policy, load_intent, policy_json, render_policy_conf  # noqa: E402
+
+
+def load_yaml(path):
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def router_hosts():
+    hosts = load_yaml(INVENTORY / "hosts.yml")
+    return sorted(hosts["all"]["children"]["routers"]["hosts"])
+
+
+ROUTERS = router_hosts()
+FRR_FILES = {router: CONFIGS / router / "frr.conf" for router in ROUTERS}
+ALL_VARS = load_yaml(INVENTORY / "group_vars/all.yml")
+CORE_LOOPBACKS = {router: ALL_VARS["peers"][router]["loopback"] for router in ROUTERS}
+POLICY_INTENT_DATA = load_intent(POLICY_INTENT)
 
 
 def frr_text(node):
@@ -28,6 +48,82 @@ def neighbors(text):
 
 
 class FrrStaticTest(unittest.TestCase):
+    def test_every_router_has_committed_frr_config(self):
+        self.assertEqual(set(ROUTERS), {"rtr", "cr1-nl1", "cr1-de1", "cr1-ch1"})
+        for node, path in FRR_FILES.items():
+            with self.subTest(node=node):
+                self.assertTrue(path.exists(), f"{node} missing {path}")
+                self.assertGreater(path.stat().st_size, 0, f"{node} config is empty")
+
+    def test_semantic_artifacts_are_current(self):
+        for node, path in FRR_FILES.items():
+            artifact = GENERATED / node / "frr-semantic.json"
+            with self.subTest(node=node):
+                self.assertTrue(artifact.exists(), f"run scripts/netops/frr_semantic.py --all; missing {artifact}")
+                expected = semantic_json(parse_frr_config(path, host=node))
+                # Validate JSON first so failures clearly distinguish malformed
+                # artifacts from stale-but-valid artifacts.
+                json.loads(artifact.read_text())
+                self.assertEqual(artifact.read_text(), expected)
+
+    def test_policy_intent_artifacts_are_current(self):
+        for node in FRR_FILES:
+            policy = effective_policy(POLICY_INTENT_DATA, node)
+            json_artifact = GENERATED / node / "frr-policy.json"
+            conf_artifact = GENERATED / node / "frr-policy.conf"
+            with self.subTest(node=node, artifact="json"):
+                self.assertTrue(json_artifact.exists(), f"run scripts/netops/render_frr_policy.py; missing {json_artifact}")
+                json.loads(json_artifact.read_text())
+                self.assertEqual(json_artifact.read_text(), policy_json(policy))
+            with self.subTest(node=node, artifact="conf"):
+                self.assertTrue(conf_artifact.exists(), f"run scripts/netops/render_frr_policy.py; missing {conf_artifact}")
+                self.assertEqual(conf_artifact.read_text(), render_policy_conf(policy))
+
+    def test_policy_intent_matches_committed_frr_policy(self):
+        for node, path in FRR_FILES.items():
+            semantic = parse_frr_config(path, host=node)
+            policy = effective_policy(POLICY_INTENT_DATA, node)
+            with self.subTest(node=node, section="prefix-lists"):
+                actual = {}
+                for name in policy["ipv6_prefix_lists"]:
+                    actual[name] = [
+                        {"seq": item["seq"], "action": item["action"], "value": item["value"]}
+                        for item in semantic["prefix_lists"]["ipv6"].get(name, [])
+                    ]
+                self.assertEqual(actual, policy["ipv6_prefix_lists"])
+            with self.subTest(node=node, section="as-path"):
+                actual = {}
+                for name in policy["as_path_access_lists"]:
+                    actual[name] = [
+                        {k: item[k] for k in ("seq", "action", "pattern") if item.get(k) is not None}
+                        for item in semantic["as_path_access_lists"].get(name, [])
+                    ]
+                self.assertEqual(actual, policy["as_path_access_lists"])
+            with self.subTest(node=node, section="route-maps"):
+                actual = {}
+                for name in policy["route_maps"]:
+                    actual[name] = []
+                    sequences = semantic["route_maps"].get(name, {}).get("sequences", {})
+                    for seq in sorted(sequences.values(), key=lambda item: item["seq"]):
+                        actual[name].append(
+                            {
+                                "seq": seq["seq"],
+                                "action": seq["action"],
+                                "matches": seq["matches"],
+                                "sets": seq["sets"],
+                                "on_match": seq["on_match"],
+                            }
+                        )
+                self.assertEqual(actual, policy["route_maps"])
+            with self.subTest(node=node, section="neighbor-route-maps"):
+                actual = {}
+                for instance in semantic["bgp"]["instances"]:
+                    af = instance["address_families"].get("ipv6 unicast", {})
+                    for neighbor, data in af.get("neighbors", {}).items():
+                        if data.get("route_maps"):
+                            actual[neighbor] = data["route_maps"]
+                self.assertEqual(actual, policy["neighbor_route_maps"])
+
     def test_bgp_router_ids_are_unique(self):
         ids = {}
         for node in FRR_FILES:
@@ -72,12 +168,39 @@ class FrrStaticTest(unittest.TestCase):
             referenced = set(re.findall(r"match ipv6 address prefix-list\s+(\S+)", text))
             self.assertTrue(referenced <= defined, f"{node}: undefined prefix-lists {referenced - defined}")
 
+    def test_route_maps_do_not_reference_undefined_as_path_lists(self):
+        for node in FRR_FILES:
+            text = frr_text(node)
+            defined = set(re.findall(r"^bgp as-path access-list\s+(\S+)", text, re.M))
+            referenced = set(re.findall(r"match as-path\s+(\S+)", text))
+            self.assertTrue(referenced <= defined, f"{node}: undefined AS-path lists {referenced - defined}")
+
     def test_route_map_references_are_defined(self):
         for node in FRR_FILES:
             text = frr_text(node)
             defined = set(re.findall(r"^route-map\s+(\S+)\s+", text, re.M))
             referenced = set(re.findall(r"neighbor\s+\S+\s+route-map\s+(\S+)\s+(?:in|out)", text))
             self.assertTrue(referenced <= defined, f"{node}: undefined route-maps {referenced - defined}")
+
+    def test_inventory_expected_frr_versions_match_config_headers(self):
+        for node in FRR_FILES:
+            host_vars = load_yaml(HOST_VARS / f"{node}.yml")
+            expected = host_vars.get("frr_version_expected")
+            match = re.search(r"^frr version\s+(\S+)", frr_text(node), re.M)
+            with self.subTest(node=node):
+                self.assertIsNotNone(expected, f"{node} has no frr_version_expected host var")
+                self.assertIsNotNone(match, f"{node} config has no frr version line")
+                self.assertEqual(expected, match.group(1))
+
+    def test_production_netconf_endpoint_and_writes_are_disabled(self):
+        router_defaults = load_yaml(ROUTERS_VARS)
+        self.assertFalse(router_defaults.get("frr_netconf_endpoint_enabled", False))
+        self.assertFalse(router_defaults.get("frr_netconf_write_enabled", False))
+        for node in FRR_FILES:
+            host_vars = load_yaml(HOST_VARS / f"{node}.yml")
+            with self.subTest(node=node):
+                self.assertFalse(host_vars.get("frr_netconf_endpoint_enabled", False))
+                self.assertFalse(host_vars.get("frr_netconf_write_enabled", False))
 
 
 if __name__ == "__main__":

--- a/tests/iac/test_inventory_schema.py
+++ b/tests/iac/test_inventory_schema.py
@@ -191,7 +191,7 @@ class InventorySchemaTest(unittest.TestCase):
                 )
 
     def test_router_loopbacks_live_in_the_loopback_subnet(self):
-        for name in ("rtr", "cr1_nl1", "cr1_de1"):
+        for name in ("rtr", "cr1_nl1", "cr1_de1", "cr1_ch1"):
             lo = self.vars["peers"][name].get("loopback")
             with self.subTest(peer=name):
                 self.assertIsNotNone(lo, f"{name} has no loopback")


### PR DESCRIPTION
## Summary

- Document AS215932 NETCONF/YANG architecture and production write gates while keeping committed `configs/<router>/frr.conf` canonical.
- Add read-only FRR YANG/NETCONF audit inventory, role, playbook, and scheduled/manual audit workflow.
- Add normalized FRR semantic and policy-intent renderers with committed generated artifacts and parity/static tests across all four routers.
- Add disabled-by-default NETCONF endpoint firewall scaffolding and a trusted-only Containerlab NETCONF/YANG lab job gated by `ENABLE_NETCONF_YANG_TESTS`.

## Safety / production impact

- No production router config is changed by this PR.
- `frr_netconf_endpoint_enabled` and `frr_netconf_write_enabled` default to `false` for routers.
- TCP/830 firewall rules only render if a future PR explicitly enables a host.
- The new production audit workflow is read-only and writes only ignored runtime snapshots/artifacts.

## Validation

- `scripts/ci/iac-static.sh`
- `cd ansible && for playbook in playbooks/*.yml; do ansible-playbook "$playbook" --syntax-check >/dev/null || exit 1; done`
- `python3 -m py_compile scripts/netops/frr_semantic.py scripts/netops/render_frr_policy.py tests/iac/containerlab/check_netconf_yang.py tests/iac/containerlab/netconf/netconf_smoke.py`
- `bash -n scripts/ci/containerlab-netconf-yang-test.sh tests/iac/containerlab/netconf/entrypoint.sh tests/iac/containerlab/netconf/install-frr-yang-modules.sh`
- `ANSIBLE_ROLES_PATH=ansible/roles ansible-lint ansible/playbooks/frr-yang.yml ansible/roles/frr_yang`

Not run: `scripts/ci/containerlab-netconf-yang-test.sh` because it builds a lab-only FRR/sysrepo/Netopeer2 image and is intended for trusted CI/manual execution.
