### PR TITLE
Expose NOC Agent dashboard via Caddy (noc.servify.network)

### DIFF
--- a/ansible/generated/noc/nftables.conf
+++ b/ansible/generated/noc/nftables.conf
@@ -37,6 +37,7 @@ table inet filter {
 
         # Per-host service allowances.
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 8000 counter accept comment "noc-agent webhook from mon (Alertmanager + Icinga)"
+        ip6 saddr 2a0c:b641:b50:2::40 tcp dport 8000 counter accept comment "noc-agent control dashboard via Caddy (proxy)"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
 
 

--- a/ansible/inventory/host_vars/noc.yml
+++ b/ansible/inventory/host_vars/noc.yml
@@ -17,6 +17,9 @@ firewall_extra_rules:
   # Webhooks from Alertmanager + Icinga2 on mon.
   - { proto: tcp, dport: 8000, src: "{{ peers.mon.ipv6 }}", comment: "noc-agent webhook from mon (Alertmanager + Icinga)" }
 
+  # Operator dashboard via Caddy on proxy (noc.servify.network -> /control + /health).
+  - { proto: tcp, dport: 8000, src: "{{ peers.proxy.ipv6 }}", comment: "noc-agent control dashboard via Caddy (proxy)" }
+
   # Monitoring scrapes.
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }
 

--- a/configs/Caddyfile.j2
+++ b/configs/Caddyfile.j2
@@ -195,6 +195,50 @@ as215932.net, www.as215932.net {
     }
 }
 
+# NOC Agent operator dashboard — noc.servify.network
+# Only the token-gated operator surfaces are exposed (the control dashboard,
+# health, metrics). Webhooks, the approval callback, and mail polling stay
+# internal-only (reachable from mon directly), so they are NOT proxied here.
+noc.servify.network {
+    tls {
+        dns rfc2136 {
+            server [2a0c:b641:b50:2::10]:53
+            key_name hyrule-dns.
+            key_alg hmac-sha256
+            key {{ tsig_secret }}
+        }
+        propagation_delay 60s
+    }
+
+    @ops path /control /control/* /health /health/* /metrics
+    handle @ops {
+        reverse_proxy [{{ peers.noc.ipv6 }}]:8000 {
+            transport http {
+                dial_timeout 3s
+                response_header_timeout 8s
+                read_timeout 30s
+                write_timeout 30s
+                keepalive 30s
+                keepalive_idle_conns 10
+            }
+        }
+    }
+    handle {
+        respond "Not found" 404
+    }
+
+    header {
+        X-Forwarded-Proto https
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+    }
+
+    log {
+        output file /var/log/caddy/noc.log
+    }
+}
+
 # Xen Orchestra — xo.servify.network
 xo.servify.network {
     tls {

--- a/configs/servify.network.zone
+++ b/configs/servify.network.zone
@@ -5,7 +5,7 @@ $ORIGIN servify.network.
 $TTL 3600
 
 @       IN  SOA   ns1.servify.network. admin.servify.network. (
-                  2026061401 ; serial (YYYYMMDDNN)
+                  2026061701 ; serial (YYYYMMDDNN)
                   3600       ; refresh (1h)
                   900        ; retry (15m)
                   604800     ; expire (7d)
@@ -52,6 +52,10 @@ grafana IN  A     46.105.40.223
 grafana IN  AAAA  2a0c:b641:b50:2::40
 mon     IN  A     46.105.40.223
 mon     IN  AAAA  2a0c:b641:b50:2::40
+
+; NOC Agent operator dashboard — via Caddy reverse proxy on proxy VM
+noc     IN  A     46.105.40.223
+noc     IN  AAAA  2a0c:b641:b50:2::40
 
 ; Core routers — underlay addresses (reachable from public internet)
 cr1-nl1 IN  A     194.28.98.69


### PR DESCRIPTION
Makes the proactive ack dashboard (AS215932/noc-agent#26) reachable from the proxy.

- **Caddy:** `noc.servify.network` → `[noc]:8000`, scoped by a path matcher to **only** `/control*`, `/health*`, `/metrics`. Webhooks (`/webhook/*`), the approval callback (`/approval/resume`), and `/mail/poll` are **not** proxied — they stay internal (reachable from mon directly); everything else → 404. Adds HSTS / nosniff / `X-Frame-Options: DENY`.
- **DNS:** `noc.servify.network` A/AAAA → proxy (`::40`); SOA serial bumped (`named-checkzone` loads `2026061701`).
- **Firewall:** allow proxy (`::40`) → `noc:8000` (was mon-only).

## Auth / security
The `/control` endpoints are gated by `NOC_CONTROL_TOKEN` (now set in Vault); the path scoping is defence-in-depth so only the operator surfaces are public. If you want stronger edge auth I can add Caddy `basic_auth` or restrict to the VPN — say the word.

Validated: `iac-static.sh` exit 0; zone check OK. Deploys via promotion/apply to **dns** (zone), **proxy** (Caddy), **noc** (firewall). Pair with #26 (dashboard panel) on noc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)