### PR TITLE
Prefer cr1-ch1 for Cloudflare egress

### DIFF
--- a/ansible/inventory/host_vars/rtr.yml
+++ b/ansible/inventory/host_vars/rtr.yml
@@ -8,12 +8,13 @@
 networkd_primary_unit: "10-enX2"
 
 # --- FRR role override ---
-# rtr runs BGP in the overlay VRF, so the frr role's post-reload soft clear must
-# target it. The role default (`clear bgp ipv6 unicast * soft`) hits the empty
-# default VRF and is a no-op here. See network-operations#150. (rtr's iBGP peers
-# carry no inbound route-maps today, so this only matters once rtr gains inbound
-# policy — e.g. future peering — but keep it correct.)
-frr_clear_bgp_cmd: "vtysh -c 'clear bgp vrf overlay ipv6 unicast * soft'"
+# rtr runs BGP in the overlay VRF, so the frr role's post-reload soft clears must
+# target it. The role defaults hit the empty default VRF and are no-ops here. See
+# network-operations#150. Keep both directions: inbound re-evaluates route-maps,
+# outbound re-advertises changed attributes such as local-pref to iBGP peers.
+frr_clear_bgp_cmds:
+  - "vtysh -c 'clear bgp vrf overlay ipv6 unicast * soft in'"
+  - "vtysh -c 'clear bgp vrf overlay ipv6 unicast * soft out'"
 
 # --- IPv4 variables for the preserved nat/forward block ---
 rtr_wan_ip:   "46.105.40.223"

--- a/ansible/roles/frr/README.md
+++ b/ansible/roles/frr/README.md
@@ -14,7 +14,8 @@ and applies a delta-reload so iBGP/OSPF sessions are not flapped.
 5. Schedules an `at(1)` watchdog (default 5 min) that restores + reloads the
    backup if the play does not cancel it — covers a lockout from a bad policy.
 6. Moves the new config into place, **reloads** (FRR integrated delta-reload —
-   no restart), then **`clear bgp ipv6 unicast * soft`** to re-apply policy.
+   no restart), then soft-clears BGP **in** and **out** to re-apply policy and
+   re-advertise changed attributes.
 7. Cancels the watchdog once the reload completes cleanly.
 
 The reload runs on **every** apply (not gated on the file changing): `frr-reload`
@@ -27,7 +28,7 @@ where the on-disk file already matches the repo but the daemon never ingested it
 
 ## OS differences (`vars/<os_family>.yml`)
 
-| | FreeBSD (cr1-nl1, cr1-de1) | Debian (rtr) |
+| | FreeBSD (cr1-nl1, cr1-de1, cr1-ch1) | Debian (rtr) |
 |---|---|---|
 | `frr_conf_path` | `/usr/local/etc/frr/frr.conf` | `/etc/frr/frr.conf` |
 | `frr_reload_cmd` | `/usr/local/sbin/frr-reload` (port wrapper) | `systemctl reload frr` |
@@ -47,7 +48,7 @@ where the on-disk file already matches the repo but the daemon never ingested it
 ## Key variables (`defaults/main.yml`)
 
 - `frr_apply` (false) — push + reload, or validate-only.
-- `frr_clear_bgp` (true) / `frr_clear_bgp_cmd` — soft policy re-eval after reload.
+- `frr_clear_bgp` (true) / `frr_clear_bgp_cmds` — soft policy re-eval after reload.
 - `frr_watchdog_minutes` (5) — rollback window.
 
 ## Usage

--- a/ansible/roles/frr/defaults/main.yml
+++ b/ansible/roles/frr/defaults/main.yml
@@ -9,11 +9,14 @@ frr_apply: false
 # inventory_hostname matches the configs/ subdir (cr1-nl1, cr1-de1, rtr).
 frr_config_src_dir: "{{ playbook_dir }}/../../configs"
 
-# After a successful reload, re-evaluate inbound + outbound policy without
-# bouncing sessions. soft-reconfiguration inbound is enabled on the transit
-# peers (see configs/cr1-*/frr.conf), so this is non-disruptive.
+# After a successful reload, re-evaluate inbound policy and re-advertise changed
+# attributes without bouncing sessions. soft-reconfiguration inbound is enabled
+# on the transit peers (see configs/cr1-*/frr.conf), so this is non-disruptive.
+# Non-default BGP VRFs must override these commands (see rtr host_vars).
 frr_clear_bgp: true
-frr_clear_bgp_cmd: "vtysh -c 'clear bgp ipv6 unicast * soft'"
+frr_clear_bgp_cmds:
+  - "vtysh -c 'clear bgp ipv6 unicast * soft in'"
+  - "vtysh -c 'clear bgp ipv6 unicast * soft out'"
 
 # Rollback watchdog window. If the play does not cancel within this long, the
 # pre-change config is restored and FRR reloaded. BGP convergence is fast; the

--- a/ansible/roles/frr/tasks/deploy.yml
+++ b/ansible/roles/frr/tasks/deploy.yml
@@ -71,7 +71,8 @@
   tags: [apply]
 
 - name: Re-evaluate BGP policy (soft — re-applies route-maps without flapping sessions)
-  command: "{{ frr_clear_bgp_cmd }}"
+  command: "{{ item }}"
+  loop: "{{ frr_clear_bgp_cmds }}"
   changed_when: false
   when: frr_clear_bgp | default(true) | bool
   tags: [apply]

--- a/configs/cr1-ch1/frr.conf
+++ b/configs/cr1-ch1/frr.conf
@@ -143,6 +143,19 @@ bgp as-path access-list 1 seq 75 deny _429496729[0-5]_
 ! Permit routes with reasonable path length (implicit deny for longer)
 bgp as-path access-list 1 seq 100 permit ^.{0,200}$
 !
+! Prefer cr1-ch1/Securebit for Cloudflare egress. CI downloads from
+! releases.astral.sh land on Cloudflare anycast where the older equal-LP path
+! chosen by rtr can be throughput-degraded. Keep this below IXP-IN's LP 200.
+bgp as-path access-list CLOUDFLARE permit _13335$
+!
+route-map TRANSIT-IN permit 5
+ match as-path CLOUDFLARE
+ set local-preference 150
+ ! Continue into permit 10 so the shared AS-path hygiene filter still gates
+ ! Cloudflare-origin routes; permit 10 has no set clauses, so LP 150 is retained.
+ on-match next
+exit
+!
 route-map TRANSIT-IN permit 10
  match as-path 1
 exit

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -123,7 +123,7 @@ delta-reloads it; it does not template/render the config.
 The apply path mirrors the firewall role: stage `<conf>.new` → `vtysh -C -f`
 syntax check → backup → schedule an `at(1)` rollback watchdog
 (`frr_watchdog_minutes`, default 5) → swap into place → handler chain
-**validate → reload → `clear bgp ipv6 unicast * soft`** → cancel the watchdog.
+**validate → reload → soft-clear BGP in/out** → cancel the watchdog.
 `serial: 1` and the pre/post Icinga snapshot bracket are on the play, so a bad
 policy change blocks the next router instead of taking the mesh down.
 
@@ -139,8 +139,9 @@ ansible-playbook playbooks/frr.yml --tags apply --limit rtr -e frr_apply=true
 
 Or via the gated workflow: `gh workflow run apply.yml -F playbook=frr -F limit=rtr -F dry_run=false`.
 
-**Rollout order:** `--limit rtr` first (Debian), then `--limit cr1-de1`, then
-`--limit cr1-nl1`. The reload runs on **every** apply (frr-reload diffs against
+**Rollout order:** `--limit rtr` first (Debian), then one FreeBSD core at a
+time (`--limit cr1-de1`, `--limit cr1-nl1`, `--limit cr1-ch1`). The reload runs
+on **every** apply (frr-reload diffs against
 the running daemon, so a converged daemon is a no-op) — this is deliberate, so a
 daemon left stale by a botched reload still gets reconverged on a re-run.
 

--- a/tests/iac/test_frr_static.py
+++ b/tests/iac/test_frr_static.py
@@ -8,11 +8,13 @@ FRR_FILES = {
     "rtr": REPO / "configs/rtr/frr.conf",
     "cr1-nl1": REPO / "configs/cr1-nl1/frr.conf",
     "cr1-de1": REPO / "configs/cr1-de1/frr.conf",
+    "cr1-ch1": REPO / "configs/cr1-ch1/frr.conf",
 }
 CORE_LOOPBACKS = {
     "rtr": "2a0c:b641:b50::d",
     "cr1-nl1": "2a0c:b641:b50::a",
     "cr1-de1": "2a0c:b641:b50::b",
+    "cr1-ch1": "2a0c:b641:b50::c",
 }
 
 
@@ -78,6 +80,13 @@ class FrrStaticTest(unittest.TestCase):
             defined = set(re.findall(r"^route-map\s+(\S+)\s+", text, re.M))
             referenced = set(re.findall(r"neighbor\s+\S+\s+route-map\s+(\S+)\s+(?:in|out)", text))
             self.assertTrue(referenced <= defined, f"{node}: undefined route-maps {referenced - defined}")
+
+    def test_route_maps_do_not_reference_undefined_as_path_lists(self):
+        for node in FRR_FILES:
+            text = frr_text(node)
+            defined = set(re.findall(r"^bgp as-path access-list\s+(\S+)", text, re.M))
+            referenced = set(re.findall(r"match as-path\s+(\S+)", text))
+            self.assertTrue(referenced <= defined, f"{node}: undefined as-path lists {referenced - defined}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Prefer cr1-ch1/Securebit for AS13335-origin routes by setting local-pref 150 on cr1-ch1 TRANSIT-IN.
- Soft-clear BGP in and out from the frr role so changed route attributes propagate after reload.
- Add cr1-ch1 to static FRR tests and update FRR docs.

## Validation
- python3 -m pytest tests/iac/test_frr_static.py
- cd ansible && ansible-playbook playbooks/frr.yml --syntax-check
- vtysh -C -f staged cr1-ch1 config
- Applied live to cr1-ch1 with ansible-playbook playbooks/frr.yml --tags apply --limit cr1-ch1 -e frr_apply=true
- Verified rtr now selects 2606:4700:20::/44 via cr1-ch1 with localpref 150
- Verified ci downloads uv tarball from the previously slow Cloudflare edge in ~0.55s
