### PR TITLE
fix: pin loop to daemon budget-override SHA (768cde6)

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,7 +4,7 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "5f0a84e1daa914b8d4498de641e68d3752968057"
+engineering_loop_version: "768cde6c996e42f3f91d395347ba9809e2e020e5"
 engineering_loop_timer_enabled: true
 
 # Dogfood scope: let the loop author the VPS launch-proof wedge in hyrule-cloud


### PR DESCRIPTION
Pin `loop` to AS215932/engineering-loop@768cde6 (#10 — per-run `--max-iterations`/`--max-wall-clock-minutes` overrides). Enables a one-off 90-min manual run to finish the VPS launch-proof contract (hyrule-cloud#28). Timer keeps the 45-min default.

Validation: `scripts/ci/iac-static.sh`, engineering-loop playbook syntax-check.

Rollout: apply.yml engineering-loop→loop dry-run → live (prod gate) → re-queue #28 → manual 90-min run.