### PR TITLE
fix(logs): allow loop VM Vector ingest

### DIFF
--- a/ansible/generated/log/nftables.conf
+++ b/ansible/generated/log/nftables.conf
@@ -48,6 +48,7 @@ table inet filter {
         ip6 saddr 2a0c:b641:b50:2::80 tcp dport 6000 counter accept comment "Vector ingest from irc"
         ip6 saddr 2a0c:b641:b50:2::a0 tcp dport 6000 counter accept comment "Vector ingest from noc"
         ip6 saddr 2a0c:b641:b50:2::d0 tcp dport 6000 counter accept comment "Vector ingest from ci"
+        ip6 saddr 2a0c:b641:b50:2::f0 tcp dport 6000 counter accept comment "Vector ingest from loop"
         ip6 saddr 2a0c:b641:b50::a tcp dport 6000 counter accept comment "Vector ingest from cr1-nl1 (over WG mesh)"
         ip6 saddr 2a0c:b641:b50::b tcp dport 6000 counter accept comment "Vector ingest from cr1-de1 (over WG mesh)"
         ip6 saddr 2001:41d0:304:300::7bfb tcp dport 6000 counter accept comment "Vector ingest from off-net ns2"

--- a/ansible/inventory/host_vars/log.yml
+++ b/ansible/inventory/host_vars/log.yml
@@ -23,6 +23,7 @@ firewall_extra_rules:
   - { proto: tcp, dport: 6000, src: "{{ peers.irc.ipv6 }}",   comment: "Vector ingest from irc" }
   - { proto: tcp, dport: 6000, src: "{{ peers.noc.ipv6 }}",   comment: "Vector ingest from noc" }
   - { proto: tcp, dport: 6000, src: "{{ peers.ci.ipv6 }}",    comment: "Vector ingest from ci" }
+  - { proto: tcp, dport: 6000, src: "{{ peers.loop.ipv6 }}",  comment: "Vector ingest from loop" }
   - { proto: tcp, dport: 6000, src: "{{ peers.cr1_nl1.loopback }}", comment: "Vector ingest from cr1-nl1 (over WG mesh)" }
   - { proto: tcp, dport: 6000, src: "{{ peers.cr1_de1.loopback }}", comment: "Vector ingest from cr1-de1 (over WG mesh)" }
 


### PR DESCRIPTION
## Summary
- allow the dedicated loop VM to send Vector logs to the log aggregator
- refresh generated log nftables artifact

## Validation
- scripts/ci/render-all.sh
- scripts/ci/iac-static.sh

## Rollout notes
This unblocks the engineering-loop apply: Vector on loop failed healthcheck because log:6000 did not yet admit peers.loop.ipv6.
