### PR TITLE
fix: allow loop vault api access

### DIFF
--- a/ansible/generated/vault/nftables.conf
+++ b/ansible/generated/vault/nftables.conf
@@ -37,7 +37,7 @@ table inet filter {
 
         # Per-host service allowances.
         ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8200 counter accept comment "Vault API from Caddy proxy"
-        ip6 saddr { 2a0c:b641:b50:2::a0, 2a0c:b641:b50:2::50, 2a0c:b641:b50:2::20, 2a0c:b641:b50:2::30, 2a0c:b641:b50:2::d0 } tcp dport 8200 counter accept comment "Vault API from internal agents/checks"
+        ip6 saddr { 2a0c:b641:b50:2::a0, 2a0c:b641:b50:2::50, 2a0c:b641:b50:2::20, 2a0c:b641:b50:2::30, 2a0c:b641:b50:2::d0, 2a0c:b641:b50:2::f0 } tcp dport 8200 counter accept comment "Vault API from internal agents/checks"
         ip6 saddr 2a0c:b641:b50:3::/64 tcp dport 8200 counter accept comment "Vault API from VPN operators"
         ip6 saddr 2a02:a442:1016::/48 tcp dport 8200 counter accept comment "Vault API from ops prefix"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"

--- a/ansible/inventory/host_vars/vault.yml
+++ b/ansible/inventory/host_vars/vault.yml
@@ -3,7 +3,7 @@
 
 firewall_extra_rules:
   - { proto: tcp, dport: 8200, src: "{{ peers.proxy.ipv6 }}", comment: "Vault API from Caddy proxy" }
-  - { proto: tcp, dport: 8200, src: ["{{ peers.noc.ipv6 }}", "{{ peers.mon.ipv6 }}", "{{ peers.api.ipv6 }}", "{{ peers.web.ipv6 }}", "{{ peers.ci.ipv6 }}"], comment: "Vault API from internal agents/checks" }
+  - { proto: tcp, dport: 8200, src: ["{{ peers.noc.ipv6 }}", "{{ peers.mon.ipv6 }}", "{{ peers.api.ipv6 }}", "{{ peers.web.ipv6 }}", "{{ peers.ci.ipv6 }}", "{{ peers.loop.ipv6 }}"], comment: "Vault API from internal agents/checks" }
   - { proto: tcp, dport: 8200, src: "{{ vpn_clients_subnet }}", comment: "Vault API from VPN operators" }
   - { proto: tcp, dport: 8200, src: "{{ ops_prefix_v6 }}", comment: "Vault API from ops prefix" }
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }


### PR DESCRIPTION
## Summary

Allow the dedicated `loop` VM to reach Vault on port 8200.

After the successful Engineering Loop live apply, `vault-agent-engineering-loop.service` on `loop` was active but unable to authenticate/render templates because Vault API connections to `[2a0c:b641:b50:2::c0]:8200` timed out. The Vault host firewall allowed the existing internal agents/checks but not `loop`.

This adds `peers.loop.ipv6` to the existing internal Vault API allow list and updates the rendered nftables artifact.

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/firewall.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/firewall.yml --tags validate --connection=local --limit vault --skip-tags=snapshot`

## Safety

- Narrow source: `2a0c:b641:b50:2::f0` only.
- Narrow destination/service: Vault host TCP/8200 only.
- Required for the already-deployed narrow `engineering-loop` Vault Agent/AppRole to render `/opt/engineering-loop/.env` and `/etc/engineering-loop/github-app.private-key.pem`.
