### PR TITLE
Fix live monitoring scrape coverage

### DIFF
--- a/ansible/generated/log/vector-aggregator.toml
+++ b/ansible/generated/log/vector-aggregator.toml
@@ -11,7 +11,8 @@ data_dir = "/var/lib/vector"
 
 [api]
 enabled = true
-address = "127.0.0.1:8686"
+# Prometheus on mon scrapes this listener; firewall only permits mon.
+address = "[::]:8686"
 
 # --- Sources -----------------------------------------------------------------
 

--- a/ansible/generated/log/vector-aggregator.toml
+++ b/ansible/generated/log/vector-aggregator.toml
@@ -11,10 +11,14 @@ data_dir = "/var/lib/vector"
 
 [api]
 enabled = true
-# Prometheus on mon scrapes this listener; firewall only permits mon.
-address = "[::]:8686"
+# Local-only diagnostics API. Prometheus does not scrape this endpoint; Vector's
+# API returns health/control-plane responses, not Prometheus samples.
+address = "127.0.0.1:8687"
 
 # --- Sources -----------------------------------------------------------------
+
+[sources.internal_metrics]
+type = "internal_metrics"
 
 [sources.from_agents]
 type = "vector"
@@ -87,6 +91,12 @@ source = '''
 '''
 
 # --- Sinks -------------------------------------------------------------------
+
+[sinks.prometheus_metrics]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+# Prometheus on mon scrapes this listener; firewall only permits mon.
+address = "[::]:8686"
 
 [sinks.loki]
 type = "loki"

--- a/ansible/roles/logs/templates/vector-aggregator.toml.j2
+++ b/ansible/roles/logs/templates/vector-aggregator.toml.j2
@@ -11,7 +11,8 @@ data_dir = "{{ logs_vector_data_dir }}"
 
 [api]
 enabled = true
-address = "127.0.0.1:{{ logs_vector_metrics_port }}"
+# Prometheus on mon scrapes this listener; firewall only permits mon.
+address = "[::]:{{ logs_vector_metrics_port }}"
 
 # --- Sources -----------------------------------------------------------------
 

--- a/ansible/roles/logs/templates/vector-aggregator.toml.j2
+++ b/ansible/roles/logs/templates/vector-aggregator.toml.j2
@@ -11,10 +11,14 @@ data_dir = "{{ logs_vector_data_dir }}"
 
 [api]
 enabled = true
-# Prometheus on mon scrapes this listener; firewall only permits mon.
-address = "[::]:{{ logs_vector_metrics_port }}"
+# Local-only diagnostics API. Prometheus does not scrape this endpoint; Vector's
+# API returns health/control-plane responses, not Prometheus samples.
+address = "127.0.0.1:8687"
 
 # --- Sources -----------------------------------------------------------------
+
+[sources.internal_metrics]
+type = "internal_metrics"
 
 [sources.from_agents]
 type = "vector"
@@ -87,6 +91,12 @@ source = '''
 '''
 
 # --- Sinks -------------------------------------------------------------------
+
+[sinks.prometheus_metrics]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+# Prometheus on mon scrapes this listener; firewall only permits mon.
+address = "[::]:{{ logs_vector_metrics_port }}"
 
 [sinks.loki]
 type = "loki"

--- a/configs/mon/blackbox.yml
+++ b/configs/mon/blackbox.yml
@@ -35,9 +35,9 @@ modules:
       tls_config:
         insecure_skip_verify: false
 
-  # Same as http_2xx but accepts self-signed / SAN-mismatch certs. Used for
-  # internal-IPv6 probes against services whose cert SAN only lists the
-  # public hostname (e.g. Vault on [::c0]:8200 — see vault_agent_vault_addr).
+  # Same as http_2xx but accepts self-signed / SAN-mismatch certs. Reserved
+  # for internal-IPv6 HTTPS probes against services whose cert SAN only lists
+  # a public hostname.
   http_2xx_skip_verify:
     prober: http
     timeout: 10s

--- a/configs/mon/prometheus-rules/logs-pipeline.yml
+++ b/configs/mon/prometheus-rules/logs-pipeline.yml
@@ -36,7 +36,7 @@ groups:
       # buffered sink. A persistent buffer backlog means downstream (Loki)
       # is unable to keep up.
       - alert: VectorBufferStalling
-        expr: rate(vector_buffer_byte_size_bytes[5m]) > 0 and vector_buffer_byte_size_bytes > 100e6
+        expr: rate(vector_buffer_byte_size[5m]) > 0 and vector_buffer_byte_size > 100e6
         for: 10m
         labels:
           severity: warning

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -16,7 +16,8 @@ rule_files:
 
 scrape_configs:
   # --- node_exporter (port 9100) ---
-  # System metrics from infrastructure VMs and routers.
+  # System metrics from infrastructure VMs and routers. Icinga's Prometheus-backed
+  # host and systemd checks key directly on these instance labels.
 
   - job_name: node-infra
     static_configs:

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -34,6 +34,7 @@ scrape_configs:
           - "[2a0c:b641:b50:2::c0]:9100"   # vault
           - "[2a0c:b641:b50:2::d0]:9100"   # ci (privileged runner)
           - "[2a0c:b641:b50:2::e0]:9100"   # netproxy
+          - "[2a0c:b641:b50:2::f0]:9100"   # loop (Engineering Loop / Knowledge MCP)
         labels:
           site: ovh1
           role: infra
@@ -188,10 +189,9 @@ scrape_configs:
       - target_label: __address__
         replacement: "[::1]:9115"
 
-  # Internal Vault probe — goes direct to [::c0]:8200, bypassing Caddy.
-  # Pair this with the public probe above to distinguish "Caddy down"
-  # (public fails, internal ok) from "Vault down" (both fail). Cert SAN
-  # doesn't cover the literal IPv6, so this uses http_2xx_skip_verify.
+  # Internal Vault probe — goes direct to the plain-HTTP listener on [::c0]:8200,
+  # bypassing Caddy. Pair this with the public probe above to distinguish
+  # "Caddy down" (public fails, internal ok) from "Vault down" (both fail).
   #
   # The address below is the same value as `peers.vault.ipv6` in
   # ansible/inventory/group_vars/all.yml; prometheus.yml is not
@@ -201,10 +201,10 @@ scrape_configs:
   - job_name: blackbox-vault-internal
     metrics_path: /probe
     params:
-      module: [http_2xx_skip_verify]
+      module: [http_2xx]
     static_configs:
       - targets:
-          - "https://[2a0c:b641:b50:2::c0]:8200/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
+          - "http://[2a0c:b641:b50:2::c0]:8200/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/configs/mon/prometheus.yml
+++ b/configs/mon/prometheus.yml
@@ -34,7 +34,6 @@ scrape_configs:
           - "[2a0c:b641:b50:2::b0]:9100"   # log
           - "[2a0c:b641:b50:2::c0]:9100"   # vault
           - "[2a0c:b641:b50:2::d0]:9100"   # ci (privileged runner)
-          - "[2a0c:b641:b50:2::e0]:9100"   # netproxy
           - "[2a0c:b641:b50:2::f0]:9100"   # loop (Engineering Loop / Knowledge MCP)
         labels:
           site: ovh1
@@ -244,11 +243,5 @@ scrape_configs:
           site: ovh1
           role: noc
 
-  - job_name: hyrule-network-proxy
-    metrics_path: /metrics
-    static_configs:
-      - targets:
-          - "[2a0c:b641:b50:2::e0]:8451"   # hyrule-network-proxy sidecar metrics
-        labels:
-          site: ovh1
-          role: netproxy
+  # netproxy / hyrule-network-proxy is intentionally not live yet. Keep its
+  # node_exporter and sidecar metrics targets disabled until issue #214 closes.

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -367,7 +367,7 @@ exceptions are:
 | ns2 → log | out | 6000 tcp | Off-net Vector agent → aggregator over public IPv6 |
 | dom0 → log | out | 6000 tcp | Hypervisor Vector agent → aggregator over mgmt v4 |
 | mon → log | out | 3100, 8686 tcp | Grafana query + Vector metrics scrape |
-| noc, mon, api, web, ci, loop → vault | out | 8200 tcp | vault-agent / health checks → Vault listener, direct internal IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Cert SAN covers `vault.as215932.net` only; agents use `tls_skip_verify`. |
+| noc, mon, api, web, ci, loop → vault | out | 8200 tcp | vault-agent / health checks → Vault's plain-HTTP internal listener over direct IPv6 (bypasses Caddy so a proxy outage doesn't break the secrets plane). Public TLS remains on `vault.as215932.net` via Caddy. |
 | mon → routers | out | 22 tcp (by_ssh) | icinga2 by_ssh checks, logged in as the dedicated `monitoring` system user. Privileged plugins (jool stats) are wrapped in `sudo`/`doas`, scoped to `/usr/local/lib/nagios/plugins/*` by the role-rendered drop. |
 
 ---

--- a/docs/network-flows.md
+++ b/docs/network-flows.md
@@ -188,9 +188,11 @@ Outbound (cross-cutting): ci → github.com TCP/443 (poll runner queue, fetch ac
 
 ### netproxy (`2a0c:b641:b50:2::e0`)
 
-Internal Hyrule Network Proxy sidecar for paid x402-gated Hyrule Cloud network
-requests. Hyrule Cloud verifies payment; this host only executes internal
-request jobs.
+Planned internal Hyrule Network Proxy sidecar for paid x402-gated Hyrule Cloud
+network requests. Hyrule Cloud verifies payment; this host only executes
+internal request jobs. It is not live yet; Prometheus scrape targets remain
+disabled until [#214](https://github.com/AS215932/network-operations/issues/214)
+completes the rollout.
 
 | From | Proto | Port | Purpose |
 |------|-------|------|---------|


### PR DESCRIPTION
## Summary
- add the loop VM node_exporter target to the mon Prometheus scrape config so Prometheus-backed Icinga checks for loop resolve data
- correct the internal Vault blackbox probe to use Vault's plain-HTTP internal listener and refresh the blackbox module comment
- expose real Vector internal metrics on log via an internal_metrics source plus prometheus_exporter sink on :8686, and correct the Vector buffer alert metric name for Vector 0.55.0
- disable netproxy Prometheus scrape targets because netproxy is intentionally not live yet; tracked in #214
- refresh the generated log Vector artifact and network-flow docs

## Live triage/remediation performed
- copied current mon Prometheus/blackbox configs to mon and reloaded Prometheus/restarted blackbox exporter
- applied the logs aggregator role on log to expose Vector Prometheus metrics on :8686
- loop Prometheus-backed Icinga checks recovered: node-up, disk, engineering-loop-timer, knowledge-mcp-service are OK
- Vector and internal Vault Prometheus probes recovered
- disabled netproxy node_exporter/sidecar Prometheus targets live; active Prometheus targets now report no down targets
- added triage notes to network-operations#214: https://github.com/AS215932/network-operations/issues/214#issuecomment-4763199568

## Validation
- scripts/ci/render-all.sh
- scripts/ci/deploy-preflight.sh --repo-only
- remote vector validate --config-toml on the rendered aggregator config
- promtool check config /etc/prometheus/prometheus.yml on mon
- Vector /metrics returns Prometheus samples including vector_buffer_byte_size
- Prometheus active target check on mon: 55 active targets, 0 down active targets
- Prometheus up == 0 returns empty