### PR TITLE
fix(cloud): temporarily relax PAYMENT_REQUIRE_NATIVE to restore service

### DIFF
--- a/ansible/roles/vault_agent/templates/hyrule-cloud.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/hyrule-cloud.env.ctmpl.j2
@@ -38,7 +38,11 @@ PAYMENT_RECEIVER_ADDRESS={{ .Data.data.payment_wallet }}
 PAYMENT_FACILITATOR_URL=https://x402.org/facilitator
 PAYMENT_NETWORK=eip155:8453
 PAYMENT_ASSET=USDC
-PAYMENT_REQUIRE_NATIVE=true
+# TEMPORARY: set to false to restore service while the Monero wallet-rpc
+# bootstrap is broken (invalid wallet password + ringdb permission denied on
+# /home/hyrule/.shared-ringdb). XMR native payment is unavailable until then;
+# BTC + x402 USDC still work. Restore to true once monero-wallet-rpc is healthy.
+PAYMENT_REQUIRE_NATIVE=false
 PAYMENT_BTC_XPUB={{ .Data.data.btc_xpub }}
 PAYMENT_XMR_VIEWKEY={{ .Data.data.xmr_viewkey }}
 PAYMENT_XMR_RPC_URL={{ or .Data.data.xmr_rpc_url "http://127.0.0.1:18088/json_rpc" }}


### PR DESCRIPTION
## Incident

`cloud.hyrule.host` is **down (502)**. hyrule-cloud's startup guard (`PAYMENT_REQUIRE_NATIVE=true` requires BTC **and** XMR ready) refuses to boot because **monero-wallet-rpc won't start**:
- view-key secret was missing → fixed by operator (now a real key);
- but it now fails on **invalid wallet password** + **ringdb permission denied** (`/home/hyrule/.shared-ringdb`).

**Not caused by the launch-proof promotion** — `git diff 270b65d 81e4316 -- hyrule_cloud/app.py` is empty; the deploy restart merely exposed a pre-existing Monero bootstrap break.

## Change (temporary)

`hyrule-cloud.env.ctmpl.j2`: `PAYMENT_REQUIRE_NATIVE=true` → `false`, so the app boots without requiring native XMR. **BTC + x402 USDC still work; native XMR payment temporarily unavailable.** Clearly commented as temporary; revert to `true` once monero-wallet-rpc is healthy.

## Validation
- `scripts/ci/iac-static.sh` — pass
- `ansible-playbook playbooks/cloud.yml --syntax-check` — pass

## Rollout
After merge: `apply.yml playbook=cloud limit=api` (production gate) → re-renders env + restarts → health check passes → cloud restored.

Follow-up: fix monero-wallet-rpc (wallet password mismatch + ringdb perms), then restore `PAYMENT_REQUIRE_NATIVE=true` (tracked separately).