### PR TITLE
Enable the proactive NOC loop on noc

### DIFF
--- a/ansible/roles/noc_agent/tasks/main.yml
+++ b/ansible/roles/noc_agent/tasks/main.yml
@@ -131,6 +131,8 @@
   loop:
     - "{{ noc_agent_install_dir }}"
     - "{{ noc_agent_state_dir }}"
+    - "{{ noc_agent_state_dir }}/proactive"
+    - "{{ noc_agent_state_dir }}/memory"
   tags: [apply]
 
 - name: Ensure noc-agent root-owned config/runtime dirs exist

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -21,6 +21,7 @@ MAIL_IMAP_PASSWORD={{ .Data.data.mail_imap_password }}
 XO_TOKEN={{ .Data.data.xo_token }}
 ICINGA_API_USER={{ .Data.data.icinga_api_user }}
 ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
+NOC_GITHUB_TOKEN={{ or .Data.data.noc_github_token "" }}
 {{- end }}{% endraw %}
 
 AGENT_MODEL={{ noc_agent_model | default('openrouter:deepseek/deepseek-v4-pro') }}
@@ -66,3 +67,25 @@ HYRULE_MCP_ACTION_SIGNING_SECRET={{ .Data.data.noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ or .Data.data.noc_action_allowed_hosts "noc,mon,cr1-nl1,cr1-de1" }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ or .Data.data.noc_action_allowed_services "node_exporter,noc-agent,noc-agent-bot,hyrule-mcp" }}
 {{- end }}{% endraw %}
+
+# --- Proactive NOC loop (active operator) ---
+# ENABLED, autonomous (shadow off). Read-only, human-gated, never mutates
+# infrastructure. The budgets below are the live safety rails. To canary, set
+# NOC_PROACTIVE_SHADOW=1; to pause, set NOC_PROACTIVE_ENABLED=0 (or POST
+# /control/proactive/pause). See the noc-agent README "Proactive loop" section.
+NOC_PROACTIVE_ENABLED=1
+NOC_PROACTIVE_SHADOW=0
+NOC_PROACTIVE_INTERVAL_S=120
+NOC_PROACTIVE_DEEP_SCAN_S=900
+NOC_PROACTIVE_MAX_INVESTIGATIONS_PER_CYCLE=1
+NOC_PROACTIVE_MAX_INVESTIGATIONS_PER_DAY=12
+NOC_PROACTIVE_MAX_COST_USD_PER_DAY=10
+NOC_PROACTIVE_AUTO_HEAVY_PROBES=0
+# Handoff opens loop:candidate issues; no-op until noc_github_token is in kv/noc-agent.
+NOC_PROACTIVE_HANDOFF_ENABLED=1
+NOC_PROACTIVE_HANDOFF_REPO=AS215932/network-operations
+NOC_PROACTIVE_SEVERITY_FLOOR=MEDIUM
+# Optional Icinga passive heartbeat. Leave URL empty to disable; when set, add a
+# matching passive Service "proactive-loop" on the noc host (reuses ICINGA_API_*).
+NOC_PROACTIVE_ICINGA_URL=
+NOC_PROACTIVE_ICINGA_CHECK=noc!proactive-loop

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -75,3 +75,24 @@ HYRULE_MCP_ENABLE_ACTIONS=1
 HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}
+
+# --- Proactive NOC loop (active operator) ---
+# ENABLED, autonomous (shadow off). Read-only, human-gated. Budgets are the live
+# safety rails. To canary set NOC_PROACTIVE_SHADOW=1; to pause set
+# NOC_PROACTIVE_ENABLED=0. See the noc-agent README.
+NOC_PROACTIVE_ENABLED=1
+NOC_PROACTIVE_SHADOW=0
+NOC_PROACTIVE_INTERVAL_S=120
+NOC_PROACTIVE_DEEP_SCAN_S=900
+NOC_PROACTIVE_MAX_INVESTIGATIONS_PER_CYCLE=1
+NOC_PROACTIVE_MAX_INVESTIGATIONS_PER_DAY=12
+NOC_PROACTIVE_MAX_COST_USD_PER_DAY=10
+NOC_PROACTIVE_AUTO_HEAVY_PROBES=0
+NOC_PROACTIVE_HANDOFF_ENABLED=1
+NOC_PROACTIVE_HANDOFF_REPO=AS215932/network-operations
+NOC_PROACTIVE_SEVERITY_FLOOR=MEDIUM
+# Issues-scoped token for the loop:candidate handoff (only needed when handoff is on).
+NOC_GITHUB_TOKEN={{ noc_github_token | default('') }}
+# Optional Icinga passive heartbeat (leave URL empty to disable).
+NOC_PROACTIVE_ICINGA_URL=
+NOC_PROACTIVE_ICINGA_CHECK=noc!proactive-loop

--- a/docs/autonomous-noc.md
+++ b/docs/autonomous-noc.md
@@ -124,6 +124,21 @@ per-cycle/per-day investigation + cost budgets. Memory (lessons / proposals /
 journal / observations) lives under `/var/lib/noc-agent/memory`; humans merge
 proposals into `lessons/`.
 
+### Activation sequence
+
+These env flags are **inert until `noc-agent` is promoted to a build that
+contains the proactive loop**. The production app version is the pinned
+`noc_agent_version` in `host_vars/noc.yml`; until that pin advances to a SHA
+with `app/proactive/`, `apply.yml` renders the new `NOC_PROACTIVE_*` vars but
+keeps running the old agent, so nothing starts. Correct order:
+
+1. Merge `noc-agent#20`.
+2. Promote `noc-agent` (the `promote-apps` flow bumps `noc_agent_version`).
+3. Merge this PR and run `apply.yml playbook=noc` (human `production` gate) — the
+   loop now starts with these flags.
+
+Merging this PR on its own is therefore safe: it cannot start the loop early.
+
 ### Deployed state and safety rails
 
 The loop ships **enabled and autonomous** (`noc-agent.env.ctmpl.j2`):

--- a/docs/autonomous-noc.md
+++ b/docs/autonomous-noc.md
@@ -102,3 +102,55 @@ uv run --group dev python -m pytest -q
 ```
 
 Live smoke suites exist but are explicitly opt-in and read-only.
+
+## Proactive operations loop
+
+The reactive path above waits for an alert. `noc-agent` also ships an **active
+operator loop** (`app/proactive/`) that continuously sweeps Prometheus/Icinga
+for precursors and investigates the worst ones *before* a tripwire hardens. It
+is **read-only**, budgeted, human-gated, and **off by default**.
+
+Lifecycle per cycle: scan (cheap PromQL/Icinga) → rank → snapshot a decision
+context → gate against the daily ledger and severity floor → (non-shadow)
+render the top hotspot as a synthetic alert and run the *existing* investigation
+graph with heavy probes stripped → Discord digest (+ optional Icinga heartbeat)
+→ open an idempotent `loop:candidate` issue when a config change is warranted →
+record the prediction and, on deep cycles, evaluate prior predictions against
+real alerts and propose candidate lessons.
+
+Governance mirrors the engineering-loop: a per-day ledger
+(`/var/lib/noc-agent/proactive/ledger-<date>.json`), a singleton run-lock, and
+per-cycle/per-day investigation + cost budgets. Memory (lessons / proposals /
+journal / observations) lives under `/var/lib/noc-agent/memory`; humans merge
+proposals into `lessons/`.
+
+### Deployed state and safety rails
+
+The loop ships **enabled and autonomous** (`noc-agent.env.ctmpl.j2`):
+`NOC_PROACTIVE_ENABLED=1`, `NOC_PROACTIVE_SHADOW=0`, `NOC_PROACTIVE_HANDOFF_ENABLED=1`.
+The standing safety rails are the budgets, which stay conservative:
+
+- 1 investigation per cycle, 12 per day, $10/day, `MEDIUM` severity floor;
+- heavy read-only probes (`tcpdump_capture`, `dns_probe_burst`,
+  `multi_source_probe`) are **proposed, not auto-run** (`NOC_PROACTIVE_AUTO_HEAVY_PROBES=0`);
+- nothing mutates infrastructure — the loop reports and hands off only.
+
+Handoff (`loop:candidate` issues) is a no-op until an issues-scoped
+`NOC_GITHUB_TOKEN` exists in `kv/noc-agent` as `noc_github_token`; once present
+the loop opens/refreshes candidate issues for findings that warrant a change.
+
+To **canary cheaply**, set `NOC_PROACTIVE_SHADOW=1` (scan-and-report only) and
+re-apply; flip back to `0` once the scanners look right. To **pause**, set
+`NOC_PROACTIVE_ENABLED=0` and re-apply, or `POST /control/proactive/pause`.
+Operators can also drive a single cycle or inspect status via the loopback
+control API: `GET /control/proactive/status`, `POST /control/proactive/run-once`,
+`POST /control/proactive/pause|resume` (all require `X-NOC-Control-Token`).
+All flag changes deploy via promotion + `apply.yml playbook=noc` (human
+`production` gate).
+
+### Optional Icinga heartbeat
+
+To alert if the loop stops, set `NOC_PROACTIVE_ICINGA_URL` to the Icinga API
+base and add a **passive** Service `proactive-loop` on the `noc` host (in
+`host_vars/noc.yml :: monitoring_extra_services`, with `enable_active_checks`
+false and a freshness threshold). Left unset, the loop posts no passive result.

--- a/scripts/vault-put-noc-agent-secrets.sh
+++ b/scripts/vault-put-noc-agent-secrets.sh
@@ -38,6 +38,7 @@ vault_args=(
   discord_allowed_role_ids="${NOC_DISCORD_ALLOWED_ROLE_IDS:-}" \
   noc_control_token="${NOC_CONTROL_TOKEN:-}" \
   noc_approval_signing_secret="${NOC_APPROVAL_SIGNING_SECRET}" \
+  noc_github_token="${NOC_GITHUB_TOKEN:-}" \
   mail_imap_password="${MAIL_NOC_PASSWORD}" \
   xo_token="${XO_TOKEN}" \
   icinga_api_user="${ICINGA_API_USER}" \


### PR DESCRIPTION
## What

Deploy wiring that **enables** the noc-agent active operator loop on `noc` (companion to AS215932/noc-agent#20).

- **Env templates** (Vault `noc-agent.env.ctmpl.j2` + env-backend `noc-agent.env.j2`): add the `NOC_PROACTIVE_*` block, shipped **enabled and autonomous** — `NOC_PROACTIVE_ENABLED=1`, `NOC_PROACTIVE_SHADOW=0`, `NOC_PROACTIVE_HANDOFF_ENABLED=1` — plus an issues-scoped `NOC_GITHUB_TOKEN` (handoff is a no-op until `noc_github_token` is added to `kv/noc-agent`).
- **`noc_agent` role**: create `/var/lib/noc-agent/{proactive,memory}` (ledger + lessons/journal).
- **`docs/autonomous-noc.md`**: proactive lifecycle, deployed state, and the canary/pause levers.

## Safety

The loop is **read-only** — it reports and hands off; it never mutates infrastructure. Standing rails (the budgets) stay conservative: 1 investigation/cycle, 12/day, \$10/day, `MEDIUM` severity floor, heavy probes proposed not auto-run, per-day ledger + run-lock.

Levers: `NOC_PROACTIVE_SHADOW=1` to canary (scan-and-report only), `NOC_PROACTIVE_ENABLED=0` (or `POST /control/proactive/pause`) to stop. All flag changes deploy via promotion + `apply.yml playbook=noc` behind the human `production` gate.

Validated: `scripts/ci/iac-static.sh` exit 0; `ansible-playbook playbooks/noc.yml --syntax-check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)