### PR TITLE
feat: authenticate engineering loop with GitHub App

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "23a2f5a8429def9cb8ce3c0a67f52b8d268d5633"
+engineering_loop_version: "203957c0bffd306b59f8882d3548c3922633c349"
 engineering_loop_timer_enabled: false
 
 monitoring_register: true

--- a/ansible/playbooks/engineering-loop.yml
+++ b/ansible/playbooks/engineering-loop.yml
@@ -70,11 +70,13 @@
             name: engineering-loop.env.ctmpl
             destination: "{{ engineering_loop_env_file }}"
             group: "{{ engineering_loop_group }}"
+            mode: "0640"
             reload_command: /bin/true
           - src: engineering-loop-github-app-key.pem.ctmpl.j2
             name: engineering-loop-github-app-key.pem.ctmpl
             destination: "{{ engineering_loop_github_app_private_key_file }}"
             group: "{{ engineering_loop_group }}"
+            mode: "0640"
             reload_command: /bin/true
         vault_agent_extra_dirs:
           - path: "{{ engineering_loop_config_dir }}"

--- a/ansible/playbooks/engineering-loop.yml
+++ b/ansible/playbooks/engineering-loop.yml
@@ -71,7 +71,15 @@
             destination: "{{ engineering_loop_env_file }}"
             group: "{{ engineering_loop_group }}"
             reload_command: /bin/true
-        vault_agent_extra_dirs: []
+          - src: engineering-loop-github-app-key.pem.ctmpl.j2
+            name: engineering-loop-github-app-key.pem.ctmpl
+            destination: "{{ engineering_loop_github_app_private_key_file }}"
+            group: "{{ engineering_loop_group }}"
+            reload_command: /bin/true
+        vault_agent_extra_dirs:
+          - path: "{{ engineering_loop_config_dir }}"
+            group: "{{ engineering_loop_group }}"
+            mode: "0750"
       when: (lookup('env', 'ENGINEERING_LOOP_SECRET_BACKEND') | default('vault', true)) == 'vault'
       tags: [vault_agent]
   post_tasks:

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -22,7 +22,7 @@ engineering_loop_daemon_wrapper_path: "{{ engineering_loop_lib_dir }}/run-daemon
 engineering_loop_github_app_private_key_file: "{{ engineering_loop_config_dir }}/github-app.private-key.pem"
 
 engineering_loop_repo: https://github.com/AS215932/engineering-loop.git
-engineering_loop_version: main
+engineering_loop_version: "203957c0bffd306b59f8882d3548c3922633c349"
 
 # GitHub issue/PR intake scope for first production rollout.
 engineering_loop_repos:
@@ -33,10 +33,12 @@ engineering_loop_repos:
   - AS215932/hyrule-mcp
   - AS215932/noc-agent
   - AS215932/hyrule-network-proxy
+  - AS215932/as215932.net
 
 # Local workspace checkout names. network-operations intentionally lands at
 # hyrule-infra to match the existing sibling checkout convention used by the
 # loop and app repos; noc-agent lands at hyrule-noc-agent for the same reason.
+# The AS/routing identity repo keeps its canonical dotted checkout name.
 engineering_loop_workspace_repositories:
   - repo: https://github.com/AS215932/engineering-loop.git
     dest: engineering-loop
@@ -58,6 +60,9 @@ engineering_loop_workspace_repositories:
     version: main
   - repo: https://github.com/AS215932/hyrule-network-proxy.git
     dest: hyrule-network-proxy
+    version: main
+  - repo: https://github.com/AS215932/as215932.net.git
+    dest: as215932.net
     version: main
 
 engineering_loop_allowed_paths:

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -9,12 +9,17 @@ engineering_loop_user: loop
 engineering_loop_group: loop
 
 engineering_loop_install_dir: /opt/engineering-loop
+engineering_loop_config_dir: /etc/engineering-loop
 engineering_loop_env_file: "{{ engineering_loop_install_dir }}/.env"
 engineering_loop_state_dir: /var/lib/engineering-loop
 engineering_loop_workspace_dir: "{{ engineering_loop_state_dir }}/workspace"
 engineering_loop_runs_dir: "{{ engineering_loop_state_dir }}/runs"
 engineering_loop_daemon_state_dir: "{{ engineering_loop_state_dir }}/state"
-engineering_loop_git_askpass_path: /usr/local/lib/engineering-loop/git-askpass
+engineering_loop_lib_dir: /usr/local/lib/engineering-loop
+engineering_loop_git_askpass_path: "{{ engineering_loop_lib_dir }}/git-askpass"
+engineering_loop_github_app_token_path: "{{ engineering_loop_lib_dir }}/github-app-token"
+engineering_loop_daemon_wrapper_path: "{{ engineering_loop_lib_dir }}/run-daemon"
+engineering_loop_github_app_private_key_file: "{{ engineering_loop_config_dir }}/github-app.private-key.pem"
 
 engineering_loop_repo: https://github.com/AS215932/engineering-loop.git
 engineering_loop_version: main
@@ -72,3 +77,4 @@ engineering_loop_packages:
   - ca-certificates
   - curl
   - gh
+  - openssl

--- a/ansible/roles/engineering_loop/tasks/apply.yml
+++ b/ansible/roles/engineering_loop/tasks/apply.yml
@@ -38,6 +38,7 @@
     mode: "{{ item.mode }}"
   loop:
     - { path: "{{ engineering_loop_install_dir }}", mode: "0755" }
+    - { path: "{{ engineering_loop_config_dir }}", owner: root, group: "{{ engineering_loop_group }}", mode: "0750" }
     - { path: "{{ engineering_loop_state_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_workspace_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_runs_dir }}", mode: "0750" }
@@ -103,6 +104,23 @@
     owner: root
     group: "{{ engineering_loop_group }}"
     mode: "0750"
+
+- name: Install Engineering Loop GitHub App token helper
+  ansible.builtin.template:
+    src: github-app-token.sh.j2
+    dest: "{{ engineering_loop_github_app_token_path }}"
+    owner: root
+    group: "{{ engineering_loop_group }}"
+    mode: "0750"
+
+- name: Install Engineering Loop daemon wrapper
+  ansible.builtin.template:
+    src: run-daemon.sh.j2
+    dest: "{{ engineering_loop_daemon_wrapper_path }}"
+    owner: root
+    group: "{{ engineering_loop_group }}"
+    mode: "0750"
+  notify: restart engineering-loop timer
 
 - name: Install Engineering Loop systemd service
   ansible.builtin.template:

--- a/ansible/roles/engineering_loop/tasks/main.yml
+++ b/ansible/roles/engineering_loop/tasks/main.yml
@@ -5,6 +5,7 @@
       - engineering_loop_user | length > 0
       - engineering_loop_group | length > 0
       - engineering_loop_install_dir.startswith('/')
+      - engineering_loop_config_dir.startswith('/')
       - engineering_loop_state_dir.startswith('/')
       - engineering_loop_workspace_dir.startswith('/')
       - engineering_loop_runs_dir.startswith('/')

--- a/ansible/roles/engineering_loop/tasks/main.yml
+++ b/ansible/roles/engineering_loop/tasks/main.yml
@@ -10,13 +10,13 @@
       - engineering_loop_workspace_dir.startswith('/')
       - engineering_loop_runs_dir.startswith('/')
       - engineering_loop_daemon_state_dir.startswith('/')
-      - engineering_loop_repos | length == 7
-      - engineering_loop_workspace_repositories | length == 7
+      - engineering_loop_repos | length == 8
+      - engineering_loop_workspace_repositories | length == 8
       - engineering_loop_max_runs_per_day | int <= 2
       - engineering_loop_max_cost_usd_per_day | float <= 10
     fail_msg: >-
       Engineering Loop production rollout must stay on the approved
-      seven-repo, low-and-slow budget profile unless a later PR explicitly
+      eight-repo, low-and-slow budget profile unless a later PR explicitly
       widens it.
   tags: [validate, always]
 

--- a/ansible/roles/engineering_loop/templates/github-app-token.sh.j2
+++ b/ansible/roles/engineering_loop/templates/github-app-token.sh.j2
@@ -31,7 +31,7 @@ installation_id="$ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID"
 private_key_file="$ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE"
 api_url="${ENGINEERING_LOOP_GITHUB_API_URL:-https://api.github.com}"
 
-[ -r "$private_key_file" ] || fatal "private key is not readable: $private_key_file"
+[ -r "$private_key_file" ] && [ -s "$private_key_file" ] || fatal "private key is not readable or empty: $private_key_file"
 command -v openssl >/dev/null 2>&1 || fatal "openssl is required"
 command -v curl >/dev/null 2>&1 || fatal "curl is required"
 command -v python3 >/dev/null 2>&1 || fatal "python3 is required"

--- a/ansible/roles/engineering_loop/templates/github-app-token.sh.j2
+++ b/ansible/roles/engineering_loop/templates/github-app-token.sh.j2
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Managed by ansible/roles/engineering_loop.
+# Mint a short-lived GitHub App installation token for one Engineering Loop run.
+# The token is printed to stdout for the caller to export; it is never written
+# to disk by this helper.
+# shellcheck shell=sh
+
+set -eu
+
+fatal() {
+  printf '%s\n' "github-app-token: $*" >&2
+  exit 1
+}
+
+require_env() {
+  name="$1"
+  eval "value=\${$name:-}"
+  [ -n "$value" ] || fatal "missing required environment variable: $name"
+}
+
+b64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+require_env ENGINEERING_LOOP_GITHUB_APP_ID
+require_env ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID
+require_env ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE
+
+app_id="$ENGINEERING_LOOP_GITHUB_APP_ID"
+installation_id="$ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID"
+private_key_file="$ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE"
+api_url="${ENGINEERING_LOOP_GITHUB_API_URL:-https://api.github.com}"
+
+[ -r "$private_key_file" ] || fatal "private key is not readable: $private_key_file"
+command -v openssl >/dev/null 2>&1 || fatal "openssl is required"
+command -v curl >/dev/null 2>&1 || fatal "curl is required"
+command -v python3 >/dev/null 2>&1 || fatal "python3 is required"
+
+now="$(date +%s)"
+iat="$((now - 60))"
+exp="$((now + 540))"
+
+header='{"alg":"RS256","typ":"JWT"}'
+payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$iat" "$exp" "$app_id")"
+
+encoded_header="$(printf '%s' "$header" | b64url)"
+encoded_payload="$(printf '%s' "$payload" | b64url)"
+signing_input="${encoded_header}.${encoded_payload}"
+signature="$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$private_key_file" -binary | b64url)"
+jwt="${signing_input}.${signature}"
+
+response="$(curl -fsS \
+  -X POST \
+  -H "Authorization: Bearer ${jwt}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${api_url%/}/app/installations/${installation_id}/access_tokens")"
+
+printf '%s' "$response" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+token = data.get("token")
+if not isinstance(token, str) or not token:
+    raise SystemExit("github-app-token: GitHub response did not contain a token")
+print(token)
+'

--- a/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.service.j2
+++ b/ansible/roles/engineering_loop/templates/hyrule-engineering-loop.service.j2
@@ -18,16 +18,7 @@ WorkingDirectory={{ engineering_loop_install_dir }}
 Environment=HOME={{ engineering_loop_state_dir }}
 Environment=HYRULE_MODEL_POLICY_FILE={{ engineering_loop_install_dir }}/configs/loop/model-policy.production.yml
 EnvironmentFile={{ engineering_loop_env_file }}
-ExecStart={{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop daemon --once \
-{% for repo in engineering_loop_repos %}
-    --repo {{ repo }} \
-{% endfor %}
-    --workspace-root {{ engineering_loop_workspace_dir }} \
-    --output-root {{ engineering_loop_runs_dir }} \
-    --state-dir-path {{ engineering_loop_daemon_state_dir }} \
-    --memory-dir {{ engineering_loop_memory_dir }} \
-    --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
-    --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}
+ExecStart={{ engineering_loop_daemon_wrapper_path }}
 TimeoutStartSec=3600
 StandardOutput=journal
 StandardError=journal

--- a/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
+++ b/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Managed by ansible/roles/engineering_loop.
+# Runtime wrapper for the one-shot Engineering Loop daemon. It prefers GitHub
+# App authentication and mints a fresh installation token for each timer/manual
+# run, then exports the token only to the daemon process and its child tools.
+# shellcheck shell=sh
+
+set -eu
+
+fatal() {
+  printf '%s\n' "engineering-loop: $*" >&2
+  exit 1
+}
+
+existing_token="${ENGINEERING_LOOP_GITHUB_TOKEN:-}"
+if [ -z "$existing_token" ]; then
+  existing_token="${GH_TOKEN:-}"
+fi
+
+if [ "${ENGINEERING_LOOP_GITHUB_AUTH_MODE:-}" = "app" ] || [ -n "${ENGINEERING_LOOP_GITHUB_APP_ID:-}" ]; then
+  token="$({{ engineering_loop_github_app_token_path }})"
+  [ -n "$token" ] || fatal "GitHub App token helper returned an empty token"
+  export GH_TOKEN="$token"
+  export ENGINEERING_LOOP_GITHUB_TOKEN="$token"
+elif [ -n "$existing_token" ]; then
+  export GH_TOKEN="$existing_token"
+  export ENGINEERING_LOOP_GITHUB_TOKEN="$existing_token"
+else
+  fatal "no GitHub authentication configured; set GitHub App credentials or a break-glass token"
+fi
+
+exec {{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop daemon --once \
+{% for repo in engineering_loop_repos -%}
+    --repo {{ repo }} \
+{% endfor -%}
+    --workspace-root {{ engineering_loop_workspace_dir }} \
+    --output-root {{ engineering_loop_runs_dir }} \
+    --state-dir-path {{ engineering_loop_daemon_state_dir }} \
+    --memory-dir {{ engineering_loop_memory_dir }} \
+    --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
+    --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}

--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -40,7 +40,8 @@ vault_agent_hashicorp_gpg_url: "https://apt.releases.hashicorp.com/gpg"
 # Secret templates Vault Agent renders. Each entry: src (Jinja2 template in
 # this role's templates/), name (ctmpl filename written into the template
 # dir), destination (final rendered file), group (chgrp target on the
-# destination), reload_command (run after each render). The default pair
+# destination), optional mode (default 0640), reload_command (run after each
+# render). The default pair
 # reproduces the noc-agent behaviour exactly; other consumers — e.g.
 # github_runner — pass their own list.
 vault_agent_templates:

--- a/ansible/roles/vault_agent/templates/engineering-loop-github-app-key.pem.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/engineering-loop-github-app-key.pem.ctmpl.j2
@@ -1,0 +1,5 @@
+{% raw %}{{- with secret "kv/data/engineering-loop" -}}
+{{- if .Data.data.github_app_private_key -}}
+{{ .Data.data.github_app_private_key }}
+{{- end -}}
+{{- end -}}{% endraw %}

--- a/ansible/roles/vault_agent/templates/engineering-loop.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/engineering-loop.env.ctmpl.j2
@@ -1,12 +1,21 @@
 # /opt/engineering-loop/.env
 # Rendered by Vault Agent from kv/data/engineering-loop. Do not edit by hand.
-# Secret scope: GitHub draft-PR/issue token, model-provider keys, and run
-# notifications only. Do not add fleet SSH, Vault, XO, registrar, or app
+# Secret scope: GitHub App auth metadata or break-glass issue/PR token,
+# model-provider keys, and run notifications only. Do not add fleet SSH,
+# Vault, XO, registrar, or app
 # runtime credentials here.
 
 {% raw %}{{ with secret "kv/data/engineering-loop" -}}
+{{- if .Data.data.github_app_id }}
+ENGINEERING_LOOP_GITHUB_AUTH_MODE=app
+ENGINEERING_LOOP_GITHUB_APP_ID={{ .Data.data.github_app_id }}
+ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID={{ .Data.data.github_app_installation_id }}
+ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE={% endraw %}{{ engineering_loop_github_app_private_key_file }}{% raw %}
+{{- else if .Data.data.github_token }}
+ENGINEERING_LOOP_GITHUB_AUTH_MODE=token
 GH_TOKEN={{ .Data.data.github_token }}
 ENGINEERING_LOOP_GITHUB_TOKEN={{ .Data.data.github_token }}
+{{- end }}
 HYRULE_CREATE_GITHUB_PR=1
 
 HYRULE_DISCORD_WEBHOOK={{ or .Data.data.discord_webhook "" }}

--- a/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
+++ b/ansible/roles/vault_agent/templates/vault-agent.hcl.j2
@@ -42,8 +42,9 @@ auto_auth {
 template {
   source      = "{{ vault_agent_template_dir }}/{{ t.name }}"
   destination = "{{ t.destination }}"
-  perms       = 0640
-{% set render_command = "/bin/sh -c 'chgrp " ~ t.group ~ " " ~ t.destination ~ " && chmod 0640 " ~ t.destination ~ " && " ~ t.reload_command ~ "'" %}
+{% set destination_mode = t.mode | default('0640') %}
+  perms       = {{ destination_mode }}
+{% set render_command = "/bin/sh -c 'chgrp " ~ t.group ~ " " ~ t.destination ~ " && chmod " ~ destination_mode ~ " " ~ t.destination ~ " && " ~ t.reload_command ~ "'" %}
   command     = {{ render_command | to_json }}
 
   wait {

--- a/docs/runbooks/bootstrap-engineering-loop-vault.md
+++ b/docs/runbooks/bootstrap-engineering-loop-vault.md
@@ -51,6 +51,7 @@ Repository access must be limited to exactly these repositories:
 - `AS215932/hyrule-mcp`
 - `AS215932/noc-agent`
 - `AS215932/hyrule-network-proxy`
+- `AS215932/as215932.net`
 
 Required repository permissions:
 
@@ -65,7 +66,7 @@ or runner permissions.
 After creating the app:
 
 1. Generate and download one private key PEM.
-2. Install the app on the seven repositories above.
+2. Install the app on the eight repositories above.
 3. Record the app ID and installation ID.
 
 A quick way to discover the installation ID after installation is:
@@ -111,7 +112,7 @@ that process tree.
 ## Break-glass PAT fallback
 
 A fine-grained PAT is supported only as a temporary fallback. It must be scoped
-to the same seven repositories and permissions above, and should have a short
+to the same eight repositories and permissions above, and should have a short
 expiration. Prefer the GitHub App path.
 
 ```bash

--- a/docs/runbooks/bootstrap-engineering-loop-vault.md
+++ b/docs/runbooks/bootstrap-engineering-loop-vault.md
@@ -1,9 +1,8 @@
 # Bootstrap Engineering Loop Vault secrets
 
 The dedicated `loop` VM runs the Engineering Loop daemon from a narrow Vault
-AppRole. This AppRole must only render the daemon's GitHub issue/PR token,
-model-provider credentials, and notification credentials into
-`/opt/engineering-loop/.env`.
+AppRole. This AppRole renders only GitHub App credentials, model-provider keys,
+and notification credentials for the Engineering Loop runtime.
 
 Do **not** place fleet SSH keys, broad Vault tokens, XO credentials, registrar
 credentials, or application runtime secrets in `kv/engineering-loop`.
@@ -38,10 +37,12 @@ vault write auth/approle/role/engineering-loop \
   secret_id_num_uses=0
 ```
 
-## Populate the KV payload
+## Create the GitHub App
 
-Use a fine-grained GitHub PAT or GitHub App installation token scoped only to
-these repositories:
+Create a GitHub App owned by `AS215932`, for example
+`hyrule-engineering-loop`.
+
+Repository access must be limited to exactly these repositories:
 
 - `AS215932/engineering-loop`
 - `AS215932/network-operations`
@@ -51,27 +52,73 @@ these repositories:
 - `AS215932/noc-agent`
 - `AS215932/hyrule-network-proxy`
 
-Required GitHub permissions:
+Required repository permissions:
 
 - Metadata: read
 - Issues: read/write
 - Contents: read/write
 - Pull requests: read/write
 
-No admin or org-wide permissions are required.
+Do not grant organization administration, Actions/workflow, secrets, members,
+or runner permissions.
+
+After creating the app:
+
+1. Generate and download one private key PEM.
+2. Install the app on the seven repositories above.
+3. Record the app ID and installation ID.
+
+A quick way to discover the installation ID after installation is:
 
 ```bash
-vault kv put kv/engineering-loop \
-  github_token="..." \
-  discord_webhook="..." \
-  icinga_url="https://[2a0c:b641:b50:2::50]:5665/v1/actions/process-check-result" \
-  icinga_user="..." \
-  icinga_password="..." \
-  icinga_check="loop!engineering-loop" \
-  openrouter_api_key="..." \
-  anthropic_api_key="..." \
-  openai_api_key="..."
+gh api /orgs/AS215932/installations \
+  --jq '.installations[] | select(.app_slug=="hyrule-engineering-loop") | .id'
 ```
+
+## Populate the KV payload with GitHub App credentials
+
+Keep the downloaded PEM file on the trusted operator workstation only long
+enough to write it to Vault. Do not paste the PEM into issue or PR comments.
+
+```bash
+read -rp 'GitHub App ID: ' ENGINEERING_LOOP_GITHUB_APP_ID
+read -rp 'GitHub App installation ID: ' ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID
+read -rp 'Path to downloaded GitHub App private key PEM: ' ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE
+
+vault kv put kv/engineering-loop \
+  github_app_id="$ENGINEERING_LOOP_GITHUB_APP_ID" \
+  github_app_installation_id="$ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID" \
+  github_app_private_key=@"$ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE" \
+  discord_webhook="$(vault kv get -field=discord_webhook_url kv/ci-runner)" \
+  icinga_url="https://[2a0c:b641:b50:2::50]:5665/v1/actions/process-check-result" \
+  icinga_user="$(vault kv get -field=icinga_api_user kv/ci-runner)" \
+  icinga_password="$(vault kv get -field=icinga_api_password kv/ci-runner)" \
+  icinga_check="loop!engineering-loop" \
+  openrouter_api_key="$(vault kv get -field=openrouter_api_key kv/noc-agent)" \
+  anthropic_api_key="$(vault kv get -field=anthropic_api_key kv/noc-agent)" \
+  openai_api_key="$(vault kv get -field=openai_api_key kv/noc-agent)"
+
+unset ENGINEERING_LOOP_GITHUB_APP_ID
+unset ENGINEERING_LOOP_GITHUB_APP_INSTALLATION_ID
+unset ENGINEERING_LOOP_GITHUB_APP_PRIVATE_KEY_FILE
+```
+
+The `loop` VM does not store a long-lived GitHub token. Vault Agent renders the
+GitHub App ID, installation ID, and private key. The systemd wrapper mints a
+fresh short-lived installation token for each daemon run and exports it only to
+that process tree.
+
+## Break-glass PAT fallback
+
+A fine-grained PAT is supported only as a temporary fallback. It must be scoped
+to the same seven repositories and permissions above, and should have a short
+expiration. Prefer the GitHub App path.
+
+```bash
+vault kv patch kv/engineering-loop github_token="..."
+```
+
+Do not store a broad personal `gh` OAuth token in `kv/engineering-loop`.
 
 ## Refresh the ci runner policy
 
@@ -104,8 +151,11 @@ Use the production workflow after the policies and KV entry exist:
 3. Approve the GitHub `production` environment gate.
 4. Confirm `/opt/engineering-loop/.env` exists on `loop` with owner/root and
    group access for the `loop` service only.
-5. Confirm `vault-agent-engineering-loop.service` is active.
-6. Keep `hyrule-engineering-loop.timer` disabled until Pi auth and the
+5. Confirm `/etc/engineering-loop/github-app.private-key.pem` exists with
+   owner `root`, group `loop`, and mode `0640`.
+6. Confirm `vault-agent-engineering-loop.service` is active.
+7. Run a manual empty-queue or docs-only canary before enabling the timer.
+8. Keep `hyrule-engineering-loop.timer` disabled until Pi auth and the
    docs-only draft PR canary pass.
 
 ## Rollback


### PR DESCRIPTION
## Summary

Move the dedicated Engineering Loop runtime from a long-lived GitHub token model to GitHub App authentication:

- Vault Agent renders GitHub App metadata into `/opt/engineering-loop/.env`.
- Vault Agent renders the GitHub App private key to `/etc/engineering-loop/github-app.private-key.pem`.
- A root-owned helper mints a fresh GitHub App installation token for each daemon run.
- The systemd service executes a wrapper that exports the short-lived token as `GH_TOKEN` / `ENGINEERING_LOOP_GITHUB_TOKEN` only for that run.
- PAT support remains as break-glass fallback only.
- The bootstrap runbook now documents GitHub App creation, repo/permission scope, and Vault seeding.

## Safety

- No long-lived GitHub token is stored in Vault for the normal path.
- The private key is rendered to `/etc/engineering-loop`, root-owned and group-readable by `loop` only.
- The short-lived installation token is not written to disk by the helper.
- GitHub App repo access remains limited to the seven core repos.
- Timer remains disabled; this only changes auth mechanics.

## Validation

- [x] `sh -n` on the GitHub App token helper
- [x] Rendered daemon wrapper syntax check with representative vars
- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`
- [x] `scripts/ci/render-all.sh`

## Follow-up after merge

1. Create/install the GitHub App on the seven core repos.
2. Seed `kv/engineering-loop` with `github_app_id`, `github_app_installation_id`, and `github_app_private_key` plus existing model/notification credentials.
3. Run `apply.yml` dry-run for `playbook=engineering-loop`, `limit=loop`.
4. Run live `apply.yml` and approve the `production` gate.
5. Verify `/opt/engineering-loop/.env`, `/etc/engineering-loop/github-app.private-key.pem`, and `vault-agent-engineering-loop.service` on `loop`.
6. Run the empty-queue canary before any timer enablement.
