### PR TITLE
fix: keep engineering loop memory outside workspaces

### DIFF
--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -70,7 +70,8 @@ engineering_loop_allowed_paths:
 engineering_loop_max_runs_per_day: 2
 engineering_loop_max_cost_usd_per_day: 10
 engineering_loop_timer_enabled: false
-engineering_loop_memory_dir: "{{ engineering_loop_workspace_dir }}/hyrule-infra/memory"
+engineering_loop_memory_dir: "{{ engineering_loop_state_dir }}/memory"
+engineering_loop_legacy_memory_dir: "{{ engineering_loop_workspace_dir }}/hyrule-infra/memory"
 
 engineering_loop_git_user_name: "hyrule-engineering-loop[bot]"
 engineering_loop_git_user_email: "engineering-loop@as215932.net"

--- a/ansible/roles/engineering_loop/tasks/apply.yml
+++ b/ansible/roles/engineering_loop/tasks/apply.yml
@@ -43,7 +43,25 @@
     - { path: "{{ engineering_loop_workspace_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_runs_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_daemon_state_dir }}", mode: "0750" }
+    - { path: "{{ engineering_loop_memory_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_git_askpass_path | dirname }}", owner: root, group: "{{ engineering_loop_group }}", mode: "0750" }
+
+- name: Migrate Engineering Loop memory out of managed repo workspaces
+  ansible.builtin.shell: |
+    set -euo pipefail
+    legacy={{ engineering_loop_legacy_memory_dir | quote }}
+    target={{ engineering_loop_memory_dir | quote }}
+    if [ "$legacy" = "$target" ] || [ ! -d "$legacy" ]; then
+      exit 0
+    fi
+    cp -a "$legacy"/. "$target"/
+    rm -rf "$legacy"
+    chown -R {{ engineering_loop_user | quote }}:{{ engineering_loop_group | quote }} "$target"
+    echo migrated
+  args:
+    executable: /bin/bash
+  register: engineering_loop_memory_migration
+  changed_when: engineering_loop_memory_migration.stdout != ''
 
 - name: Checkout Engineering Loop runtime
   ansible.builtin.git:

--- a/ansible/roles/engineering_loop/tasks/apply.yml
+++ b/ansible/roles/engineering_loop/tasks/apply.yml
@@ -46,22 +46,30 @@
     - { path: "{{ engineering_loop_memory_dir }}", mode: "0750" }
     - { path: "{{ engineering_loop_git_askpass_path | dirname }}", owner: root, group: "{{ engineering_loop_group }}", mode: "0750" }
 
+- name: Check for legacy Engineering Loop memory inside managed workspace
+  ansible.builtin.stat:
+    path: "{{ engineering_loop_legacy_memory_dir }}"
+  register: engineering_loop_legacy_memory
+
 - name: Migrate Engineering Loop memory out of managed repo workspaces
-  ansible.builtin.shell: |
-    set -euo pipefail
-    legacy={{ engineering_loop_legacy_memory_dir | quote }}
-    target={{ engineering_loop_memory_dir | quote }}
-    if [ "$legacy" = "$target" ] || [ ! -d "$legacy" ]; then
-      exit 0
-    fi
-    cp -a "$legacy"/. "$target"/
-    rm -rf "$legacy"
-    chown -R {{ engineering_loop_user | quote }}:{{ engineering_loop_group | quote }} "$target"
-    echo migrated
-  args:
-    executable: /bin/bash
-  register: engineering_loop_memory_migration
-  changed_when: engineering_loop_memory_migration.stdout != ''
+  ansible.builtin.copy:
+    src: "{{ engineering_loop_legacy_memory_dir }}/"
+    dest: "{{ engineering_loop_memory_dir }}/"
+    remote_src: true
+    owner: "{{ engineering_loop_user }}"
+    group: "{{ engineering_loop_group }}"
+    mode: preserve
+  when:
+    - engineering_loop_legacy_memory_dir != engineering_loop_memory_dir
+    - engineering_loop_legacy_memory.stat.exists
+
+- name: Remove legacy Engineering Loop memory from managed workspace
+  ansible.builtin.file:
+    path: "{{ engineering_loop_legacy_memory_dir }}"
+    state: absent
+  when:
+    - engineering_loop_legacy_memory_dir != engineering_loop_memory_dir
+    - engineering_loop_legacy_memory.stat.exists
 
 - name: Checkout Engineering Loop runtime
   ansible.builtin.git:


### PR DESCRIPTION
## Summary

Keep Engineering Loop memory outside managed repository workspaces and migrate/remove the legacy `workspace/hyrule-infra/memory` directory.

## Context

The canary retry after deploying `engineering-loop#4` did not publish a PR because the previous failed run had written journal/proposal files under:

`/var/lib/engineering-loop/workspace/hyrule-infra/memory`

That made the managed `network-operations` checkout dirty, so the repo adapter refused to proceed.

This changes the memory location to:

`/var/lib/engineering-loop/memory`

and migrates/removes the legacy workspace-local memory directory during apply so managed workspaces stay clean.

## Validation

- [x] `scripts/ci/iac-static.sh`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --syntax-check`
- [x] `cd ansible && ansible-playbook playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags=snapshot`

## Safety

- Timer remains disabled.
- No app production pins changed.
- Existing memory is copied before the legacy directory is removed.
- This only touches Engineering Loop state placement on the dedicated `loop` VM.

## Rollout note

The 2026-06-15 canary run budget is now consumed (`runs: 2`). Do not manually retry the canary again today unless explicitly overriding the low-and-slow rollout policy.
