### PR TITLE
feat: VPS launch-proof smoke runbook + script (step 10)

### DIFF
--- a/docs/runbooks/vps-launch-proof-smoke.md
+++ b/docs/runbooks/vps-launch-proof-smoke.md
@@ -1,0 +1,56 @@
+# VPS launch-proof smoke
+
+End-to-end proof of the AS215932 VPS launch-proof wedge: a customer can quote a
+VM, be told payment is required, pay, watch it provision, and reach a working
+box — or get a safe failure with rollback available. This runbook is the
+human procedure; `scripts/smoke/vps-launch-proof.sh` automates the
+no-payment-required checks and the status-contract assertions.
+
+Identities (do not conflate): product = `hyrule.host`, infra = `servify.network`,
+AS/routing = `as215932.net`.
+
+## Preconditions
+
+- The launch-proof contract (`AS215932/hyrule-cloud#29`) is **deployed** to the
+  running cloud app — i.e. `hyrule_cloud_version` in `ansible/inventory/host_vars/`
+  has been **promoted** to a SHA that includes #29 and applied (see Promotion below).
+- A controlled **test order** and **test wallet / payment path** for the paid leg.
+- Default is controlled simulation; real XCP-NG/Openprovider/DNS are opt-in on the
+  cloud side via `HCP_LAUNCH_PROOF_REAL_XCPNG=1`.
+
+## Promotion (deploy #29's contract — do this first)
+
+Use the app-promotion path, never a manual pin edit:
+
+1. `gh workflow run promote-apps.yml -F hyrule_cloud_sha=<#29 merge SHA> -F note="VPS launch-proof contract"`
+2. Review + merge the promotion PR.
+3. `app-promotion-deploy` calls `apply.yml playbook=cloud`; approve the `production` gate.
+4. Record the **rollback SHA** = the `hyrule_cloud_version` *before* this promotion (for the rollback-by-SHA step).
+
+## Smoke sequence
+
+Run `scripts/smoke/vps-launch-proof.sh --base <cloud-api-base>` (it performs 1–2, 5–7
+and prints the launch-proof fields); steps 3–4 and 8–9 are operator-driven.
+
+1. **Quote** — `POST /v1/vm/quote` → `quote_id`, `payment_required`, accepted methods.
+2. **Unpaid create returns 402** — `POST /v1/vm/create` without payment → **HTTP 402** (x402 gate). Proves payment is enforced.
+3. **Paid create** — pay the quote via the test wallet/payment path, then `POST /v1/vm/create` → `vm_id`, `status_url`.
+4. **Poll status to terminal** — `GET /v1/vm/{vm_id}/status` until `provisioned` (happy path) or `failed`. Assert the launch-proof contract fields appear: `payment_status`, `dns_aaaa_verified`, `ssh_smoke_status`, `rollback_available`, `operator_message`, `customer_message`.
+5. **Verify DNS AAAA** — `dig AAAA <fqdn>` resolves to the VM's `ipv6` (or `dns_aaaa_verified: true`).
+6. **Verify SSH** — `ssh_smoke_status: passed` (or a bounded SSH connect to the VM's `ipv6`).
+7. **Record rollback SHA** — capture the pre-promotion `hyrule_cloud_version`.
+8. **Demonstrate rollback-by-SHA** — promote the **previous** `hyrule_cloud_version` via a promotion (rollback) PR + `app-promotion-deploy`; **do not** hand-edit the pin. Confirm the app serves the prior revision.
+9. **Confirm monitoring/support path** — Icinga/Discord reflect the deploy; the customer-facing failure copy points at the support/abuse contact.
+
+## Acceptance
+
+- Quote/create/status reaches `payment_required` then (paid) `provisioned`.
+- A forced failure reaches `failed` with a **customer-safe** message (no XCP-NG IDs / raw operator errors) and `rollback_available`.
+- DNS AAAA + SSH evidence captured; saved smoke output artifact attached to the tracker.
+- Rollback-by-SHA demonstrated via promotion (not a manual pin edit), with the rollback SHA documented.
+- Blocked-port policy and paid-VM cap still enforced.
+
+## Failure handling
+
+If any step regresses customer-facing behavior, roll back by promoting the previous
+`hyrule_cloud_version` (step 8) and stop. Do not leave a half-provisioned paid VM.

--- a/scripts/smoke/vps-launch-proof.sh
+++ b/scripts/smoke/vps-launch-proof.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# VPS launch-proof smoke — exercises the hyrule-cloud launch-proof contract.
+#
+# Automates the no-payment-required checks and the status-contract assertions
+# from docs/runbooks/vps-launch-proof-smoke.md. The paid create + provisioning
+# leg is operator-driven (x402 test wallet); pass --vm-id <id> for an already
+# created VM to assert its launch-proof status fields, DNS AAAA, and SSH.
+#
+# Usage:
+#   scripts/smoke/vps-launch-proof.sh --base https://api.hyrule.host [--vm-id VM] [--quote-file q.json]
+#
+# Requires: curl, jq. Optional: dig, ssh (for steps 5–6).
+set -euo pipefail
+
+BASE=""
+VM_ID=""
+QUOTE_FILE=""
+
+die() { printf 'launch-proof-smoke: %s\n' "$*" >&2; exit 1; }
+note() { printf '\n=== %s ===\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE="${2:-}"; shift 2 ;;
+    --vm-id) VM_ID="${2:-}"; shift 2 ;;
+    --quote-file) QUOTE_FILE="${2:-}"; shift 2 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+done
+
+[ -n "$BASE" ] || die "--base <cloud-api-base> is required"
+command -v curl >/dev/null || die "curl is required"
+command -v jq >/dev/null || die "jq is required"
+BASE="${BASE%/}"
+
+# 1. Quote -----------------------------------------------------------------
+note "1. quote (POST /v1/vm/quote)"
+quote_payload='{"size":"s1","region":"nl1","os":"debian-13"}'
+[ -n "$QUOTE_FILE" ] && quote_payload="$(cat "$QUOTE_FILE")"
+quote_resp="$(curl -fsS -X POST "$BASE/v1/vm/quote" -H 'content-type: application/json' -d "$quote_payload")" \
+  || die "quote request failed (check --quote-file matches the current VMQuoteRequest schema)"
+quote_id="$(printf '%s' "$quote_resp" | jq -r '.quote_id // empty')"
+[ -n "$quote_id" ] || die "no quote_id in quote response: $quote_resp"
+printf 'quote_id=%s status=%s\n' "$quote_id" "$(printf '%s' "$quote_resp" | jq -r '.status // "?"')"
+
+# 2. Unpaid create must be x402-gated -------------------------------------
+note "2. unpaid create returns 402"
+code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/vm/create" \
+  -H 'content-type: application/json' -d "{\"quote_id\":\"$quote_id\"}")"
+[ "$code" = "402" ] || die "expected HTTP 402 for unpaid create, got $code"
+printf 'unpaid create -> HTTP 402 (payment enforced) OK\n'
+
+# 3–4. Paid create + provisioning are operator-driven (x402 test wallet).
+note "3-4. paid create + provisioning"
+printf 'operator step: pay quote %s via the test wallet, POST /v1/vm/create, then re-run with --vm-id <id>\n' "$quote_id"
+
+# 5–6. Status contract + DNS + SSH (when a VM id is supplied) --------------
+if [ -n "$VM_ID" ]; then
+  note "status contract (GET /v1/vm/$VM_ID/status)"
+  status="$(curl -fsS "$BASE/v1/vm/$VM_ID/status")" || die "status request failed for $VM_ID"
+  printf '%s\n' "$status" | jq '{status, payment_status, dns_aaaa_verified, ssh_smoke_status, rollback_available, fqdn, ipv6, customer_message}'
+  for field in status payment_status dns_aaaa_verified ssh_smoke_status rollback_available; do
+    printf '%s' "$status" | jq -e "has(\"$field\")" >/dev/null || die "status missing launch-proof field: $field"
+  done
+  printf 'launch-proof status fields present OK\n'
+
+  fqdn="$(printf '%s' "$status" | jq -r '.fqdn // empty')"
+  ipv6="$(printf '%s' "$status" | jq -r '.ipv6 // empty')"
+  if [ -n "$fqdn" ] && command -v dig >/dev/null; then
+    note "5. DNS AAAA ($fqdn)"
+    dig +short AAAA "$fqdn" || true
+  fi
+  if [ -n "$ipv6" ] && command -v ssh >/dev/null; then
+    note "6. SSH reachability ($ipv6)"
+    ssh -o BatchMode=yes -o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new "root@$ipv6" true \
+      && printf 'SSH connect OK\n' || printf 'SSH not reachable (check ssh_smoke_status above)\n'
+  fi
+else
+  printf '\n(no --vm-id given; skipped status/DNS/SSH. Re-run with --vm-id after a paid create.)\n'
+fi
+
+note "done"


### PR DESCRIPTION
## Context

Phase D / step 10 (tracker #225): the smoke tooling that proves the VPS launch-proof wedge end-to-end, exercising the launch-proof contract merged in hyrule-cloud#29.

## What's here

- **`docs/runbooks/vps-launch-proof-smoke.md`** — operator procedure: promote #29's contract → quote → unpaid-create-**402** → paid create → poll status to `provisioned`/`failed` → verify DNS AAAA + SSH → record rollback SHA → **rollback-by-SHA via promotion** (never a manual pin edit) → monitoring/support. Includes acceptance + failure handling. Identities kept distinct (hyrule.host / servify.network / as215932.net).
- **`scripts/smoke/vps-launch-proof.sh`** — parametric harness: automates quote, the unpaid-create-returns-402 assertion, and the launch-proof status-contract field checks (`payment_status`, `dns_aaaa_verified`, `ssh_smoke_status`, `rollback_available`, …), plus DNS/SSH when `--vm-id` is given. The x402-paid leg is operator-driven (test wallet), per the plan's controlled-test assumption.

## Validation

- `bash -n` clean; `scripts/ci/iac-static.sh` pass.

## Rollout (the live run)

This PR is the tooling. The live proof requires promoting hyrule-cloud#29 to the running cloud app first (promote-apps → app-promotion-deploy), then running the smoke + the rollback-by-SHA demonstration — captured as a saved artifact on #225. Tracked as the step-10 rollout.