### PR TITLE
feat: enable the engineering loop hourly timer

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -5,7 +5,7 @@
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
 engineering_loop_version: "58735fa051d24290f128109b4267e136316cbc86"
-engineering_loop_timer_enabled: false
+engineering_loop_timer_enabled: true
 
 monitoring_register: true
 monitoring_role: loop


### PR DESCRIPTION
## Context

The production docs-only canary (#235) published exactly one docs-only draft PR (#239) from the dedicated `loop` VM, on the substrate-hardening pin `58735fa` (engineering-loop#5 via #238). All Phase A substrate blockers are resolved (provider env #4, memory location #237, worktree self-heal + handoff allowlist #5). Time to turn on the hourly timer.

## Change

- `ansible/inventory/host_vars/loop.yml`: `engineering_loop_timer_enabled: true`.

## Safety

- `OnCalendar=hourly` (`RandomizedDelaySec=300`), but the per-day ledger caps real runs at **2/day** — no runaway.
- The `loop:approved` queue is **empty** (#235 closed by #239), so the loop reports `idle` until a human approves an issue.
- Today's ledger is already at its cap, so no run fires until tomorrow's budget regardless.
- Resolves the standing `engineering-loop-timer` Icinga check (was inactive while the timer was disabled).

## Validation

- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/engineering-loop.yml --syntax-check` — pass

## Rollout

After merge: `apply.yml` `playbook=engineering-loop limit=loop` dry-run → live (production gate). Verify:
- `systemctl is-enabled hyrule-engineering-loop.timer` → enabled
- `systemctl is-active hyrule-engineering-loop.timer` → active
- `systemctl list-timers hyrule-engineering-loop.timer` → next run scheduled
- Icinga `engineering-loop-timer` check OK