### PR TITLE
Deploy reviewed Knowledge enrichment

### DIFF
--- a/ansible/inventory/host_vars/loop.yml
+++ b/ansible/inventory/host_vars/loop.yml
@@ -9,7 +9,7 @@ engineering_loop_timer_enabled: true
 
 # Local read-only knowledge MCP server for Engineering Loop context. It is
 # deployed as a Docker container and bound to host loopback only.
-knowledge_mcp_version: "ffa2ee7a459c9f8b1fa8df2867aad5153aab0a87"
+knowledge_mcp_version: "5a6666cbb9d290868db3fb854ffed39099515b91"
 knowledge_mcp_enabled: true
 knowledge_mcp_host: 127.0.0.1
 knowledge_mcp_port: 8767


### PR DESCRIPTION
## Summary
- bump loop Knowledge MCP pin to AS215932/knowledge merge commit 5a6666cbb9d290868db3fb854ffed39099515b91 from knowledge PR #14
- deploy reviewed services enrichment and context-pack prioritization fixes

## Validation
- python -m pytest tests/iac/test_vault_and_runner_contracts.py -q
- scripts/ci/render-all.sh
- scripts/ci/deploy-preflight.sh --repo-only

## Deployment
Use the engineering-loop apply path with Knowledge MCP enabled after merge:

```bash
ansible-playbook playbooks/engineering-loop.yml --limit loop --tags knowledge_mcp,apply --skip-tags snapshot -e knowledge_mcp_apply=true
```

Smoke after apply:
- /health revision/pin is 5a6666cbb9d290868db3fb854ffed39099515b91
- MCP context pack includes reviewed generated/enriched/services advisory synthesis for service landscape tasks
- monitoring remains clean