### PR TITLE
fix(noc): use explicit CaseService Postgres user

### DIFF
--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -47,6 +47,52 @@
       run_once: true
       tags: [snapshot, always]
   post_tasks:
+    - name: Verify noc-agent CaseService health
+      tags: [validate, apply]
+      block:
+        - name: Wait for noc-agent CaseService health endpoint
+          uri:
+            url: http://127.0.0.1:8000/health/cases
+            return_content: true
+            status_code: 200
+            timeout: 10
+          register: noc_agent_case_health
+          retries: 12
+          delay: 5
+          until:
+            - noc_agent_case_health.status == 200
+            - (noc_agent_case_health.json.status | default('')) == 'ok'
+            - (noc_agent_case_health.json.backend | default('')) == 'PostgresCaseStore'
+            - (noc_agent_case_health.json.outbox_worker.running | default(false)) | bool
+
+        - name: Show noc-agent CaseService health
+          debug:
+            var: noc_agent_case_health.json
+      rescue:
+        - name: Capture noc-agent service status
+          command: systemctl status noc-agent --no-pager -l
+          register: noc_agent_service_status
+          changed_when: false
+          failed_when: false
+
+        - name: Capture noc-agent journal
+          command: journalctl -u noc-agent -n 120 --no-pager
+          register: noc_agent_journal
+          changed_when: false
+          failed_when: false
+
+        - name: Show noc-agent service status
+          debug:
+            var: noc_agent_service_status.stdout_lines
+
+        - name: Show noc-agent recent journal
+          debug:
+            var: noc_agent_journal.stdout_lines
+
+        - name: Fail noc-agent health verification
+          fail:
+            msg: noc-agent /health/cases did not become healthy after deploy
+
     - name: Post-deploy Icinga snapshot
       include_role:
         name: firewall

--- a/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
+++ b/ansible/roles/vault_agent/templates/noc-agent.env.ctmpl.j2
@@ -51,7 +51,7 @@ NOC_CASESERVICE_REACTIVE_PRIMARY=1
 NOC_CASESERVICE_CONTROL_PRIMARY=1
 NOC_CASE_OUTBOX_ENABLED=1
 NOC_REQUIRE_POSTGRES=1
-NOC_DATABASE_URL=postgresql:///noc_agent?host=/var/run/postgresql
+NOC_DATABASE_URL=postgresql://noc-agent@/noc_agent?host=/var/run/postgresql
 NOC_CONTROL_PUBLIC_URL=https://noc.servify.network
 
 HYRULE_MCP_CMD="/opt/hyrule-mcp/.venv/bin/python /opt/hyrule-mcp/mcp_server.py"

--- a/configs/noc-agent.env.j2
+++ b/configs/noc-agent.env.j2
@@ -46,7 +46,7 @@ NOC_CASESERVICE_REACTIVE_PRIMARY=1
 NOC_CASESERVICE_CONTROL_PRIMARY=1
 NOC_CASE_OUTBOX_ENABLED=1
 NOC_REQUIRE_POSTGRES=1
-NOC_DATABASE_URL=postgresql:///noc_agent?host=/var/run/postgresql
+NOC_DATABASE_URL=postgresql://noc-agent@/noc_agent?host=/var/run/postgresql
 NOC_CONTROL_PUBLIC_URL=https://noc.servify.network
 
 # --- Shared NOC mailbox ---


### PR DESCRIPTION
## Summary\n- use an explicit local Postgres role in noc-agent's CaseService DSN\n- add post-deploy /health/cases verification with service/journal capture on failure\n\n## Context\nThe CaseService primary promotion deployed successfully, but public health is returning 502. This follow-up keeps the production workflow as source of truth and makes noc deploys fail loud with diagnostics if CaseService health does not come up.\n\n## Tests\n- scripts/ci/iac-static.sh\n- git diff --check