### PR TITLE
Render GitHub App credentials for proactive handoff

### DIFF
--- a/ansible/roles/vault_agent/defaults/main.yml
+++ b/ansible/roles/vault_agent/defaults/main.yml
@@ -21,6 +21,7 @@ vault_agent_token_sink_mode: "0600"
 vault_agent_template_dir: "{{ vault_agent_config_dir }}/templates"
 vault_agent_env_destination: /opt/noc-agent/.env
 vault_agent_google_subject_token_destination: /run/noc-agent/google-subject.jwt
+vault_agent_noc_github_app_key_destination: /etc/noc-agent/github-app.pem
 # Backward-compat alias: callers that set vault_agent_reload_command still work —
 # both per-template commands fall back to it. New callers should set the
 # per-template variant directly.
@@ -55,6 +56,12 @@ vault_agent_templates:
     destination: "{{ vault_agent_google_subject_token_destination }}"
     group: noc-agent
     # /bin/true by default — JWT re-renders must not bounce the consumer (#26).
+    reload_command: "{{ vault_agent_jwt_reload_command }}"
+  - src: noc-agent-github-app-key.pem.ctmpl.j2
+    name: noc-agent-github-app-key.pem.ctmpl
+    destination: "{{ vault_agent_noc_github_app_key_destination }}"
+    group: noc-agent
+    # noc-agent reads the PEM per handoff, so a re-render must not bounce it.
     reload_command: "{{ vault_agent_jwt_reload_command }}"
 
 # Extra directories the consumer needs created beyond the Vault Agent

--- a/ansible/roles/vault_agent/templates/noc-agent-github-app-key.pem.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent-github-app-key.pem.ctmpl.j2
@@ -1,0 +1,5 @@
+{% raw %}{{- with secret "kv/data/noc-agent" -}}
+{{- if .Data.data.noc_github_app_private_key -}}
+{{ .Data.data.noc_github_app_private_key }}
+{{- end -}}
+{{- end -}}{% endraw %}

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -22,7 +22,10 @@ XO_TOKEN={{ .Data.data.xo_token }}
 ICINGA_API_USER={{ .Data.data.icinga_api_user }}
 ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
 NOC_GITHUB_TOKEN={{ or .Data.data.noc_github_token "" }}
+NOC_GITHUB_APP_ID={{ or .Data.data.noc_github_app_id "" }}
 {{- end }}{% endraw %}
+# Vault Agent renders the App private key to this file (see vault_agent_templates).
+NOC_GITHUB_APP_PRIVATE_KEY_PATH=/etc/noc-agent/github-app.pem
 
 AGENT_MODEL={{ noc_agent_model | default('openrouter:deepseek/deepseek-v4-pro') }}
 AGENT_FALLBACK_MODELS={{ noc_agent_fallback_models | default('openrouter:anthropic/claude-sonnet-4.6') }}

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -91,6 +91,9 @@ NOC_PROACTIVE_AUTO_HEAVY_PROBES=0
 NOC_PROACTIVE_HANDOFF_ENABLED=1
 NOC_PROACTIVE_HANDOFF_REPO=AS215932/network-operations
 NOC_PROACTIVE_SEVERITY_FLOOR=MEDIUM
+# Handoff auth: GitHub App preferred (App id + PEM path), PAT as fallback.
+NOC_GITHUB_APP_ID={{ noc_github_app_id | default('') }}
+NOC_GITHUB_APP_PRIVATE_KEY_PATH={{ noc_github_app_private_key_path | default('/etc/noc-agent/github-app.pem') }}
 # Issues-scoped token for the loop:candidate handoff (only needed when handoff is on).
 NOC_GITHUB_TOKEN={{ noc_github_token | default('') }}
 # Optional Icinga passive heartbeat (leave URL empty to disable).

--- a/docs/autonomous-noc.md
+++ b/docs/autonomous-noc.md
@@ -150,9 +150,15 @@ The standing safety rails are the budgets, which stay conservative:
   `multi_source_probe`) are **proposed, not auto-run** (`NOC_PROACTIVE_AUTO_HEAVY_PROBES=0`);
 - nothing mutates infrastructure — the loop reports and hands off only.
 
-Handoff (`loop:candidate` issues) is a no-op until an issues-scoped
-`NOC_GITHUB_TOKEN` exists in `kv/noc-agent` as `noc_github_token`; once present
-the loop opens/refreshes candidate issues for findings that warrant a change.
+Handoff (`loop:candidate` issues) is a no-op until GitHub auth is present in
+`kv/noc-agent`. Preferred is an org-owned **GitHub App** (Issues: RW + Metadata:
+R on `network-operations`): store `noc_github_app_id` and the PEM as
+`noc_github_app_private_key`. Vault Agent renders the key to
+`/etc/noc-agent/github-app.pem` and the app mints short-lived installation
+tokens at call time. A fine-grained PAT in `noc_github_token` works as a
+fallback. Keep these in `secrets.local.sh` (`NOC_GITHUB_APP_ID`,
+`NOC_GITHUB_APP_PRIVATE_KEY_FILE`) so `vault-put-noc-agent-secrets.sh` rotations
+don't drop them.
 
 To **canary cheaply**, set `NOC_PROACTIVE_SHADOW=1` (scan-and-report only) and
 re-apply; flip back to `0` once the scanners look right. To **pause**, set

--- a/scripts/vault-put-noc-agent-secrets.sh
+++ b/scripts/vault-put-noc-agent-secrets.sh
@@ -53,6 +53,19 @@ if [ -n "${NOC_ACTION_ALLOWED_SERVICES:-}" ]; then
   vault_args+=(noc_action_allowed_services="${NOC_ACTION_ALLOWED_SERVICES}")
 fi
 
+# Proactive-loop handoff via GitHub App. NOTE: `vault kv put` replaces the whole
+# secret, so set these (e.g. in secrets.local.sh) or a rotation will DROP the
+# app credentials and handoff reverts to a no-op:
+#   NOC_GITHUB_APP_ID            numeric App ID
+#   NOC_GITHUB_APP_PRIVATE_KEY_FILE  path to the App's .pem
+if [ -n "${NOC_GITHUB_APP_ID:-}" ]; then
+  vault_args+=(noc_github_app_id="${NOC_GITHUB_APP_ID}")
+fi
+
+if [ -n "${NOC_GITHUB_APP_PRIVATE_KEY_FILE:-}" ]; then
+  vault_args+=(noc_github_app_private_key=@"${NOC_GITHUB_APP_PRIVATE_KEY_FILE}")
+fi
+
 vault kv put kv/noc-agent "${vault_args[@]}"
 
 echo "Wrote kv/noc-agent."


### PR DESCRIPTION
## What
Companion to AS215932/noc-agent#21. Provisions the loop's handoff auth as an org-owned **GitHub App** (App `4071799`) instead of a static PAT.

- **Vault Agent** renders the App private key (`kv/noc-agent:noc_github_app_private_key`) to `/etc/noc-agent/github-app.pem` via a new `vault_agent_templates` entry — mirrors the existing `engineering-loop-github-app-key.pem` pattern, with a no-bounce reload (noc-agent reads the PEM per handoff).
- **noc-agent `.env`** (both the Vault `.ctmpl` and the env-backend template) render `NOC_GITHUB_APP_ID` + `NOC_GITHUB_APP_PRIVATE_KEY_PATH`. `NOC_GITHUB_TOKEN` stays as a PAT fallback.
- **Rotation script** preserves `noc_github_app_id` + `noc_github_app_private_key` (from `NOC_GITHUB_APP_PRIVATE_KEY_FILE`) so `vault kv put` won't drop them.
- **Docs** updated: App-based handoff auth, PAT fallback, rotation note.

The App credentials are already in `kv/noc-agent` (`noc_github_app_id`, `noc_github_app_private_key`); this PR just renders them onto `noc` on the next `apply.yml playbook=noc`.

Validated: `iac-static.sh` exit 0, `ansible-playbook playbooks/noc.yml --syntax-check` exit 0, `bash -n` on the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)