### PR TITLE
fix: pin engineering loop to merged as215932 scope SHA

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "203957c0bffd306b59f8882d3548c3922633c349"
+engineering_loop_version: "a8c6d3f12d2c36532ed0745728750adf4ac29396"
 engineering_loop_timer_enabled: false
 
 monitoring_register: true

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -22,7 +22,7 @@ engineering_loop_daemon_wrapper_path: "{{ engineering_loop_lib_dir }}/run-daemon
 engineering_loop_github_app_private_key_file: "{{ engineering_loop_config_dir }}/github-app.private-key.pem"
 
 engineering_loop_repo: https://github.com/AS215932/engineering-loop.git
-engineering_loop_version: "203957c0bffd306b59f8882d3548c3922633c349"
+engineering_loop_version: "a8c6d3f12d2c36532ed0745728750adf4ac29396"
 
 # GitHub issue/PR intake scope for first production rollout.
 engineering_loop_repos:


### PR DESCRIPTION
## Summary

Fix the Engineering Loop runtime pin after `AS215932/engineering-loop#3` was squash-merged.

`network-operations#228` pinned the pre-merge branch commit `203957c0...`. That commit contains the right code, but it is not an ancestor of `engineering-loop/main` after the squash merge. This updates the deployment pin to the merged `engineering-loop#3` SHA:

`a8c6d3f12d2c36532ed0745728750adf4ac29396`

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`

## Safety

- Timer remains disabled.
- No secret or app pin changes.
- This only makes the Engineering Loop runtime pin auditable/reachable from `engineering-loop/main` before production apply.
