### PR TITLE
fix: pin loop to full-issue-body backend fix (5f0a84e)

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "d45f89292fe95f2d37de79202782eeb6ea61a1b0"
+engineering_loop_version: "5f0a84e1daa914b8d4498de641e68d3752968057"
 engineering_loop_timer_enabled: true
 
 # Dogfood scope: let the loop author the VPS launch-proof wedge in hyrule-cloud


### PR DESCRIPTION
Pin `loop` to AS215932/engineering-loop@5f0a84e (merged #9 — backend prompt carries the full issue body, not just the truncated title). Unblocks a faithful re-run of the VPS launch-proof dogfood (hyrule-cloud#28).

Validation: `scripts/ci/iac-static.sh`, engineering-loop playbook syntax-check.

Rollout: apply.yml playbook=engineering-loop limit=loop dry-run → live (prod gate) → re-run #28.