### PR TITLE
Deploy Knowledge MCP on loop VM

### DIFF
--- a/ansible/generated/loop/icinga_host.conf
+++ b/ansible/generated/loop/icinga_host.conf
@@ -28,3 +28,13 @@ object Service "engineering-loop-timer" {
   vars.systemd_unit = "hyrule-engineering-loop.timer"
 }
 
+object Service "knowledge-mcp-service" {
+  host_name = "loop"
+  check_command = "prom_systemd_unit"
+  check_interval = 2m
+  retry_interval = 1m
+  notes = "Knowledge MCP container service is active on loopback for Engineering Loop context"
+  vars.prom_instance = "[2a0c:b641:b50:2::f0]:9100"
+  vars.systemd_unit = "hyrule-knowledge-mcp.service"
+}
+

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,12 +4,12 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "7378306dca8e562f7774f6efa2f28894846585de"
+engineering_loop_version: "34dd5e82c02b577a51d4f477b0bb50b716a5492f"
 engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: "8e97e89cca80a8e65030fb3c259acfd0f732aa06"
+knowledge_mcp_version: "ec09b7df21f9c08d155d5b4d63b3dba21d976e93"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -4,12 +4,12 @@
 # not a deploy source for the infra fleet: no fleet SSH key, no production
 # Vault breadth, and no public listener beyond node_exporter for mon.
 
-engineering_loop_version: "768cde6c996e42f3f91d395347ba9809e2e020e5"
+engineering_loop_version: "7378306dca8e562f7774f6efa2f28894846585de"
 engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: main
+knowledge_mcp_version: "8e97e89cca80a8e65030fb3c259acfd0f732aa06"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -7,6 +7,14 @@
 engineering_loop_version: "768cde6c996e42f3f91d395347ba9809e2e020e5"
 engineering_loop_timer_enabled: true
 
+# Local read-only knowledge MCP server for Engineering Loop context. It is
+# deployed as a Docker container and bound to host loopback only.
+knowledge_mcp_version: main
+knowledge_mcp_enabled: true
+knowledge_mcp_host: 127.0.0.1
+knowledge_mcp_port: 8767
+knowledge_mcp_transport: streamable-http
+
 # Dogfood scope: let the loop author the VPS launch-proof wedge in hyrule-cloud
 # (still draft-PR + human-merge gated). All other repos stay docs-only.
 engineering_loop_allowed_paths:
@@ -37,6 +45,14 @@ monitoring_extra_services:
     vars:
       prom_instance: "[{{ peers.loop.ipv6 }}]:9100"
       systemd_unit: hyrule-engineering-loop.timer
+  - name: knowledge-mcp-service
+    check_command: prom_systemd_unit
+    interval: 2m
+    retry: 1m
+    notes: "Knowledge MCP container service is active on loopback for Engineering Loop context"
+    vars:
+      prom_instance: "[{{ peers.loop.ipv6 }}]:9100"
+      systemd_unit: hyrule-knowledge-mcp.service
 
 firewall_extra_rules:
   # node_exporter scrape from mon only.

--- a/ansible/playbooks/engineering-loop.yml
+++ b/ansible/playbooks/engineering-loop.yml
@@ -9,7 +9,7 @@
 #
 # Apply (live deploy, timer remains disabled by default):
 #   ansible-playbook playbooks/engineering-loop.yml --tags apply \
-#     -e engineering_loop_apply=true --limit loop
+#     -e engineering_loop_apply=true -e knowledge_mcp_apply=true --limit loop
 #
 # First bootstrap with Vault Agent requires either:
 #   VAULT_ENGINEERING_LOOP_ROLE_ID=...
@@ -47,6 +47,8 @@
       tags: [logs]
     - role: engineering_loop
       tags: [engineering_loop]
+    - role: knowledge_mcp
+      tags: [knowledge_mcp]
     - role: vault_agent
       vars:
         vault_agent_name: engineering-loop

--- a/ansible/roles/engineering_loop/defaults/main.yml
+++ b/ansible/roles/engineering_loop/defaults/main.yml
@@ -75,6 +75,12 @@ engineering_loop_max_cost_usd_per_day: 10
 engineering_loop_timer_enabled: false
 engineering_loop_memory_dir: "{{ engineering_loop_state_dir }}/memory"
 engineering_loop_legacy_memory_dir: "{{ engineering_loop_workspace_dir }}/hyrule-infra/memory"
+engineering_loop_knowledge_context_enabled: true
+engineering_loop_knowledge_mcp_url: http://127.0.0.1:8767/mcp
+engineering_loop_knowledge_mcp_transport: streamable-http
+engineering_loop_knowledge_context_budget: 6000
+engineering_loop_knowledge_context_timeout: 20
+engineering_loop_knowledge_learning_dir: ""
 
 engineering_loop_git_user_name: "hyrule-engineering-loop[bot]"
 engineering_loop_git_user_email: "engineering-loop@as215932.net"

--- a/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
+++ b/ansible/roles/engineering_loop/templates/run-daemon.sh.j2
@@ -29,18 +29,40 @@ else
   fatal "no GitHub authentication configured; set GitHub App credentials or a break-glass token"
 fi
 
-exec {{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop daemon --once \
+loop_bin="{{ engineering_loop_install_dir }}/.venv/bin/hyrule-engineering-loop"
+
+set -- daemon --once
 {% for repo in engineering_loop_repos -%}
-    --repo {{ repo }} \
+set -- "$@" --repo {{ repo }}
 {% endfor -%}
-    --workspace-root {{ engineering_loop_workspace_dir }} \
-    --output-root {{ engineering_loop_runs_dir }} \
-    --state-dir-path {{ engineering_loop_daemon_state_dir }} \
-    --memory-dir {{ engineering_loop_memory_dir }} \
+set -- "$@" \
+  --workspace-root {{ engineering_loop_workspace_dir }} \
+  --output-root {{ engineering_loop_runs_dir }} \
+  --state-dir-path {{ engineering_loop_daemon_state_dir }} \
+  --memory-dir {{ engineering_loop_memory_dir }}
 {% for repo, prefixes in engineering_loop_allowed_paths.items() -%}
 {% for prefix in prefixes -%}
-    --allow {{ repo }}={{ prefix }} \
+set -- "$@" --allow {{ repo }}={{ prefix }}
 {% endfor -%}
 {% endfor -%}
-    --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
-    --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}
+set -- "$@" \
+  --max-runs-per-day {{ engineering_loop_max_runs_per_day }} \
+  --max-cost-usd-per-day {{ engineering_loop_max_cost_usd_per_day }}
+
+{% if engineering_loop_knowledge_context_enabled | bool -%}
+if "$loop_bin" daemon --help 2>/dev/null | grep -q -- '--knowledge-mcp-url'; then
+  set -- "$@" \
+    --knowledge-context \
+    --knowledge-mcp-url {{ engineering_loop_knowledge_mcp_url }} \
+    --knowledge-mcp-transport {{ engineering_loop_knowledge_mcp_transport }} \
+    --knowledge-context-budget {{ engineering_loop_knowledge_context_budget }} \
+    --knowledge-context-timeout {{ engineering_loop_knowledge_context_timeout }}
+{% if engineering_loop_knowledge_learning_dir | length > 0 %}
+  set -- "$@" --knowledge-learning-dir {{ engineering_loop_knowledge_learning_dir }}
+{% endif %}
+else
+  printf '%s\n' "engineering-loop: installed CLI lacks --knowledge-mcp-url; running without knowledge MCP context" >&2
+fi
+{% endif -%}
+
+exec "$loop_bin" "$@"

--- a/ansible/roles/knowledge_mcp/defaults/main.yml
+++ b/ansible/roles/knowledge_mcp/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# Containerized AS215932 knowledge MCP server on the dedicated loop VM.
+# Default is validate/render only; live mutation requires
+# -e knowledge_mcp_apply=true from the engineering-loop playbook.
+
+knowledge_mcp_apply: false
+knowledge_mcp_enabled: true
+
+knowledge_mcp_user: loop
+knowledge_mcp_group: loop
+knowledge_mcp_install_dir: /opt/knowledge
+knowledge_mcp_state_dir: /var/lib/knowledge-mcp
+knowledge_mcp_repo: https://github.com/AS215932/knowledge.git
+# Use a commit SHA for production promotion; `main` keeps first bootstrap usable
+# after the Dockerfile lands.
+knowledge_mcp_version: main
+
+knowledge_mcp_container_name: hyrule-knowledge-mcp
+knowledge_mcp_image_repository: as215932/knowledge-mcp
+knowledge_mcp_image_tag: "{{ knowledge_mcp_version | regex_replace('[^A-Za-z0-9_.-]', '-') }}"
+knowledge_mcp_image: "{{ knowledge_mcp_image_repository }}:{{ knowledge_mcp_image_tag }}"
+knowledge_mcp_host: 127.0.0.1
+knowledge_mcp_port: 8767
+knowledge_mcp_transport: streamable-http
+knowledge_mcp_mcp_path: /mcp
+knowledge_mcp_sse_path: /sse
+knowledge_mcp_message_path: /messages/
+knowledge_mcp_mount_path: /
+knowledge_mcp_log_level: INFO
+knowledge_mcp_memory: 512m
+knowledge_mcp_pids_limit: 256
+
+knowledge_mcp_packages:
+  - docker.io
+  - git
+  - ca-certificates
+  - curl

--- a/ansible/roles/knowledge_mcp/defaults/main.yml
+++ b/ansible/roles/knowledge_mcp/defaults/main.yml
@@ -11,9 +11,8 @@ knowledge_mcp_group: loop
 knowledge_mcp_install_dir: /opt/knowledge
 knowledge_mcp_state_dir: /var/lib/knowledge-mcp
 knowledge_mcp_repo: https://github.com/AS215932/knowledge.git
-# Use a commit SHA for production promotion; `main` keeps first bootstrap usable
-# after the Dockerfile lands.
-knowledge_mcp_version: main
+# Pinned AS215932/knowledge commit containing the Dockerfile and MCP HTTP health checks.
+knowledge_mcp_version: 8e97e89cca80a8e65030fb3c259acfd0f732aa06
 
 knowledge_mcp_container_name: hyrule-knowledge-mcp
 knowledge_mcp_image_repository: as215932/knowledge-mcp

--- a/ansible/roles/knowledge_mcp/defaults/main.yml
+++ b/ansible/roles/knowledge_mcp/defaults/main.yml
@@ -11,8 +11,8 @@ knowledge_mcp_group: loop
 knowledge_mcp_install_dir: /opt/knowledge
 knowledge_mcp_state_dir: /var/lib/knowledge-mcp
 knowledge_mcp_repo: https://github.com/AS215932/knowledge.git
-# Pinned AS215932/knowledge commit containing the Dockerfile and MCP HTTP health checks.
-knowledge_mcp_version: 8e97e89cca80a8e65030fb3c259acfd0f732aa06
+# Pinned AS215932/knowledge merge commit containing the Dockerfile and MCP HTTP health checks.
+knowledge_mcp_version: ec09b7df21f9c08d155d5b4d63b3dba21d976e93
 
 knowledge_mcp_container_name: hyrule-knowledge-mcp
 knowledge_mcp_image_repository: as215932/knowledge-mcp

--- a/ansible/roles/knowledge_mcp/handlers/main.yml
+++ b/ansible/roles/knowledge_mcp/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart knowledge-mcp
+  ansible.builtin.systemd:
+    name: hyrule-knowledge-mcp.service
+    state: restarted
+    daemon_reload: true
+  when: knowledge_mcp_enabled | bool

--- a/ansible/roles/knowledge_mcp/meta/main.yml
+++ b/ansible/roles/knowledge_mcp/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  role_name: knowledge_mcp
+  author: AS215932
+  description: Containerized AS215932 knowledge MCP server
+  license: private
+  min_ansible_version: "2.15"
+dependencies: []

--- a/ansible/roles/knowledge_mcp/tasks/apply.yml
+++ b/ansible/roles/knowledge_mcp/tasks/apply.yml
@@ -1,0 +1,86 @@
+---
+- name: Ensure Knowledge MCP packages are installed
+  ansible.builtin.apt:
+    name: "{{ knowledge_mcp_packages }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Ensure Docker is enabled for Knowledge MCP
+  ansible.builtin.systemd:
+    name: docker
+    enabled: true
+    state: started
+
+- name: Ensure Knowledge MCP group exists
+  ansible.builtin.group:
+    name: "{{ knowledge_mcp_group }}"
+    state: present
+    system: true
+
+- name: Ensure Knowledge MCP user exists
+  ansible.builtin.user:
+    name: "{{ knowledge_mcp_user }}"
+    group: "{{ knowledge_mcp_group }}"
+    home: "{{ knowledge_mcp_state_dir }}"
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+
+- name: Ensure Knowledge MCP directories exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner | default(knowledge_mcp_user) }}"
+    group: "{{ item.group | default(knowledge_mcp_group) }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ knowledge_mcp_install_dir }}", mode: "0755" }
+    - { path: "{{ knowledge_mcp_state_dir }}", mode: "0750" }
+
+- name: Checkout Knowledge MCP source
+  ansible.builtin.git:
+    repo: "{{ knowledge_mcp_repo }}"
+    dest: "{{ knowledge_mcp_install_dir }}"
+    version: "{{ knowledge_mcp_version }}"
+    update: true
+    force: true
+  become: true
+  become_user: "{{ knowledge_mcp_user }}"
+  notify: restart knowledge-mcp
+
+- name: Build Knowledge MCP container image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - build
+      - --pull
+      - -t
+      - "{{ knowledge_mcp_image }}"
+      - .
+  args:
+    chdir: "{{ knowledge_mcp_install_dir }}"
+  register: knowledge_mcp_docker_build
+  changed_when: >-
+    'Successfully built' in knowledge_mcp_docker_build.stdout or
+    'Successfully tagged' in knowledge_mcp_docker_build.stdout or
+    'writing image' in knowledge_mcp_docker_build.stderr
+  notify: restart knowledge-mcp
+
+- name: Install Knowledge MCP systemd service
+  ansible.builtin.template:
+    src: hyrule-knowledge-mcp.service.j2
+    dest: /etc/systemd/system/hyrule-knowledge-mcp.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart knowledge-mcp
+
+- name: Set Knowledge MCP service state
+  ansible.builtin.systemd:
+    name: hyrule-knowledge-mcp.service
+    enabled: "{{ knowledge_mcp_enabled | bool }}"
+    state: "{{ 'started' if knowledge_mcp_enabled | bool else 'stopped' }}"
+    daemon_reload: true

--- a/ansible/roles/knowledge_mcp/tasks/apply.yml
+++ b/ansible/roles/knowledge_mcp/tasks/apply.yml
@@ -44,27 +44,39 @@
     dest: "{{ knowledge_mcp_install_dir }}"
     version: "{{ knowledge_mcp_version }}"
     update: true
-    force: true
+    force: false
   become: true
   become_user: "{{ knowledge_mcp_user }}"
   notify: restart knowledge-mcp
+
+- name: Inspect existing Knowledge MCP container image revision
+  ansible.builtin.command:
+    argv:
+      - docker
+      - image
+      - inspect
+      - "{{ knowledge_mcp_image }}"
+      - --format
+      - "{{ '{{' }} index .Config.Labels \"org.opencontainers.image.revision\" {{ '}}' }}"
+  register: knowledge_mcp_image_revision
+  failed_when: false
+  changed_when: false
 
 - name: Build Knowledge MCP container image
   ansible.builtin.command:
     argv:
       - docker
       - build
-      - --pull
       - -t
       - "{{ knowledge_mcp_image }}"
+      - --label
+      - "org.opencontainers.image.revision={{ knowledge_mcp_version }}"
       - .
   args:
     chdir: "{{ knowledge_mcp_install_dir }}"
   register: knowledge_mcp_docker_build
-  changed_when: >-
-    'Successfully built' in knowledge_mcp_docker_build.stdout or
-    'Successfully tagged' in knowledge_mcp_docker_build.stdout or
-    'writing image' in knowledge_mcp_docker_build.stderr
+  changed_when: true
+  when: knowledge_mcp_image_revision.stdout | trim != knowledge_mcp_version
   notify: restart knowledge-mcp
 
 - name: Install Knowledge MCP systemd service

--- a/ansible/roles/knowledge_mcp/tasks/main.yml
+++ b/ansible/roles/knowledge_mcp/tasks/main.yml
@@ -7,7 +7,7 @@
       - knowledge_mcp_install_dir.startswith('/')
       - knowledge_mcp_state_dir.startswith('/')
       - knowledge_mcp_transport in ['streamable-http', 'sse']
-      - knowledge_mcp_host in ['127.0.0.1', '::1']
+      - knowledge_mcp_host == '127.0.0.1'
       - knowledge_mcp_port | int > 1024
       - knowledge_mcp_port | int < 65536
     fail_msg: >-

--- a/ansible/roles/knowledge_mcp/tasks/main.yml
+++ b/ansible/roles/knowledge_mcp/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Validate Knowledge MCP deployment inputs
+  ansible.builtin.assert:
+    that:
+      - knowledge_mcp_user | length > 0
+      - knowledge_mcp_group | length > 0
+      - knowledge_mcp_install_dir.startswith('/')
+      - knowledge_mcp_state_dir.startswith('/')
+      - knowledge_mcp_transport in ['streamable-http', 'sse']
+      - knowledge_mcp_host in ['127.0.0.1', '::1']
+      - knowledge_mcp_port | int > 1024
+      - knowledge_mcp_port | int < 65536
+    fail_msg: >-
+      Knowledge MCP must remain a local loopback read-only service on the
+      dedicated loop VM unless a later PR explicitly widens the exposure.
+  tags: [validate, always]
+
+- name: Apply Knowledge MCP runtime
+  ansible.builtin.import_tasks: apply.yml
+  when: knowledge_mcp_apply | bool
+  tags: [apply]

--- a/ansible/roles/knowledge_mcp/templates/hyrule-knowledge-mcp.service.j2
+++ b/ansible/roles/knowledge_mcp/templates/hyrule-knowledge-mcp.service.j2
@@ -17,16 +17,17 @@ ExecStart=/usr/bin/docker run \
     --name {{ knowledge_mcp_container_name }} \
     --rm \
     --pull=never \
+    --network=host \
+    --user=65534:65534 \
     --read-only \
     --cap-drop=ALL \
     --security-opt no-new-privileges \
     --pids-limit={{ knowledge_mcp_pids_limit }} \
     --memory={{ knowledge_mcp_memory }} \
-    --tmpfs /tmp:rw,noexec,nosuid,size=64m \
-    -p {{ knowledge_mcp_host }}:{{ knowledge_mcp_port }}:8767 \
+    --tmpfs /tmp:rw,noexec,nosuid,size=64m,mode=1777 \
     -e HYRULE_KNOWLEDGE_MCP_TRANSPORT={{ knowledge_mcp_transport }} \
-    -e HYRULE_KNOWLEDGE_MCP_BIND=0.0.0.0 \
-    -e HYRULE_KNOWLEDGE_MCP_PORT=8767 \
+    -e HYRULE_KNOWLEDGE_MCP_BIND={{ knowledge_mcp_host }} \
+    -e HYRULE_KNOWLEDGE_MCP_PORT={{ knowledge_mcp_port }} \
     -e HYRULE_KNOWLEDGE_MCP_PATH={{ knowledge_mcp_mcp_path }} \
     -e HYRULE_KNOWLEDGE_MCP_SSE_PATH={{ knowledge_mcp_sse_path }} \
     -e HYRULE_KNOWLEDGE_MCP_MESSAGE_PATH={{ knowledge_mcp_message_path }} \

--- a/ansible/roles/knowledge_mcp/templates/hyrule-knowledge-mcp.service.j2
+++ b/ansible/roles/knowledge_mcp/templates/hyrule-knowledge-mcp.service.j2
@@ -1,0 +1,52 @@
+# /etc/systemd/system/hyrule-knowledge-mcp.service
+# Managed by ansible/roles/knowledge_mcp. Read-only MCP server for the
+# AS215932 knowledge SQLite export. Bound to loopback on the dedicated loop VM.
+
+[Unit]
+Description=AS215932 Knowledge MCP server (containerized)
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+ConditionEnvironment=!GITHUB_ACTIONS
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5s
+ExecStartPre=-/usr/bin/docker rm -f {{ knowledge_mcp_container_name }}
+ExecStart=/usr/bin/docker run \
+    --name {{ knowledge_mcp_container_name }} \
+    --rm \
+    --pull=never \
+    --read-only \
+    --cap-drop=ALL \
+    --security-opt no-new-privileges \
+    --pids-limit={{ knowledge_mcp_pids_limit }} \
+    --memory={{ knowledge_mcp_memory }} \
+    --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+    -p {{ knowledge_mcp_host }}:{{ knowledge_mcp_port }}:8767 \
+    -e HYRULE_KNOWLEDGE_MCP_TRANSPORT={{ knowledge_mcp_transport }} \
+    -e HYRULE_KNOWLEDGE_MCP_BIND=0.0.0.0 \
+    -e HYRULE_KNOWLEDGE_MCP_PORT=8767 \
+    -e HYRULE_KNOWLEDGE_MCP_PATH={{ knowledge_mcp_mcp_path }} \
+    -e HYRULE_KNOWLEDGE_MCP_SSE_PATH={{ knowledge_mcp_sse_path }} \
+    -e HYRULE_KNOWLEDGE_MCP_MESSAGE_PATH={{ knowledge_mcp_message_path }} \
+    -e HYRULE_KNOWLEDGE_MCP_MOUNT_PATH={{ knowledge_mcp_mount_path }} \
+    -e HYRULE_KNOWLEDGE_MCP_LOG_LEVEL={{ knowledge_mcp_log_level }} \
+    {{ knowledge_mcp_image }}
+ExecStop=/usr/bin/docker stop {{ knowledge_mcp_container_name }}
+TimeoutStopSec=20
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=knowledge-mcp
+
+# Keep the daemon as a read-only loopback dependency of the Engineering Loop.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/run /var/run {{ knowledge_mcp_state_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -207,7 +207,9 @@ SSRF/IP policy.
 Dedicated Engineering Loop operations-lane VM. It consumes human-approved
 `loop:approved` GitHub issues and stops at draft PRs. It is not an infra deploy
 source: no fleet SSH key, no app runtime secrets, no Vault breadth, and no public
-listener beyond node_exporter for mon.
+listener beyond node_exporter for mon. A containerized `hyrule-knowledge-mcp`
+service binds to `127.0.0.1:8767` only, exposing streamable HTTP MCP at `/mcp`,
+legacy SSE at `/sse` when configured, and `/health` for local smoke checks.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
@@ -215,10 +217,12 @@ listener beyond node_exporter for mon.
 | ops-prefix, vpn-clients, ci, noc, mon | TCP | 22 | SSH (standard infra-host access set for operator/bootstrap, CI apply, and diagnostics) |
 
 Outbound (cross-cutting): loop → github.com TCP/443 (issues, checkouts, branch
-pushes, draft PRs), loop → model provider APIs TCP/443 (through the selected
-backend/provider auth), loop → mon TCP/5665 (Icinga passive check submission),
-loop → log TCP/6000 (Vector agent), loop → vault TCP/8200 (Vault Agent render).
-It does **not** SSH to the infra fleet.
+pushes, draft PRs, and knowledge MCP image source checkouts/build context),
+loop → model provider APIs TCP/443 (through the selected backend/provider auth),
+loop → mon TCP/5665 (Icinga passive check submission), loop → log TCP/6000
+(Vector agent), loop → vault TCP/8200 (Vault Agent render), loop → container
+base-image registries TCP/443 during knowledge MCP Docker image builds. It does
+**not** SSH to the infra fleet.
 
 ### ci-pr (`2a0c:b641:b51::c1`) — unprivileged PR runner, customer-isolated
 


### PR DESCRIPTION
## Summary
- add a `knowledge_mcp` Ansible role for a containerized read-only Knowledge MCP service on `loop`
- bind Knowledge MCP to loopback only at `127.0.0.1:8767`, with streamable HTTP at `/mcp`
- wire the Engineering Loop daemon wrapper to use the loopback Knowledge MCP endpoint when supported
- add systemd monitoring for `hyrule-knowledge-mcp.service`
- document the loop VM local MCP/network-flow shape

## Validation
- `ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook -i ansible/inventory/hosts.yml ansible/playbooks/engineering-loop.yml --tags validate --connection=local --limit loop --skip-tags snapshot -e engineering_loop_apply=false -e knowledge_mcp_apply=false`
- `scripts/ci/iac-static.sh`

## Follow-up before production apply
After the dependent PRs merge, pin:
- `knowledge_mcp_version` to the merge SHA from AS215932/knowledge
- `engineering_loop_version` to the merge SHA from AS215932/engineering-loop
