### PR TITLE
ci: reduce PR lint queue time

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  yamllint:
-    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    steps:
-      - uses: actions/checkout@v6
-      - name: yamllint
-        run: yamllint -c .yamllint .
-
-  ansible-lint:
+  lint:
+    name: lint
     runs-on: [self-hosted, linux, x64, hyrule-public-pr]
     # roles_path lives in ansible/ansible.cfg, which isn't picked up when lint
     # runs from the repo root — point ansible at ansible/roles explicitly so
@@ -28,14 +22,20 @@ jobs:
       ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles
     steps:
       - uses: actions/checkout@v6
+
+      - name: yamllint
+        id: yamllint
+        continue-on-error: true
+        run: yamllint -c .yamllint .
+
       - name: ansible-lint
+        id: ansible_lint
+        continue-on-error: true
         run: ansible-lint -c .ansible-lint ansible/playbooks/ ansible/roles/
 
-  shellcheck:
-    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    steps:
-      - uses: actions/checkout@v6
       - name: shellcheck
+        id: shellcheck
+        continue-on-error: true
         run: |
           set -e
           # Skip generated/, but lint all hand-written scripts.
@@ -48,11 +48,9 @@ jobs:
             echo "no shell scripts found, skipping"
           fi
 
-  jinja-syntax:
-    runs-on: [self-hosted, linux, x64, hyrule-public-pr]
-    steps:
-      - uses: actions/checkout@v6
       - name: jinja2 syntax check
+        id: jinja_syntax
+        continue-on-error: true
         run: |
           python3 - <<'EOF'
           import sys
@@ -74,3 +72,13 @@ jobs:
                   fail = 1
           sys.exit(fail)
           EOF
+
+      - name: Fail if any lint check failed
+        if: >
+          steps.yamllint.outcome == 'failure' ||
+          steps.ansible_lint.outcome == 'failure' ||
+          steps.shellcheck.outcome == 'failure' ||
+          steps.jinja_syntax.outcome == 'failure'
+        run: |
+          echo "::error::one or more lint checks failed"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # AS215932 Infrastructure Agent Guide
 
+## Branch Hygiene - Read Before Editing or Pushing
+
+- Before making changes, run `git branch --show-current` and `git status --short`.
+- Unless the user explicitly says to continue work on the current branch, create a fresh task branch from up-to-date `main` before editing:
+  - `git fetch origin main`
+  - `git switch -c <type>/<short-task-name> origin/main`
+- Never add unrelated work to an existing feature branch or PR just because it is currently checked out.
+- If a task is about CI/CD, docs, runner config, or general maintenance, it almost always needs its own branch from `main`; do not build it on a feature branch such as NETCONF/YANG, app promotion, or routing changes.
+- Before committing and before pushing, re-check `git status --short`, `git branch --show-current`, and `gh pr list --head "$(git branch --show-current)"` to confirm the branch matches the task.
+- If you discover changes were made on the wrong branch, stop and split them onto a new branch from `main` before pushing.
+
 ## Deployment Rules - Read Before Touching App Pins
 
 - Production deploys for `noc-agent`, `hyrule-mcp`, `hyrule-cloud`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@
 - Before committing and before pushing, re-check `git status --short`, `git branch --show-current`, and `gh pr list --head "$(git branch --show-current)"` to confirm the branch matches the task.
 - If you discover changes were made on the wrong branch, stop and split them onto a new branch from `main` before pushing.
 
+## Pull Request Hygiene - Do Not Hand Off Red PRs
+
+- After opening or updating a PR, wait for automated CI and AI agent reviews to complete before leaving it for a human reviewer.
+- Inspect failing checks, AI review comments, and normal review comments; fix real issues in follow-up commits on the same PR branch.
+- Respond to review comments that you address, and briefly explain if a comment is intentionally not changed.
+- Re-run or wait for CI after fixes, then confirm the required checks are green before asking for human review or saying the PR is ready.
+- If CI or an AI review is still pending when you must stop, say so explicitly and include the PR URL plus the pending/failing contexts.
+
 ## Deployment Rules - Read Before Touching App Pins
 
 - Production deploys for `noc-agent`, `hyrule-mcp`, `hyrule-cloud`,

--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -7,7 +7,7 @@ a blocking gate per `docs/ci/semgrep.md` once each repo's baseline is triaged.
 
 | Repo | Required checks | strict | reviews | enforce_admins |
 |------|-----------------|:------:|:-------:|:--------------:|
-| `network-operations` | `yamllint, ansible-lint, shellcheck, jinja-syntax, render, iac-gate, semgrep` | ✓ | 1 | off |
+| `network-operations` | `lint, render, iac-gate, semgrep` | ✓ | 1 | off |
 | `hyrule-web` | `test, frontend` | ✓ | 1 | off |
 | `hyrule-cloud` | `test, semgrep` | ✓ | 0 | off |
 | `noc-agent` | `semgrep` | ✓ | 0 | off |

--- a/docs/ci/org-cicd-inventory.md
+++ b/docs/ci/org-cicd-inventory.md
@@ -14,7 +14,7 @@ change.
 
 | Repo | Stack | Workflows (`main`) | Branch protection / required checks | Deploys? | AI review | Semgrep |
 |------|-------|--------------------|-------------------------------------|----------|-----------|---------|
-| `network-operations` | Ansible / IaC + Python tests | `lint.yml`, `render-check.yml`, `iac-tests.yml`, `apply.yml`, `drift-detection.yml` | **Protected** — required: `yamllint`, `ansible-lint`, `shellcheck`, `jinja-syntax`, `render`, `Sourcery review` (strict) | Yes (`apply.yml`, manual + `production`) | Sourcery (to remove) | none yet |
+| `network-operations` | Ansible / IaC + Python tests | `lint.yml`, `render-check.yml`, `iac-tests.yml`, `apply.yml`, `drift-detection.yml` | **Protected** — required: `lint`, `render`, `iac-gate`, `semgrep` (strict) | Yes (`apply.yml`, manual + `production`) | PR-Agent advisory | token-less SARIF |
 | `hyrule-web` | Python (uv) + TS/Vite | `ci.yml` (`test`, `frontend`), `deploy.yml` | **Protected** — required: `test`, `frontend` (strict) | Yes (`deploy.yml`, push→main / dispatch, `production`) | Sourcery (to remove) | none yet |
 | `hyrule-cloud` | Python (uv), FastAPI / x402 | `ci.yml` (`test`), `deploy.yml` | **Not protected** | Yes (`deploy.yml`, `production`) | Sourcery (to remove) | none yet |
 | `noc-agent` | Python ≥3.14, PydanticAI / langgraph / redis / mcp | none | **Not protected** | No | Sourcery (to remove) | none yet |
@@ -23,10 +23,13 @@ change.
 
 Notes:
 
-- Check names on `network-operations` are **bare job ids** (`yamllint`, not
-  `lint / yamllint`); `render` is the job in `render-check.yml`. The
-  `iac-tests.yml` jobs (`static-iac`, `ansible-idempotency`, `batfish`,
-  `containerlab-frr`) are **not** required yet.
+- Check names on `network-operations` are **bare job ids**: `lint`, `render`,
+  `iac-gate`, and `semgrep`. `lint.yml` intentionally reports a single `lint`
+  job while running yamllint, ansible-lint, shellcheck, and Jinja syntax checks
+  as steps to reduce queue slots on the single public PR runner. The
+  `iac-tests.yml` tier jobs (`static-iac`, `ansible-idempotency`, `batfish`,
+  `containerlab-frr`) are **not** required individually; `iac-gate` is the
+  required aggregate context.
 - `hyrule-cloud` `ci.yml` lints/types **touched files only**, and `mypy
   --strict` is currently suffixed `|| true` (deliberate, temporary — tracked as
   the post-A0 type-cleanup PR's exit criterion). Its in-file comment claims


### PR DESCRIPTION
## Summary
- consolidate the four PR lint jobs into one required `lint` job to reduce queue slots on the single public PR runner
- keep individual lint checks visible as separate steps and fail at the end if any check failed
- add AGENTS.md branch-hygiene guidance so future agent work starts from `main` unless explicitly told otherwise

## Validation
- `yamllint -c .yamllint .github/workflows/lint.yml .github/workflows/render-check.yml .github/workflows/iac-tests.yml`
- `actionlint` unavailable locally, skipped

## Follow-up
- update branch protection required checks from `yamllint`, `ansible-lint`, `shellcheck`, `jinja-syntax` to single `lint` after this workflow exists on the PR branch
