### PR TITLE
feat(loop): scope loop write access to author the hyrule-cloud launch-proof wedge

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,8 +4,17 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "58735fa051d24290f128109b4267e136316cbc86"
+engineering_loop_version: "d45f89292fe95f2d37de79202782eeb6ea61a1b0"
 engineering_loop_timer_enabled: true
+
+# Dogfood scope: let the loop author the VPS launch-proof wedge in hyrule-cloud
+# (still draft-PR + human-merge gated). All other repos stay docs-only.
+engineering_loop_allowed_paths:
+  hyrule-cloud:
+    - hyrule_cloud
+    - tests
+    - scripts
+    - docs
 
 monitoring_register: true
 monitoring_role: loop

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -65,8 +65,11 @@ engineering_loop_workspace_repositories:
     dest: as215932.net
     version: main
 
-engineering_loop_allowed_paths:
-  - docs
+# Per-repo write-path widening for the daemon (--allow REPO=PATH_PREFIX).
+# Keyed by the loop's sibling checkout name (e.g. hyrule-cloud; network-operations
+# maps to hyrule-infra). Empty by default: the daemon stays docs-only for any
+# repo not listed here. Widen per repo in host_vars when dogfooding code.
+engineering_loop_allowed_paths: {}
 engineering_loop_max_runs_per_day: 2
 engineering_loop_max_cost_usd_per_day: 10
 engineering_loop_timer_enabled: false

--- a/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
+++ b/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
@@ -37,5 +37,10 @@ exec {{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop daemon
     --output-root {{ engineering_loop_runs_dir }} \
     --state-dir-path {{ engineering_loop_daemon_state_dir }} \
     --memory-dir {{ engineering_loop_memory_dir }} \
+{% for repo, prefixes in engineering_loop_allowed_paths.items() -%}
+{% for prefix in prefixes -%}
+    --allow {{ repo }}={{ prefix }} \
+{% endfor -%}
+{% endfor -%}
     --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
     --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}


### PR DESCRIPTION
## Context

Phase D dogfood (tracker #225): let the live Engineering Loop author the VPS launch-proof code in `hyrule-cloud`. Requires engineering-loop#8 (per-repo `--allow`, merged) deployed + a scoped widening.

## Change

- `host_vars/loop.yml`: `engineering_loop_version` → `d45f892` (#8); add `engineering_loop_allowed_paths` for **hyrule-cloud only** (`hyrule_cloud`, `tests`, `scripts`, `docs`).
- `engineering_loop` role: `engineering_loop_allowed_paths` is now a per-repo map (default `{}` = docs-only); `run-daemon.sh.j2` emits `--allow REPO=PREFIX` per entry.

## Safety

- All other repos stay **docs-only** (empty default; only hyrule-cloud widened).
- Unchanged rails: draft-PR only, human merge, gate commands + path/secret policy, eval corpus, 2 runs/day, $10/day.

## Validation

- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/engineering-loop.yml --syntax-check` — pass
- `run-daemon.sh.j2` render sanity — `--allow hyrule-cloud=…` lines correct

## Rollout

After merge: `apply.yml playbook=engineering-loop limit=loop` dry-run → live (production gate). Then I queue the step-8 `loop:approved` launch-proof issue in `hyrule-cloud` and trigger a run to review the loop's first code draft PR.