### PR TITLE
fix(noc): allow noc-agent workers longer startup

### DIFF
--- a/ansible/playbooks/noc.yml
+++ b/ansible/playbooks/noc.yml
@@ -57,7 +57,7 @@
             status_code: 200
             timeout: 10
           register: noc_agent_case_health
-          retries: 12
+          retries: 36
           delay: 5
           until:
             - noc_agent_case_health.status == 200

--- a/configs/noc-agent.service
+++ b/configs/noc-agent.service
@@ -19,6 +19,7 @@ ExecStart=/opt/noc-agent/.venv/bin/uvicorn app.main:app \
     --host :: \
     --port 8000 \
     --workers 2 \
+    --timeout-worker-healthcheck 60 \
     --log-level info \
     --access-log
 Restart=always


### PR DESCRIPTION
## Summary\n- raise uvicorn worker startup healthcheck timeout to 60s\n- extend post-deploy /health/cases wait window\n\n## Context\nAfter CaseService primary deploy, uvicorn workers were being killed during lifespan startup while MCP clients were still connecting/cleaning up. This lets startup finish and keeps the CaseService health gate.\n\n## Tests\n- scripts/ci/iac-static.sh\n- git diff --check