### PR TITLE
Fix NOC_GITHUB_APP_ID gluing in rendered noc-agent .env

### DIFF
--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -24,7 +24,10 @@ ICINGA_API_PASSWORD={{ .Data.data.icinga_api_password }}
 NOC_GITHUB_TOKEN={{ or .Data.data.noc_github_token "" }}
 NOC_GITHUB_APP_ID={{ or .Data.data.noc_github_app_id "" }}
 {{- end }}{% endraw %}
-# Vault Agent renders the App private key to this file (see vault_agent_templates).
+
+# NOTE: the blank line above is required. Ansible trim_blocks drops the newline
+# after the Vault secret block, so without it the rendered .env glues this line
+# onto NOC_GITHUB_APP_ID (e.g. NOC_GITHUB_APP_ID=4071799# ...).
 NOC_GITHUB_APP_PRIVATE_KEY_PATH=/etc/noc-agent/github-app.pem
 
 AGENT_MODEL={{ noc_agent_model | default('openrouter:deepseek/deepseek-v4-pro') }}


### PR DESCRIPTION
## Why
On `noc` the rendered `/opt/noc-agent/.env` came out as:
```
NOC_GITHUB_APP_ID=4071799# Vault Agent renders the App private key to this file (see vault_agent_templates).
```
Ansible `trim_blocks` drops the newline after the `{% endraw %}` that closes the Vault secret block, so the next line got concatenated onto the app id — corrupting `NOC_GITHUB_APP_ID` and breaking the App's JWT auth for handoff.

## Fix
Add the blank line after the secret block (the same spacing `AGENT_MODEL` already relies on) so the app id stays on its own line. Verified by rendering the template through Jinja2 (`trim_blocks=True`) and emulating consul-template's `{{- end }}` trim — `NOC_GITHUB_APP_ID=4071799` now renders on its own line.

iac-static passes. Applies on the next `apply.yml playbook=noc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)