### PR TITLE
Route loop Docker bridge over IPv6

### DIFF
--- a/ansible/generated/loop/nftables.conf
+++ b/ansible/generated/loop/nftables.conf
@@ -47,6 +47,10 @@ table inet filter {
         type filter hook forward priority filter; policy drop;
         ct state established,related accept
         ct state invalid drop
+
+        # --- raw forward escape hatch ---
+        iifname docker0 ip6 saddr 2a0c:b641:b50:f0::/64 counter accept comment "loop Docker IPv6 egress"
+
     }
 
     chain output {

--- a/ansible/generated/rtr/nftables.conf
+++ b/ansible/generated/rtr/nftables.conf
@@ -96,8 +96,8 @@ table inet filter {
         ip saddr 77.166.211.126/32 tcp dport 22 counter accept comment "ssh from 77.166.211.126/32"
 
         # Per-host service allowances.
-        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2001:41d0:303:48a::2 } tcp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
-        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2001:41d0:303:48a::2 } udp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
+        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2a0c:b641:b50:f0::/64, 2001:41d0:303:48a::2 } tcp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
+        ip6 saddr { 2a0c:b641:b50:2::/64, 2a0c:b641:b51::/48, 2a0c:b641:b50:3::/64, 2a0c:b641:b50:f0::/64, 2001:41d0:303:48a::2 } udp dport 53 counter accept comment "DNS recursion from overlay + rtr's own (underlay src, VRF)"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9100 counter accept comment "node_exporter scrape"
         ip6 saddr 2a0c:b641:b50:2::50 tcp dport 9342 counter accept comment "frr_exporter scrape"
         ip6 saddr { 2a0c:b641:b50::a, 2a0c:b641:b50::b, 2a0c:b641:b50::c } tcp dport 179 counter accept comment "iBGP from cr1-* loopbacks"

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -7,6 +7,8 @@
 as215932_prefix: "2a0c:b641:b50::/44"
 infra_subnet: "2a0c:b641:b50:2::/64"
 vpn_clients_subnet: "2a0c:b641:b50:3::/64"
+# Routed GUA /64 for Docker bridge containers on the loop VM.
+loop_docker_subnet: "2a0c:b641:b50:f0::/64"
 customer_subnet: "2a0c:b641:b51::/48"
 wg_link_prefix: "2a0c:b641:b50:ff00::/56"  # all wg /127s sit under this
 router_loopback_subnet: "2a0c:b641:b50::/64"

--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -14,6 +14,12 @@ knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767
 knowledge_mcp_transport: streamable-http
+# Docker uses routed IPv6 for egress: containers receive GUA addresses from
+# this /64, and rtr has a static/iBGP return route via loop's infra address.
+knowledge_mcp_docker_ipv6_enabled: true
+knowledge_mcp_docker_fixed_cidr_v6: "{{ loop_docker_subnet }}"
+knowledge_mcp_docker_dns:
+  - "{{ peers.rtr.ipv6 }}"
 
 # Dogfood scope: let the loop author the VPS launch-proof wedge in hyrule-cloud
 # (still draft-PR + human-merge gated). All other repos stay docs-only.
@@ -57,6 +63,9 @@ monitoring_extra_services:
 firewall_extra_rules:
   # node_exporter scrape from mon only.
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }
+
+firewall_forward_extra_raw_nft: |
+  iifname docker0 ip6 saddr {{ loop_docker_subnet }} counter accept comment "loop Docker IPv6 egress"
 
 # --- Logs --- (ships journald to log VM via Vector)
 logs_register: true

--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -36,7 +36,7 @@ firewall_extra_rules:
   # default-VRF processes (apt, curl, unbound-anchor) therefore query the
   # overlay Unbound with rtr's underlay source — allow it so rtr can resolve.
   # See issue #135. (Goes away with the OpenBSD/rdomain migration, #14.)
-  - { proto: tcp+udp, dport: 53, src: ["{{ infra_subnet }}", "{{ customer_subnet }}", "{{ vpn_clients_subnet }}", "{{ peers.rtr.underlay }}"], comment: "DNS recursion from overlay + rtr's own (underlay src, VRF)" }
+  - { proto: tcp+udp, dport: 53, src: ["{{ infra_subnet }}", "{{ customer_subnet }}", "{{ vpn_clients_subnet }}", "{{ loop_docker_subnet }}", "{{ peers.rtr.underlay }}"], comment: "DNS recursion from overlay + rtr's own (underlay src, VRF)" }
 
   # Monitoring scrapes from mon.
   - { proto: tcp, dport: 9100, src: "{{ peers.mon.ipv6 }}", comment: "node_exporter scrape" }

--- a/ansible/roles/knowledge_mcp/defaults/main.yml
+++ b/ansible/roles/knowledge_mcp/defaults/main.yml
@@ -29,6 +29,15 @@ knowledge_mcp_log_level: INFO
 knowledge_mcp_memory: 512m
 knowledge_mcp_pids_limit: 256
 
+# Optional routed-GUA IPv6 Docker bridge support. This keeps Docker usable on
+# IPv6-only hosts without falling back to IPv4-only public resolvers or IPv4
+# masquerade.
+knowledge_mcp_docker_ipv6_enabled: false
+knowledge_mcp_docker_fixed_cidr_v6: ""
+knowledge_mcp_docker_dns: []
+knowledge_mcp_docker_daemon_config: /etc/docker/daemon.json
+knowledge_mcp_docker_sysctl_file: /etc/sysctl.d/99-knowledge-mcp-docker.conf
+
 knowledge_mcp_packages:
   - docker.io
   - git

--- a/ansible/roles/knowledge_mcp/tasks/apply.yml
+++ b/ansible/roles/knowledge_mcp/tasks/apply.yml
@@ -67,6 +67,7 @@
     argv:
       - docker
       - build
+      - --network=host
       - -t
       - "{{ knowledge_mcp_image }}"
       - --label

--- a/ansible/roles/knowledge_mcp/tasks/apply.yml
+++ b/ansible/roles/knowledge_mcp/tasks/apply.yml
@@ -6,6 +6,46 @@
     update_cache: true
     cache_valid_time: 3600
 
+- name: Ensure Docker config directory exists
+  ansible.builtin.file:
+    path: "{{ knowledge_mcp_docker_daemon_config | dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: knowledge_mcp_docker_ipv6_enabled | bool
+
+- name: Install Docker daemon routed IPv6 config for Knowledge MCP
+  ansible.builtin.template:
+    src: docker-daemon.json.j2
+    dest: "{{ knowledge_mcp_docker_daemon_config }}"
+    owner: root
+    group: root
+    mode: "0644"
+  register: knowledge_mcp_docker_daemon_config_result
+  when: knowledge_mcp_docker_ipv6_enabled | bool
+
+- name: Enable IPv6 forwarding for Knowledge MCP Docker routed subnet
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: "1"
+    sysctl_file: "{{ knowledge_mcp_docker_sysctl_file }}"
+    state: present
+    reload: true
+  register: knowledge_mcp_docker_ipv6_forwarding
+  when: knowledge_mcp_docker_ipv6_enabled | bool
+
+- name: Restart Docker to apply Knowledge MCP routed IPv6 config
+  ansible.builtin.systemd:
+    name: docker
+    enabled: true
+    state: restarted
+  when:
+    - knowledge_mcp_docker_ipv6_enabled | bool
+    - >-
+      knowledge_mcp_docker_daemon_config_result.changed | default(false) or
+      knowledge_mcp_docker_ipv6_forwarding.changed | default(false)
+
 - name: Ensure Docker is enabled for Knowledge MCP
   ansible.builtin.systemd:
     name: docker
@@ -67,7 +107,6 @@
     argv:
       - docker
       - build
-      - --network=host
       - -t
       - "{{ knowledge_mcp_image }}"
       - --label

--- a/ansible/roles/knowledge_mcp/tasks/main.yml
+++ b/ansible/roles/knowledge_mcp/tasks/main.yml
@@ -10,6 +10,7 @@
       - knowledge_mcp_host == '127.0.0.1'
       - knowledge_mcp_port | int > 1024
       - knowledge_mcp_port | int < 65536
+      - not (knowledge_mcp_docker_ipv6_enabled | bool) or knowledge_mcp_docker_fixed_cidr_v6 | length > 0
     fail_msg: >-
       Knowledge MCP must remain a local loopback read-only service on the
       dedicated loop VM unless a later PR explicitly widens the exposure.

--- a/ansible/roles/knowledge_mcp/templates/docker-daemon.json.j2
+++ b/ansible/roles/knowledge_mcp/templates/docker-daemon.json.j2
@@ -1,0 +1,15 @@
+{% set docker_daemon_config = {} %}
+{% if knowledge_mcp_docker_ipv6_enabled | bool %}
+{% set _ = docker_daemon_config.update({
+  "ipv6": true,
+  "fixed-cidr-v6": knowledge_mcp_docker_fixed_cidr_v6,
+  "ip6tables": false,
+  "ip-masq": false
+}) %}
+{% endif %}
+{% if knowledge_mcp_docker_dns | length > 0 %}
+{% set _ = docker_daemon_config.update({
+  "dns": knowledge_mcp_docker_dns
+}) %}
+{% endif %}
+{{ docker_daemon_config | to_nice_json }}

--- a/configs/rtr/frr.conf
+++ b/configs/rtr/frr.conf
@@ -13,6 +13,8 @@ vrf overlay
  ipv6 route 2a0c:b641:b50::/44 blackhole
  ! VPN client subnet → vpn VM
  ipv6 route 2a0c:b641:b50:3::/64 2a0c:b641:b50:2::60
+ ! loop Docker container subnet
+ ipv6 route 2a0c:b641:b50:f0::/64 2a0c:b641:b50:2::f0
  ! ci-pr Docker container subnet
  ipv6 route 2a0c:b641:b51:c1::/64 2a0c:b641:b51::c1
 exit-vrf
@@ -72,6 +74,7 @@ router bgp 215932 vrf overlay
   network 2a0c:b641:b50::/44
   network 2a0c:b641:b50:2::/64
   network 2a0c:b641:b50:3::/64
+  network 2a0c:b641:b50:f0::/64
   network 2a0c:b641:b51::/48
   ! iBGP peers — no transit filters
   neighbor 2a0c:b641:b50::a activate

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -49,6 +49,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 | `2a0c:b641:b50::/64` | Router loopbacks (`::a` cr1-nl1, `::b` cr1-de1, `::c` cr1-ch1, `::d` rtr) |
 | `2a0c:b641:b50:2::/64` | Infra subnet (rtr `::1`, VMs `::10`–`::f0`) |
 | `2a0c:b641:b50:3::/64` | VPN clients (routed via vpn VM) |
+| `2a0c:b641:b50:f0::/64` | loop VM Docker bridge containers (routed GUA /64 via loop) |
 | `2a0c:b641:b50:ffXX::/127` | WireGuard tunnel /127s (mesh links) |
 | `2a0c:b641:b51::/48` | Customer VM allocations (also `::c1` = ci-pr, the unprivileged PR runner) |
 | `10.0.0.0/24` | Mgmt v4 (dom0 ↔ XOA XAPI) |
@@ -63,7 +64,7 @@ dom0 is an XCP-NG hypervisor on the underlay only, not in this map.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|
-| infra subnet, customer subnet, vpn-clients | TCP/UDP | 53 | DNS recursion (Unbound + DNS64) |
+| infra subnet, customer subnet, vpn-clients, loop Docker subnet | TCP/UDP | 53 | DNS recursion (Unbound + DNS64) |
 | rtr underlay (`2001:41d0:303:48a::2`) | TCP/UDP | 53 | rtr's **own** DNS queries to its Unbound — Unbound is overlay-VRF-confined so rtr's default-VRF processes query it with the underlay source (#135) |
 | mon | TCP | 9100 | node_exporter scrape |
 | mon | TCP | 9342 | frr_exporter scrape |
@@ -220,9 +221,10 @@ Outbound (cross-cutting): loop → github.com TCP/443 (issues, checkouts, branch
 pushes, draft PRs, and knowledge MCP image source checkouts/build context),
 loop → model provider APIs TCP/443 (through the selected backend/provider auth),
 loop → mon TCP/5665 (Icinga passive check submission), loop → log TCP/6000
-(Vector agent), loop → vault TCP/8200 (Vault Agent render), loop → container
-base-image registries TCP/443 during knowledge MCP Docker image builds. It does
-**not** SSH to the infra fleet.
+(Vector agent), loop → vault TCP/8200 (Vault Agent render). Docker bridge
+containers receive routed GUA addresses from `2a0c:b641:b50:f0::/64`, query
+rtr Unbound over IPv6, and use routed IPv6 egress for container base-image and
+package downloads. loop does **not** SSH to the infra fleet.
 
 ### ci-pr (`2a0c:b641:b51::c1`) — unprivileged PR runner, customer-isolated
 


### PR DESCRIPTION
## Summary
- replace the temporary `docker build --network=host` workaround with routed-GUA IPv6 Docker bridge support on `loop`
- allocate `2a0c:b641:b50:f0::/64` for loop Docker containers
- configure Docker with IPv6, rtr Unbound as IPv6 DNS, no IPv6 iptables automation, and no IPv4 masquerade
- add loop firewall forwarding and rtr DNS/firewall + FRR static/iBGP return route for the Docker /64
- document the loop Docker subnet and flows

## Live validation
- applied rtr FRR and firewall changes
- applied loop firewall and Knowledge MCP Docker config
- `docker network inspect bridge` now includes `2a0c:b641:b50:f0::/64`
- bridge container DNS uses `2a0c:b641:b50:2::1`
- bridge container IPv6 HTTPS smoke to `https://deb.debian.org/debian/` returned `HTTP/2 200`
- default `docker build` of `/opt/knowledge` succeeded without `--network=host`
- `hyrule-knowledge-mcp.service`, Docker, and `hyrule-engineering-loop.timer` are active
- Knowledge MCP `/health` returned `status=ok`, `transport=streamable-http`, `tool_count=14`

## Notes
- Docker 26 still assigns an RFC1918 address on the default bridge, but the host has no IPv4 default route and Docker IPv4 masquerade is disabled. Effective container egress/DNS is IPv6-routed.
