### PR TITLE
feat(noc): enable autonomous Icinga acknowledgement (take-ownership + non-urgent snooze)

### DIFF
--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -74,6 +74,17 @@ HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ or .Data.data.noc_action_allowed_hosts "noc,m
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ or .Data.data.noc_action_allowed_services "node_exporter,noc-agent,noc-agent-bot,hyrule-mcp" }}
 {{- end }}{% endraw %}
 
+# --- Autonomous Icinga acknowledgement (hyrule-mcp #21 + noc-agent #30) ---
+# Acking is reversible + expiring, so it uses its own broad allowlist (default
+# '*'), kept separate from the narrow restart allowlist above.
+HYRULE_MCP_ACK_ALLOWED_HOSTS=*
+HYRULE_MCP_ACK_ALLOWED_SERVICES=*
+# Take-ownership: when an Icinga-sourced alert starts an investigation, ack the
+# problem so it stops re-paging humans. notify off; auto-expires after the TTL so
+# an unresolved investigation re-surfaces.
+NOC_AUTO_ACK_ON_INVESTIGATION=1
+NOC_AUTO_ACK_TTL_S=7200
+
 # --- Proactive NOC loop (active operator) ---
 # ENABLED, autonomous (shadow off). Read-only, human-gated, never mutates
 # infrastructure. The budgets below are the live safety rails. To canary, set
@@ -91,6 +102,13 @@ NOC_PROACTIVE_AUTO_HEAVY_PROBES=0
 NOC_PROACTIVE_HANDOFF_ENABLED=1
 NOC_PROACTIVE_HANDOFF_REPO=AS215932/network-operations
 NOC_PROACTIVE_SEVERITY_FLOOR=MEDIUM
+# Autonomously snooze non-urgent (LOW, not warrants_change) findings: mute from
+# the digest for the TTL + best-effort ack the matching Icinga WARNING problem
+# (expiring). HIGH/MEDIUM/CRITICAL/config-change always stay surfaced.
+NOC_PROACTIVE_AUTO_SNOOZE_ENABLED=1
+NOC_PROACTIVE_AUTO_SNOOZE_TTL_S=86400
+NOC_PROACTIVE_AUTO_SNOOZE_MAX_PER_CYCLE=3
+NOC_PROACTIVE_AUTO_SNOOZE_ICINGA_ACK=1
 # Optional Icinga passive heartbeat. Leave URL empty to disable; when set, add a
 # matching passive Service "proactive-loop" on the noc host (reuses ICINGA_API_*).
 NOC_PROACTIVE_ICINGA_URL=

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -76,6 +76,16 @@ HYRULE_MCP_ACTION_SIGNING_SECRET={{ noc_approval_signing_secret }}
 HYRULE_MCP_ACTION_ALLOWED_HOSTS={{ noc_action_allowed_hosts | default('noc,mon,cr1-nl1,cr1-de1') }}
 HYRULE_MCP_ACTION_ALLOWED_SERVICES={{ noc_action_allowed_services | default('node_exporter,noc-agent,noc-agent-bot,hyrule-mcp') }}
 
+# --- Autonomous Icinga acknowledgement (hyrule-mcp #21 + noc-agent #30) ---
+# Acking is reversible + expiring → its own broad allowlist (default '*'),
+# separate from the narrow restart allowlist above.
+HYRULE_MCP_ACK_ALLOWED_HOSTS=*
+HYRULE_MCP_ACK_ALLOWED_SERVICES=*
+# Take-ownership ack when an Icinga-sourced alert starts an investigation
+# (notify off; auto-expires after the TTL).
+NOC_AUTO_ACK_ON_INVESTIGATION=1
+NOC_AUTO_ACK_TTL_S=7200
+
 # --- Proactive NOC loop (active operator) ---
 # ENABLED, autonomous (shadow off). Read-only, human-gated. Budgets are the live
 # safety rails. To canary set NOC_PROACTIVE_SHADOW=1; to pause set
@@ -91,6 +101,13 @@ NOC_PROACTIVE_AUTO_HEAVY_PROBES=0
 NOC_PROACTIVE_HANDOFF_ENABLED=1
 NOC_PROACTIVE_HANDOFF_REPO=AS215932/network-operations
 NOC_PROACTIVE_SEVERITY_FLOOR=MEDIUM
+# Autonomously snooze non-urgent (LOW, not warrants_change) findings: mute from
+# the digest for the TTL + best-effort ack the matching Icinga WARNING problem.
+# HIGH/MEDIUM/CRITICAL/config-change always stay surfaced.
+NOC_PROACTIVE_AUTO_SNOOZE_ENABLED=1
+NOC_PROACTIVE_AUTO_SNOOZE_TTL_S=86400
+NOC_PROACTIVE_AUTO_SNOOZE_MAX_PER_CYCLE=3
+NOC_PROACTIVE_AUTO_SNOOZE_ICINGA_ACK=1
 # Handoff auth: GitHub App preferred (App id + PEM path), PAT as fallback.
 NOC_GITHUB_APP_ID={{ noc_github_app_id | default('') }}
 NOC_GITHUB_APP_PRIVATE_KEY_PATH={{ noc_github_app_private_key_path | default('/etc/noc-agent/github-app.pem') }}


### PR DESCRIPTION
Turns on the autonomous-ack behaviours now that **hyrule-mcp #21** (deployed) and **noc-agent #30** are in. Env-flag only — no code, no topology.

Adds to `noc-agent.env` (both the vault-agent ctmpl and the configs reference):

- `NOC_AUTO_ACK_ON_INVESTIGATION=1` + `NOC_AUTO_ACK_TTL_S=7200` — **take-ownership**: when an Icinga-sourced alert starts an investigation, ack the problem (notify off; auto-expires in 2h so an unresolved one re-surfaces).
- `NOC_PROACTIVE_AUTO_SNOOZE_ENABLED=1` (+ `_TTL_S=86400`, `_MAX_PER_CYCLE=3`, `_ICINGA_ACK=1`) — **non-urgent auto-snooze**: mute LOW / non-`warrants_change` findings for 24h + best-effort expiring ack of the matching Icinga WARNING. HIGH/MEDIUM/CRITICAL/config-change always stay surfaced.
- `HYRULE_MCP_ACK_ALLOWED_HOSTS/SERVICES=*` (explicit) — broad **ack** allowlist, separate from the narrow **restart** allowlist (unchanged). `HYRULE_MCP_ENABLE_ACTIONS` was already 1.

Everything is reversible: acks expire, snoozes are TTL'd, operator can un-snooze. Deploys via `apply playbook=noc` alongside the noc-agent #30 promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)