### PR TITLE
feat(loop): widen loop write scope to hyrule-web for launch-proof UI

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -15,6 +15,10 @@ engineering_loop_allowed_paths:
     - tests
     - scripts
     - docs
+  hyrule-web:
+    - frontend
+    - hyrule_web
+    - tests
 
 monitoring_register: true
 monitoring_role: loop


### PR DESCRIPTION
Add `hyrule-web` (frontend, hyrule_web, tests) to `engineering_loop_allowed_paths` so the loop can dogfood the VPS launch-proof status UI (step 9). hyrule-cloud scope unchanged; all other repos stay docs-only; pin unchanged.

Validation: `scripts/ci/iac-static.sh`, engineering-loop syntax-check, run-daemon render shows `--allow` for both repos.

Rollout: apply.yml engineering-loop→loop dry-run → live (gate) → queue the step-9 `loop:approved` issue → 90-min run.