### PR TITLE
Deploy refreshed Knowledge observation

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -9,7 +9,7 @@ engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: "67b338757efe9b496c4e154fbb0212563b1b96e8"
+knowledge_mcp_version: "19339283a2d8860994395eef0c69458a58a59647"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767


### PR DESCRIPTION
## Summary
- bump loop Knowledge MCP to AS215932/knowledge merge commit 19339283a2d8860994395eef0c69458a58a59647
- deploys refreshed observed evidence showing Prometheus with zero down targets and Icinga with no unhandled problem services after #288

## Validation
- scripts/ci/render-all.sh
- scripts/ci/deploy-preflight.sh --repo-only