### PR TITLE
Deploy updated Knowledge MCP evidence bundle

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -9,7 +9,7 @@ engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: "ec09b7df21f9c08d155d5b4d63b3dba21d976e93"
+knowledge_mcp_version: "69e9a30bcb11a6242f6d4adc4587e48ce20e5754"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767


### PR DESCRIPTION
## Summary
- bump `loop` Knowledge MCP deployment pin to AS215932/knowledge main `69e9a30bcb11a6242f6d4adc4587e48ce20e5754`
- includes the rollout evidence bundle from knowledge #9 plus deterministic observation-expiry follow-up from knowledge #10

## Expected post-deploy health
- Knowledge MCP `/health` should report `concept_count=867`
- `claim_count=4569`
- manifest `observation_count=1`

## Validation
- `ansible-playbook playbooks/engineering-loop.yml --tags validate --skip-tags snapshot --limit loop`
