### PR TITLE
feat(noc): deploy gated remediation + dormant no-op rollback guards

### DIFF
--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -5,8 +5,8 @@
 # on mon, runs an LLM-driven investigation against hyrule-mcp tools, and
 # notifies a Discord channel. hyrule-mcp is a stdio child of noc-agent.
 
-noc_agent_version: eb709a88236d29aec439927bbba63413ead9aa67
-hyrule_mcp_version: 78b97ee626d665160b9bd3c3741589392655a00e
+noc_agent_version: aab7d429cae25dfe820b5bba8263262890ca1bb2
+hyrule_mcp_version: 326bcc85e1c69f0d7c1839ebaa4abb73acd84185
 
 # XO MCP occasionally takes >5s to answer tools/list via supergateway during
 # streamable-HTTP session churn. Keep Icinga + app health probes below their

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -54,6 +54,13 @@ XO_PASSWORD={{ or .Data.data.xo_password "" }}
 PROMETHEUS_URL=http://[{{ peers.mon.ipv6 }}]:9090
 HYRULE_MCP_HOSTS_CONFIG=/etc/hyrule-mcp/hosts.yml
 HYRULE_MCP_ENABLE_ACTIONS=1
+# Approved remediation is gated in noc-agent; keep it enabled to preserve the
+# existing real-action flow. The no-op rollback guard substrate ships dormant
+# (opt in by flipping the two guard flags to 1 once smoke-tested on noc).
+NOC_ENABLE_APPROVED_EXECUTION=1
+NOC_ENABLE_NOOP_ROLLBACK_GUARDS=0
+HYRULE_MCP_ENABLE_NOOP_GUARDS=0
+HYRULE_MCP_ROLLBACK_GUARD_DIR=/var/lib/hyrule-mcp/rollback
 {% raw %}{{ with secret "kv/data/noc-agent" -}}
 HYRULE_MCP_ACTION_SIGNING_SECRET={{ .Data.data.noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ or .Data.data.noc_action_allowed_hosts "noc,mon,cr1-nl1,cr1-de1" }}

--- a/docs/autonomous-noc-remediation-execution.md
+++ b/docs/autonomous-noc-remediation-execution.md
@@ -20,6 +20,19 @@ This document is the issue body for the next tranche: safe, auditable, approved 
 - Vault Agent renders `/opt/noc-agent/.env`; local plaintext NOC secrets have been moved out of the local secret file.
 - Live smoke checks for NOC Agent health and MCP daemon health pass against production.
 
+### Execution gating (current posture)
+
+Approved-remediation execution is now flag-gated in `noc-agent` and routed through `hyrule-mcp`:
+
+| Flag (in `/opt/noc-agent/.env`) | Value | Effect |
+|---|---|---|
+| `HYRULE_MCP_ENABLE_ACTIONS` | `1` | MCP real-action tools (restart/ack) available, allowlist-scoped |
+| `NOC_ENABLE_APPROVED_EXECUTION` | `1` | noc-agent executes approved remediation (off → `execution_disabled`) |
+| `NOC_ENABLE_NOOP_ROLLBACK_GUARDS` | `0` | when `1`, execution routes through inert no-op rollback guards instead of real actions |
+| `HYRULE_MCP_ENABLE_NOOP_GUARDS` | `0` | when `1`, exposes the MCP `prepare_commit_confirm`/`confirm_change`/`rollback_change`/`get_pending_rollback_guards` tools |
+
+The no-op rollback guard substrate (hyrule-mcp#20, noc-agent#19) ships **dormant**: to exercise the inert prepare→confirm/rollback path without real mutation, flip `HYRULE_MCP_ENABLE_NOOP_GUARDS=1` and `NOC_ENABLE_NOOP_ROLLBACK_GUARDS=1` (real actions can stay enabled or be turned off independently), smoke `prepare_commit_confirm` + cancel against `noc`, then revert.
+
 ## Goal
 
 Allow the NOC graph to execute only human-approved remediation plans with automatic rollback protection, full evidence retention, and post-change verification.


### PR DESCRIPTION
## Context

Phase C / step 7 (tracker #225): deploy the no-op rollback guard substrate (hyrule-mcp#20, noc-agent#19) to `noc`.

**Posture decision (preserve real remediation, guards dormant):** real MCP actions are already live in production (`HYRULE_MCP_ENABLE_ACTIONS=1`). noc-agent#19 newly gates execution behind `NOC_ENABLE_APPROVED_EXECUTION` (default off), so this sets it to `1` to keep today's approved-remediation flow working. The no-op rollback guard flags ship **disabled** (opt in later).

## Change

- `host_vars/noc.yml`: `noc_agent_version` → `aab7d42` (#19), `hyrule_mcp_version` → `326bcc8` (#20).
- `noc-agent.env.ctmpl.j2` (the MCP child inherits this env):
  - `NOC_ENABLE_APPROVED_EXECUTION=1` (preserve current behavior under the new gate)
  - `NOC_ENABLE_NOOP_ROLLBACK_GUARDS=0`, `HYRULE_MCP_ENABLE_NOOP_GUARDS=0` (dormant)
  - `HYRULE_MCP_ROLLBACK_GUARD_DIR=/var/lib/hyrule-mcp/rollback`
  - `HYRULE_MCP_ENABLE_ACTIONS=1` unchanged; signing secret already Vault-rendered.
- docs: execution-gating posture + how to smoke the inert no-op path later.

## Safety

- No capability regression: approved remediation keeps working exactly as before.
- No-op guard tools remain **unexposed** (flags off); enabling them is a separate, reversible env flip + smoke.

## Validation

- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/noc.yml --syntax-check` — pass

## Rollout

After merge: `apply.yml playbook=noc limit=noc` dry-run → live (production gate). Verify the new SHAs are deployed and `/opt/noc-agent/.env` carries the flags. (No no-op smoke needed now — guards stay off.)