### PR TITLE
fix: pin engineering loop to substrate-hardening SHA (58735fa)

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "5916408731c828a20ff5c5403ef884505b1fe556"
+engineering_loop_version: "58735fa051d24290f128109b4267e136316cbc86"
 engineering_loop_timer_enabled: false
 
 monitoring_register: true


### PR DESCRIPTION
## Context

Pins `loop` to `AS215932/engineering-loop@58735fa` (merged engineering-loop#5: **worktree self-heal + production handoff-dir allowlist**).

Finishing the Phase A loop cutover, the docs-only production canary (#235) reached `needs_triage` twice without publishing a draft PR:
1. worktree setup aborted on a worktree left by a prior crashed run (would wedge the hourly timer);
2. a fully executed run was rejected because the handoff dir under `/var/lib/engineering-loop/runs` was not in the gate policy's `allowed_handoff_dirs` (only `/tmp`).

Both are fixed in engineering-loop#5; this bumps the runtime pin so they reach `loop`.

## Change

- `ansible/inventory/host_vars/loop.yml`: `engineering_loop_version` → `58735fa051d24290f128109b4267e136316cbc86`.
- Timer stays **disabled** (`engineering_loop_timer_enabled: false`) until the canary publishes exactly one draft PR.

## Validation

- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/engineering-loop.yml --syntax-check` — pass

## Rollout

After merge: `apply.yml` `playbook=engineering-loop limit=loop` dry-run → live (production gate) → verify runtime SHA on `loop` → re-run canary #235 → enable timer only once it publishes one docs-only draft PR.