### PR TITLE
docs: update CI runner sizing guidance

### DIFF
--- a/docs/ci/org-cicd-inventory.md
+++ b/docs/ci/org-cicd-inventory.md
@@ -47,16 +47,12 @@ Notes:
 
 ## Runner topology (today)
 
-One org-scoped self-hosted runner:
+Two org-scoped self-hosted runners:
 
-- **`ci-runner`** on the `ci` VM (`2a0c:b641:b50:2::d0`), online, labels
-  `self-hosted, Linux, X64, hyrule, hyrule-infra`.
-- **Privileged**: Vault AppRole → `/etc/github-runner/secrets.env`, the fleet
-  deploy key `id_ci` (`/var/lib/github-runner/.ssh/id_ci`), Docker + Containerlab,
-  and overlay-v6 reach to every infra host. Provisioned by the toggle-driven
-  `ansible/roles/github_runner` role (+ `ansible/roles/ci_runner_key`). Host
-  vars: `ansible/inventory/host_vars/ci.yml`. Provisioning runbook:
-  `docs/ci/provision.md`.
+- **`ci-runner`** on the `ci` VM (`2a0c:b641:b50:2::d0`), sized **4 vCPU / 8 GiB RAM** plus a 20 GiB root disk and 50 GiB runner data disk, labels `self-hosted, Linux, X64, hyrule, hyrule-infra`.
+- **`ci-pr-runner-recovery2`** on the `ci-pr` VM (`2a0c:b641:b51::c1`), sized **4 vCPU / 8 GiB RAM** with a 20 GiB root disk, labels `self-hosted, Linux, X64, hyrule-public-pr`.
+- **Privileged `ci`**: Vault AppRole → `/etc/github-runner/secrets.env`, the fleet deploy key `id_ci` (`/var/lib/github-runner/.ssh/id_ci`), Docker + Containerlab, and overlay-v6 reach to every infra host. Provisioned by the toggle-driven `ansible/roles/github_runner` role (+ `ansible/roles/ci_runner_key`). Host vars: `ansible/inventory/host_vars/ci.yml`. Provisioning runbook: `docs/ci/provision.md`.
+- **Unprivileged `ci-pr`**: no Vault, no `id_ci`, no `secrets.env`, no management-overlay reachability, Docker only. Provisioned by `ansible/roles/github_runner` with the unprivileged host vars in `ansible/inventory/host_vars/ci-pr.yml`. Provisioning runbook: `docs/ci/provision-ci-pr.md`.
 
 Runner groups (org Actions settings):
 
@@ -64,11 +60,9 @@ Runner groups (org Actions settings):
 |-------|----|-----------|-------|---------|
 | `Default` | 1 | all | (all) | none |
 | `hyrule-ci` | 3 | selected | `hyrule-cloud`, `hyrule-web`, `network-operations` | `ci-runner` |
+| `public-pr` | org-scoped | selected | AS215932 repos with untrusted PR jobs | `ci-pr-runner-recovery2` |
 
-**Consequence**: today every `pull_request` job in web/cloud/network-operations
-runs untrusted PR code on the single privileged runner. The only controls are
-GitHub's fork-PR approval requirement (public repos) and the `hyrule-ci` group
-ACL. This is the exposure the two-runner model closes.
+**Consequence**: untrusted `pull_request` jobs run on the isolated `ci-pr` runner, while deploy/apply/lab work stays on the privileged `ci` runner. Each VM still runs a single GitHub Actions runner process, so resizing improves per-job runtime and memory headroom without increasing job concurrency.
 
 ## Secrets & credentials
 
@@ -90,14 +84,14 @@ Code Scanning, free for these public repos.
 | `claude` | all | keep |
 | `sourcery-ai` | all | **remove** — drop the `Sourcery review` required check on `network-operations` first, then uninstall/limit the app |
 
-## Target architecture (being implemented)
+## Current architecture
 
-- **Two-runner security model**: keep the privileged `ci-runner` (`hyrule`,
-  `hyrule-infra`, group `hyrule-ci`) for deploy/apply/Vault/labs only; add a new
-  **unprivileged `ci-pr`** runner (label `hyrule-public-pr`, its own `public-pr`
-  runner group permitting all six repos) with no Vault, no `id_ci`, no
-  `secrets.env`, and no management-overlay reachability. All untrusted-PR-code
-  jobs (PR-Agent, Semgrep, lint/test/build/static checks) move to `ci-pr`.
+- **Two-runner security model**: the privileged `ci-runner` (`hyrule`,
+  `hyrule-infra`, group `hyrule-ci`) runs deploy/apply/Vault/labs only. The
+  unprivileged `ci-pr` runner (label `hyrule-public-pr`, `public-pr` runner
+  group) has no Vault, no `id_ci`, no `secrets.env`, and no management-overlay
+  reachability. All untrusted-PR-code jobs (PR-Agent, Semgrep,
+  lint/test/build/static checks) run on `ci-pr`.
 - **PR-Agent** replaces Sourcery: advisory, read/comment-only, OpenRouter
   primary `openrouter/deepseek/deepseek-v4-flash`, fallback
   `openrouter/minimax/minimax-m2.7`, pinned `The-PR-Agent/pr-agent` Docker

--- a/docs/ci/provision-ci-pr.md
+++ b/docs/ci/provision-ci-pr.md
@@ -20,7 +20,7 @@ Contrast with the privileged `ci` runner: see `docs/ci/provision.md`.
 
 - `~/.ssh/id_servify` (ops workstation key — also authorizes `ci-pr` SSH).
 - `gh` authenticated to the AS215932 org.
-- Decide sizing: **1 vCPU, 2 GiB RAM, 20 GiB root** (Debian 13). No data disk.
+- Decide sizing: **4 vCPU, 8 GiB RAM, 20 GiB root** (Debian 13). No data disk. This remains a single GitHub Actions runner process (one job at a time); the larger VM reduces per-job runtime and avoids Docker/Semgrep/Ansible memory pressure without increasing PR job concurrency.
 
 ## 1. Create the VM on the customer (vm) bridge
 
@@ -36,7 +36,7 @@ export VM_NET=<that-uuid>
 
 # create-vms.sh skips ci-pr unless VM_NET is set. It uses args 9,10 =
 # NETWORK + GATEWAY to place ci-pr on the vm bridge with the rtr enX3 gateway:
-#   create_vm ci-pr "..." 1 2147483648 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
+#   create_vm ci-pr "..." 4 8589934592 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
 bash scripts/create-vms.sh   # or copy just the ci-pr block
 ```
 

--- a/docs/ci/provision.md
+++ b/docs/ci/provision.md
@@ -4,8 +4,7 @@ The `ci` VM hosts the self-hosted GitHub Actions runner that powers every
 workflow in `.github/workflows/`. It must exist before the workflows can
 do any work — until then the workflow jobs sit queued.
 
-Reasonable size: **1 vCPU, 2 GB RAM, 20 GB root disk + 50 GB runner data disk** (Debian 13). The runner is
-mostly I/O-bound during `ansible-playbook --tags validate` jobs.
+Reasonable size: **4 vCPU, 8 GiB RAM, 20 GiB root disk + 50 GiB runner data disk** (Debian 13). The runner still serializes one GitHub Actions job at a time, but the extra headroom keeps Docker, Ansible, and trusted lab bursts from stretching the PR/apply queue.
 
 ## 1. Provision the VM via Xen Orchestra
 
@@ -14,7 +13,7 @@ via overlay v6 `2a0c:b641:b50:2::70` or the dom0 jump `193.70.32.138`) — see
 `scripts/create-vms.sh` for the `vm.create` + `vdi.set` + `vm.setBootOrder` +
 `vm.start` sequence. The `ci` VM follows it with these parameters:
 
-- Template: **Debian 13 cloud-init**. Name: `ci`. 1 vCPU, 2 GiB RAM,
+- Template: **Debian 13 cloud-init**. Name: `ci`. 4 vCPU, 8 GiB RAM,
   20 GiB root disk on `local_storage` plus a second 50 GiB data disk attached
   at VBD position `8` so the guest sees it as `/dev/xvdi`.
 - VIF on `xenbr-infra` (overlay). Static IPv6 `2a0c:b641:b50:2::d0`

--- a/scripts/create-vms.sh
+++ b/scripts/create-vms.sh
@@ -99,7 +99,7 @@ create_vm mon "Monitoring (Icinga2 + Prometheus + Grafana)" 2 4294967296 4294967
 create_vm vpn "WireGuard VPN" 1 1073741824 10737418240 "2a0c:b641:b50:2::60"
 create_vm irc "Soju IRC bouncer" 1 1073741824 10737418240 "2a0c:b641:b50:2::80"
 create_vm vault "Vault secret plane" 1 2147483648 21474836480 "2a0c:b641:b50:2::c0"
-create_vm ci "GitHub Actions self-hosted runner" 1 2147483648 21474836480 "2a0c:b641:b50:2::d0" 53687091200 8
+create_vm ci "GitHub Actions self-hosted runner" 4 8589934592 21474836480 "2a0c:b641:b50:2::d0" 53687091200 8
 create_vm netproxy "Hyrule Network Proxy sidecar" 1 1073741824 21474836480 "2a0c:b641:b50:2::e0"
 
 # ci-pr — UNPRIVILEGED PR runner on the CUSTOMER-isolated vm bridge (xenbr-vm),
@@ -111,7 +111,7 @@ create_vm netproxy "Hyrule Network Proxy sidecar" 1 1073741824 21474836480 "2a0c
 VM_NET="${VM_NET:-}"
 if [ -n "$VM_NET" ]; then
   create_vm ci-pr "Unprivileged PR runner (PR-Agent/Semgrep/PR CI)" \
-    1 2147483648 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
+    4 8589934592 21474836480 "2a0c:b641:b51::c1" "" "" "$VM_NET" "2a0c:b641:b51::1"
 else
   echo "SKIP ci-pr: export VM_NET=<xenbr-vm network UUID> to create it (see docs/ci/provision-ci-pr.md)."
 fi


### PR DESCRIPTION
## Summary
- update ci and ci-pr VM creation defaults to 4 vCPU / 8 GiB RAM
- update ci and ci-pr provisioning docs with the selected sizing and concurrency note
- refresh CI/CD inventory to document the current two-runner topology and runner names

## Validation
- `bash -n scripts/create-vms.sh`
- `git diff --check`

## Manual follow-up
- resize the existing `ci` and `ci-pr` VMs in Xen Orchestra to 4 vCPU / 8 GiB RAM
- verify both GitHub runners come back online
- measure PR CI wait time after resize
