### PR TITLE
promote: VPS launch-proof apps (hyrule-cloud#29 + hyrule-web#27)

### DIFF
--- a/ansible/inventory/host_vars/api.yml
+++ b/ansible/inventory/host_vars/api.yml
@@ -1,7 +1,7 @@
 ---
 # api — hyrule-cloud (FastAPI on :8402) + PostgreSQL (localhost) + postgres_exporter.
 
-hyrule_cloud_version: 270b65d764dbab7155fa98f08ab4370f7c605b19
+hyrule_cloud_version: 81e4316f3d1f4e7f770bc2589bd84a2c7972aad5
 hyrule_cloud_monero_wallet_rpc_enabled: true
 
 firewall_extra_rules:

--- a/ansible/inventory/host_vars/web.yml
+++ b/ansible/inventory/host_vars/web.yml
@@ -1,7 +1,7 @@
 ---
 # web — hyrule-web (uvicorn :8080 hyrule.host) + nginx (:8081 as215932.net).
 
-hyrule_web_version: 418cfd6257dd2640e02dca23605f12f0c19caedb
+hyrule_web_version: d94146e67f9eb05f8eeb5c57cab74cbe676f5c79
 
 firewall_extra_rules:
   - { proto: tcp, dport: 8080, src: ["{{ peers.proxy.ipv6 }}", "{{ peers.mon.ipv6 }}"], comment: "hyrule-web upstream from proxy/mon" }


### PR DESCRIPTION
Clean app-pin promotion for the VPS launch-proof wedge, off **current main**.

- `api.yml`: `hyrule_cloud_version` → `81e4316` (launch-proof contract, hyrule-cloud#29)
- `web.yml`: `hyrule_web_version` → `d94146e` (status UI, hyrule-web#27/#28)

**Why not the promote-apps PR (#215):** the rolling `promotion/app-sha-pins` branch is ~20 commits behind main (predates the timer enable, every loop pin #238/#242/#243/#244, the noc deploy #241, allowed-paths #247, the smoke #248). Merging it risks reverting that cutover, so this is a clean two-line promotion instead. **#215 should be closed / the rolling branch reset to main** (filed separately).

## Validation
- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/{cloud,web}.yml --syntax-check` — pass

## Rollout
After merge: `apply.yml playbook=cloud limit=api` then `playbook=web limit=web` (production gate). Then the step-10 smoke runs against the live launch-proof contract; rollback SHA = the pre-promotion `hyrule_cloud_version` (`270b65d`).