### PR TITLE
fix: pin engineering loop provider-env fix

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "a8c6d3f12d2c36532ed0745728750adf4ac29396"
+engineering_loop_version: "5916408731c828a20ff5c5403ef884505b1fe556"
 engineering_loop_timer_enabled: false
 
 monitoring_register: true


### PR DESCRIPTION
## Summary

Pin the dedicated `loop` runtime to `AS215932/engineering-loop@5916408731c828a20ff5c5403ef884505b1fe556`, which fixes the production canary blocker where the Pi backend subprocess did not receive model-provider API keys.

## Context

- `engineering-loop#4` merged successfully.
- Step 2 is complete: Vault Agent renders `/opt/engineering-loop/.env` and the GitHub App key on `loop`.
- The first docs-only canary (`network-operations#235`) reached the Pi backend but stopped at `needs_triage` because the backend scrubbed provider env vars before invoking Pi.
- This deploys the merged backend fix before retrying that same canary.

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`

## Safety

- Timer remains disabled (`engineering_loop_timer_enabled: false`).
- No app production pins changed.
- No Vault, firewall, or workflow behavior changed.
