### PR TITLE
fix: move live apply concurrency to fresh serialized key

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -90,8 +90,10 @@ permissions:
 
 concurrency:
   # Live applies remain strictly serialized. Dry-runs are render/check only and
-  # must not get stuck behind, or block, the production apply lane.
-  group: ${{ inputs.dry_run && format('production-infra-dry-run-{0}', github.run_id) || 'production-infra' }}
+  # must not get stuck behind, or block, the production apply lane. The live
+  # key is versioned because the original production-infra key produced
+  # jobless pending workflow_dispatch runs after cancelled attempts.
+  group: ${{ inputs.dry_run && format('production-infra-dry-run-{0}', github.run_id) || 'production-infra-live-v2' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Live `apply.yml` dispatches are again entering the jobless `pending` state with no deployments to approve. Dry-runs were already moved off the old static key in #226 and now schedule correctly.

This keeps live applies serialized but changes the live concurrency group from the apparently wedged `production-infra` key to `production-infra-live-v2`.

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`

## Safety

- Live applies remain serialized.
- Production environment approval is unchanged.
- No host, app pin, Vault, or secret changes.
