### PR TITLE
Deploy broader Knowledge MCP observations

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -9,7 +9,7 @@ engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: "69e9a30bcb11a6242f6d4adc4587e48ce20e5754"
+knowledge_mcp_version: "67b338757efe9b496c4e154fbb0212563b1b96e8"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767


### PR DESCRIPTION
## Summary
- bump loop Knowledge MCP checkout/image to AS215932/knowledge merge commit 67b338757efe9b496c4e154fbb0212563b1b96e8
- deploys the broader core automation observed evidence bundle from knowledge PR #11

## Validation
- scripts/ci/render-all.sh
- scripts/ci/deploy-preflight.sh --repo-only

Note: local unrelated untracked files were left untouched: docs/plans/ and pi-session-2026-06-14T16-21-14-446Z_019ec6ef-f24e-7347-ad53-cb24250b9687.html