### PR TITLE
feat: cut over engineering loop Vault bootstrap

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -89,7 +89,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: production-infra
+  # Live applies remain strictly serialized. Dry-runs are render/check only and
+  # must not get stuck behind, or block, the production apply lane.
+  group: ${{ inputs.dry_run && format('production-infra-dry-run-{0}', github.run_id) || 'production-infra' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -277,6 +277,45 @@ jobs:
             echo "Minted response-wrapped AppRole SecretID for this apply run."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Mint engineering-loop Vault bootstrap
+        if: ${{ !inputs.dry_run && inputs.playbook == 'engineering-loop' }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${VAULT_ENGINEERING_LOOP_ROLE_ID:-}" ] && { [ -n "${VAULT_ENGINEERING_LOOP_WRAPPED_SECRET_ID:-}" ] || [ -n "${VAULT_ENGINEERING_LOOP_SECRET_ID:-}" ]; }; then
+            echo "engineering-loop Vault bootstrap already provided by environment"
+            exit 0
+          fi
+
+          token_file="/run/vault-agent/github-runner.token"
+          if [ ! -r "$token_file" ]; then
+            echo "::error::${token_file} is not readable by the runner user; re-apply playbooks/ci.yml to refresh Vault Agent token sink permissions"
+            exit 1
+          fi
+          vault_token="$(cat "$token_file")"
+
+          export VAULT_ADDR="${VAULT_ADDR:-http://[2a0c:b641:b50:2::c0]:8200}"
+          export VAULT_TOKEN="$vault_token"
+
+          role_id="$(vault read -field=role_id auth/approle/role/engineering-loop/role-id)"
+          wrapped_secret_id="$(vault write -wrap-ttl=10m -field=wrapping_token -f auth/approle/role/engineering-loop/secret-id)"
+
+          if [ -z "$role_id" ] || [ -z "$wrapped_secret_id" ]; then
+            echo "::error::failed to mint engineering-loop Vault bootstrap credentials"
+            exit 1
+          fi
+
+          echo "::add-mask::$role_id"
+          echo "::add-mask::$wrapped_secret_id"
+          printf 'VAULT_ENGINEERING_LOOP_ROLE_ID=%s\n' "$role_id" >> "$GITHUB_ENV"
+          printf 'VAULT_ENGINEERING_LOOP_WRAPPED_SECRET_ID=%s\n' "$wrapped_secret_id" >> "$GITHUB_ENV"
+
+          {
+            echo "## engineering-loop Vault bootstrap"
+            echo
+            echo "Minted response-wrapped AppRole SecretID for this apply run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # -e ansible_user=ci: the runner connects as the dedicated `ci` deploy
       # user on every host (created + NOPASSWD-root by the ci_runner_key role)
       # and escalates with sudo — never root, never the operator's svag. An

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,6 +4,9 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
+engineering_loop_version: "23a2f5a8429def9cb8ce3c0a67f52b8d268d5633"
+engineering_loop_timer_enabled: false
+
 monitoring_register: true
 monitoring_role: loop
 monitoring_check_vars:

--- a/ansible/playbooks/engineering-loop.yml
+++ b/ansible/playbooks/engineering-loop.yml
@@ -11,7 +11,10 @@
 #   ansible-playbook playbooks/engineering-loop.yml --tags apply \
 #     -e engineering_loop_apply=true --limit loop
 #
-# First bootstrap with Vault Agent requires:
+# First bootstrap with Vault Agent requires either:
+#   VAULT_ENGINEERING_LOOP_ROLE_ID=...
+#   VAULT_ENGINEERING_LOOP_WRAPPED_SECRET_ID=...
+# or, for break-glass/operator use only:
 #   VAULT_ENGINEERING_LOOP_ROLE_ID=...
 #   VAULT_ENGINEERING_LOOP_SECRET_ID=...
 
@@ -48,7 +51,17 @@
       vars:
         vault_agent_name: engineering-loop
         vault_agent_role_id: "{{ lookup('env', 'VAULT_ENGINEERING_LOOP_ROLE_ID') | default('', true) }}"
-        vault_agent_secret_id: "{{ lookup('env', 'VAULT_ENGINEERING_LOOP_SECRET_ID') | default('', true) }}"
+        vault_agent_secret_id: >-
+          {{
+            lookup('env', 'VAULT_ENGINEERING_LOOP_WRAPPED_SECRET_ID') |
+            default(lookup('env', 'VAULT_ENGINEERING_LOOP_SECRET_ID'), true)
+          }}
+        vault_agent_secret_id_response_wrapping_path: >-
+          {{
+            'auth/approle/role/engineering-loop/secret-id'
+            if (lookup('env', 'VAULT_ENGINEERING_LOOP_WRAPPED_SECRET_ID') | default('', true)) | length > 0
+            else ''
+          }}
         vault_agent_env_destination: "{{ engineering_loop_env_file }}"
         vault_agent_reload_command: /bin/true
         vault_agent_env_reload_command: /bin/true

--- a/configs/vault/policies/github-runner.hcl
+++ b/configs/vault/policies/github-runner.hcl
@@ -26,3 +26,15 @@ path "auth/approle/role/hyrule-cloud/role-id" {
 path "auth/approle/role/hyrule-cloud/secret-id" {
   capabilities = ["update"]
 }
+
+# Production engineering-loop applies run on the trusted ci runner and need to
+# bootstrap the loop VM's target-side Vault Agent. The runner may mint only a
+# short-lived, response-wrapped SecretID for the engineering-loop AppRole; it
+# still cannot read kv/engineering-loop runtime secrets.
+path "auth/approle/role/engineering-loop/role-id" {
+  capabilities = ["read"]
+}
+
+path "auth/approle/role/engineering-loop/secret-id" {
+  capabilities = ["update"]
+}

--- a/docs/runbooks/bootstrap-engineering-loop-vault.md
+++ b/docs/runbooks/bootstrap-engineering-loop-vault.md
@@ -1,0 +1,117 @@
+# Bootstrap Engineering Loop Vault secrets
+
+The dedicated `loop` VM runs the Engineering Loop daemon from a narrow Vault
+AppRole. This AppRole must only render the daemon's GitHub issue/PR token,
+model-provider credentials, and notification credentials into
+`/opt/engineering-loop/.env`.
+
+Do **not** place fleet SSH keys, broad Vault tokens, XO credentials, registrar
+credentials, or application runtime secrets in `kv/engineering-loop`.
+
+## Preconditions
+
+- You are an authorized Vault operator.
+- You are running from a trusted operator host or the trusted `ci` runner.
+- The `engineering-loop` policy in this repository has been reviewed.
+- The `github-runner` policy has been updated in live Vault before relying on
+  `apply.yml` to mint a response-wrapped SecretID for the `loop` VM.
+
+```bash
+export VAULT_ADDR='http://[2a0c:b641:b50:2::c0]:8200'
+vault token lookup
+```
+
+## Install the engineering-loop policy
+
+```bash
+vault policy write engineering-loop configs/vault/policies/engineering-loop.hcl
+```
+
+## Create or update the AppRole
+
+```bash
+vault write auth/approle/role/engineering-loop \
+  token_policies="engineering-loop" \
+  token_ttl=1h \
+  token_max_ttl=24h \
+  secret_id_ttl=0 \
+  secret_id_num_uses=0
+```
+
+## Populate the KV payload
+
+Use a fine-grained GitHub PAT or GitHub App installation token scoped only to
+these repositories:
+
+- `AS215932/engineering-loop`
+- `AS215932/network-operations`
+- `AS215932/hyrule-cloud`
+- `AS215932/hyrule-web`
+- `AS215932/hyrule-mcp`
+- `AS215932/noc-agent`
+- `AS215932/hyrule-network-proxy`
+
+Required GitHub permissions:
+
+- Metadata: read
+- Issues: read/write
+- Contents: read/write
+- Pull requests: read/write
+
+No admin or org-wide permissions are required.
+
+```bash
+vault kv put kv/engineering-loop \
+  github_token="..." \
+  discord_webhook="..." \
+  icinga_url="https://[2a0c:b641:b50:2::50]:5665/v1/actions/process-check-result" \
+  icinga_user="..." \
+  icinga_password="..." \
+  icinga_check="loop!engineering-loop" \
+  openrouter_api_key="..." \
+  anthropic_api_key="..." \
+  openai_api_key="..."
+```
+
+## Refresh the ci runner policy
+
+After merging the production cutover PR, apply the updated `github-runner`
+policy so `apply.yml` can mint a short-lived response-wrapped SecretID for the
+`engineering-loop` AppRole:
+
+```bash
+vault policy write github-runner configs/vault/policies/github-runner.hcl
+```
+
+## Verify without exposing secrets
+
+```bash
+vault kv metadata get kv/engineering-loop
+vault read auth/approle/role/engineering-loop/role-id
+vault write -wrap-ttl=10m -f auth/approle/role/engineering-loop/secret-id
+```
+
+Do not unwrap SecretIDs in logs or paste them into issue/PR comments.
+
+## Rollout
+
+Use the production workflow after the policies and KV entry exist:
+
+1. Run `apply.yml` with `playbook=engineering-loop`, `limit=loop`,
+   `dry_run=true`.
+2. Run `apply.yml` with `playbook=engineering-loop`, `limit=loop`,
+   `dry_run=false`.
+3. Approve the GitHub `production` environment gate.
+4. Confirm `/opt/engineering-loop/.env` exists on `loop` with owner/root and
+   group access for the `loop` service only.
+5. Confirm `vault-agent-engineering-loop.service` is active.
+6. Keep `hyrule-engineering-loop.timer` disabled until Pi auth and the
+   docs-only draft PR canary pass.
+
+## Rollback
+
+```bash
+systemctl disable --now hyrule-engineering-loop.timer
+systemctl stop hyrule-engineering-loop.service
+systemctl stop vault-agent-engineering-loop.service
+```


### PR DESCRIPTION
## Summary

Production cutover prep for the dedicated Engineering Loop `loop` VM:

- Pin the deployed Engineering Loop runtime to the merged daemon rollout SHA `23a2f5a8429def9cb8ce3c0a67f52b8d268d5633`.
- Keep `hyrule-engineering-loop.timer` disabled.
- Allow `apply.yml` to mint a response-wrapped `engineering-loop` AppRole SecretID from the trusted `ci` runner.
- Pass wrapped SecretIDs through the existing Vault Agent response-wrapping support.
- Add the operator runbook for bootstrapping the narrow `engineering-loop` Vault policy/AppRole/KV.

## Safety

- The loop timer remains disabled.
- The GitHub runner policy can mint only `engineering-loop` AppRole bootstrap credentials; it still cannot read `kv/engineering-loop`.
- `kv/engineering-loop` is documented as GitHub/model/notification credentials only: no fleet SSH, broad Vault, XO, registrar, or app runtime secrets.
- Live apply still requires the GitHub `production` environment gate.

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`

## Follow-up after merge

1. Vault operator applies `configs/vault/policies/engineering-loop.hcl` and refreshes `github-runner`.
2. Vault operator creates AppRole `engineering-loop` and populates `kv/engineering-loop`.
3. Run `apply.yml` dry-run for `playbook=engineering-loop`, `limit=loop`.
4. Run `apply.yml` live with production approval.
5. Verify `/opt/engineering-loop/.env` and `vault-agent-engineering-loop.service`.
6. Keep the timer disabled until Pi auth and the docs-only canary pass.
